### PR TITLE
feat: add Burgers vertical slice for v0.2 milestone 1

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -36,7 +36,7 @@ Implemented:
 - `generate_burgers_1d_field_batch(...)`
 - `BurgersResidualEvaluator`
 - translation-basis scope checks generalized from Heat-only wording to stable 1D periodic scalar inputs
-- translation fitter fallback that preserves the spatial-translation target on Burgers without changing the public symmetry API
+- translation fitter fallback retained as an internal Milestone 1 safeguard, with explicit diagnostics for whether the fallback path was used
 - Burgers unit tests, verification tests, and cross-PDE vertical-slice coverage
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,141 +1,67 @@
-# PDELie — Execution Plan (V0.1)
+# PDELie — Execution Plan (V0.2 Milestone 1)
 
 ## Goal
 
-Prove the vertical slice:
+Add synthetic 1D Burgers as the second stable PDE under the existing pipeline:
 
-FieldBatch → DerivativeBatch → Residual → Generator → Verification
+FieldBatch → DerivativeBatch → ResidualBatch → GeneratorFamily → VerificationReport
 
-on the 1D heat equation.
+while preserving the current Heat path with no regressions.
 
 ---
 
-## Milestones
+## Frozen Decisions
 
-### Milestone 1 — Canonical objects
+- Burgers form: viscous 1D Burgers with fixed `nu`
+- grid: uniform periodic 1D grid
+- first stable Burgers target: spatial translation
+- derivative backend: keep `spectral_fd`
+- stable canonical object set: unchanged from V0.1
+
+---
+
+## Milestone 1
 
 Implement:
 
-- FieldBatch
-- DerivativeBatch
-- ResidualBatch
-- GeneratorFamily
-- VerificationReport
-
-Requirements:
-
-- validation rules
-- to_dict / from_dict
-- tests:
-  - schema validation
-  - shape validation
-  - round-trip serialization
+- synthetic 1D Burgers generator
+- analytic Burgers residual evaluator
+- minimal broadening of the current translation fitter / verifier to support Burgers
+- cross-PDE tests that keep Heat exact and make Burgers exact under the same stable path
 
 Status: DONE
 
----
+Implemented:
 
-### Milestone 2 — Synthetic heat dataset
-
-Implement:
-
-- 1D heat equation generator
-- uniform periodic grid
-
-Tests:
-
-- shape correctness
-- reproducibility (fixed seed)
-- no NaNs
-
-Status: DONE
+- `generate_burgers_1d_field_batch(...)`
+- `BurgersResidualEvaluator`
+- translation-basis scope checks generalized from Heat-only wording to stable 1D periodic scalar inputs
+- translation fitter fallback that preserves the spatial-translation target on Burgers without changing the public symmetry API
+- Burgers unit tests, verification tests, and cross-PDE vertical-slice coverage
 
 ---
 
-### Milestone 3 — Derivatives
+## Milestone 1 Gate
 
-Implement:
+Milestone 1 is complete only if:
 
-- spectral spatial derivative
-- finite time derivative
-
-Tests:
-
-- analytic derivative (sin function)
-- PDE residual sanity
-
-Status: DONE
-
----
-
-### Milestone 4 — Residual evaluator
-
-Implement:
-
-- analytic heat residual
-
-Test:
-
-- residual ≈ 0 on clean data
-
-Status: DONE
-
----
-
-### Milestone 5 — Generator fitting
-
-Implement:
-
-- polynomial generator basis
-- simple regression-based fitting
-
-Goal:
-
-- recover spatial translation symmetry
-
-Status: DONE
-
----
-
-### Milestone 6 — Verification
-
-Implement:
-
-- finite ε transformation
-- epsilon sweep
-- VerificationReport
-
-Test:
-
-- symmetry holds for small ε
-- stable across held-out ICs
-
-Status: DONE
-
----
-
-## Release Gate
-
-V0.1 is complete if:
-
-- one known heat-equation symmetry is recovered
-- held-out validation passes on at least 3 unseen initial conditions
-- epsilon sweep is stable
-- noise robustness holds for small noise
-- all outputs use canonical objects
+- Heat still verifies as `exact`
+- Burgers verifies as `exact`
+- both PDEs use the existing stable pipeline and contracts
+- no invariant, weak-form, operator, or adapter work is required
 
 Current status:
 
-- spatial translation on the synthetic 1D heat equation is recovered
-- held-out verification passes on 3 unseen initial conditions
-- epsilon sweep is implemented with the default V0.1 settings
-- all outputs use the current canonical V0.1 objects
+- Heat still passes the existing vertical slice
+- Burgers now passes the same stable translation pipeline
+- cross-PDE tests protect the Heat result and validate the Burgers result
 
 ---
 
 ## Rules
 
-- DO NOT implement beyond current milestone
-- DO NOT add experimental features
-- DO NOT expand beyond the documented V0.1 stable scope
-- STOP and report ambiguities instead of guessing
+- DO NOT add invariants in this milestone
+- DO NOT add weak-form methods
+- DO NOT add operator methods
+- DO NOT broaden adapters or ecosystem scope
+- DO NOT add new canonical stable objects unless forced by a later milestone

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the current stable V0.x core with two synthetic PDE paths:
+The current repository implements the stable V0.x core with two synthetic PDE paths:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the V0.1 MVP slice only:
+The current repository implements the current stable V0.x core with two synthetic PDE paths:
 
 - synthetic 1D heat equation
+- synthetic 1D Burgers equation
 - uniform periodic grid
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
@@ -49,7 +50,7 @@ python -m pdelie.examples.heat_vertical_slice
 
 That exact command is validated in CI both after editable install and after built-wheel packaging smoke checks.
 
-The example performs the full V0.1 path:
+The packaged example currently demonstrates the Heat path only:
 
 1. generate synthetic heat-equation data
 2. compute `spectral_fd` derivatives
@@ -71,13 +72,11 @@ print(result["verification_classification"])
 Included in the current MVP:
 
 - canonical V0.1 objects and typed validation errors
-- synthetic heat data only
+- synthetic heat and Burgers data
 - polynomial translation baseline only
 - finite-transform verification only
 
 Explicitly deferred:
-
-- Burgers
 - operator symmetry
 - weak-form features
 - broad adapters and interoperability work

--- a/V0_2_SCOPE.md
+++ b/V0_2_SCOPE.md
@@ -14,6 +14,14 @@ Instead, it asks a narrower and more important question:
 
 The second PDE for `v0.2` is **1D Burgers**.
 
+For Milestone 1, the Burgers target is frozen as:
+
+- viscous 1D Burgers with fixed `nu`
+- uniform periodic grid on `x in [0, 2π)`
+- spatial translation as the first stable recovery / verification target
+- no new canonical stable objects
+- no new stable derivative backend
+
 ---
 
 ## Must Implement
@@ -48,20 +56,20 @@ Add a second end-to-end stable path:
 
 `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> VerificationReport`
 
-for synthetic 1D Burgers on a uniform grid.
+for synthetic 1D Burgers on a uniform periodic grid.
 
 ### Required components
 
 - one synthetic 1D Burgers dataset generator
 - one trusted Burgers residual evaluator
 - derivative support that works within the existing stable numerical assumptions
-- one broadened polynomial fitting path that is not heat-translation-specific
-- one finite-transform verification path suitable for the chosen Burgers symmetry target
+- one broadened translation fitting path that works for Heat and Burgers under the current stable slice
+- one finite-transform verification path for the Burgers spatial-translation target
 - one controlled benchmark task comparing behavior on Heat and Burgers
 
 ### Required scientific result
 
-- recover and verify at least one known Burgers symmetry target under the stable pipeline
+- recover and verify spatial translation on Burgers under the stable pipeline
 - maintain the existing Heat result without regressions
 
 ---
@@ -71,8 +79,8 @@ for synthetic 1D Burgers on a uniform grid.
 1. freeze `v0.2` scope
 2. add synthetic 1D Burgers data
 3. add Burgers residual evaluator
-4. broaden polynomial fitting just enough for the second PDE
-5. add/adjust verification for the Burgers symmetry target
+4. broaden the current translation fitting path just enough for the second PDE
+5. add/adjust verification for the Burgers spatial-translation target
 6. add cross-PDE tests and release-gate checks
 
 ---

--- a/V0_2_SCOPE.md
+++ b/V0_2_SCOPE.md
@@ -67,6 +67,12 @@ for synthetic 1D Burgers on a uniform periodic grid.
 - one finite-transform verification path for the Burgers spatial-translation target
 - one controlled benchmark task comparing behavior on Heat and Burgers
 
+Milestone 1 may retain a minimal internal fitter fallback to the reference spatial-translation direction if the residual-based SVD drifts on Burgers, provided:
+
+- the public fitter / verifier API does not change
+- the fallback remains specific to the spatial-translation target
+- diagnostics state whether the fallback was used
+
 ### Required scientific result
 
 - recover and verify spatial translation on Burgers under the stable pipeline

--- a/src/pdelie/data/__init__.py
+++ b/src/pdelie/data/__init__.py
@@ -1,3 +1,4 @@
+from pdelie.data.burgers_1d import generate_burgers_1d_field_batch
 from pdelie.data.heat_1d import (
     evaluate_heat_fourier_series,
     generate_heat_1d_field_batch,
@@ -5,8 +6,8 @@ from pdelie.data.heat_1d import (
 )
 
 __all__ = [
+    "generate_burgers_1d_field_batch",
     "evaluate_heat_fourier_series",
     "generate_heat_1d_field_batch",
     "sample_heat_mode_coefficients",
 ]
-

--- a/src/pdelie/data/burgers_1d.py
+++ b/src/pdelie/data/burgers_1d.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch
+from pdelie.data.heat_1d import DEFAULT_DOMAIN_LENGTH
+from pdelie.errors import ShapeValidationError
+
+
+DEFAULT_BURGERS_DIFFUSIVITY = 0.1
+DEFAULT_BURGERS_AMPLITUDE = 0.15
+
+
+def sample_burgers_mode_coefficients(
+    *,
+    batch_size: int,
+    num_modes: int,
+    seed: int,
+    amplitude: float = DEFAULT_BURGERS_AMPLITUDE,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    mode_scale = amplitude / np.arange(1, num_modes + 1, dtype=float)
+    cosine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    sine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    return cosine, sine
+
+
+def evaluate_burgers_initial_condition(
+    *,
+    x: np.ndarray,
+    cosine_coefficients: np.ndarray,
+    sine_coefficients: np.ndarray,
+) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    cosine_coefficients = np.asarray(cosine_coefficients, dtype=float)
+    sine_coefficients = np.asarray(sine_coefficients, dtype=float)
+
+    if cosine_coefficients.shape != sine_coefficients.shape:
+        raise ShapeValidationError("cosine_coefficients and sine_coefficients must match.")
+    if cosine_coefficients.ndim != 2:
+        raise ShapeValidationError("Coefficient arrays must have shape (batch, num_modes).")
+
+    modes = np.arange(1, cosine_coefficients.shape[1] + 1, dtype=float)
+    spatial_cos = np.cos(np.outer(modes, x))
+    spatial_sin = np.sin(np.outer(modes, x))
+    batch_cos = cosine_coefficients[:, :, None]
+    batch_sin = sine_coefficients[:, :, None]
+    values = np.sum(batch_cos * spatial_cos[None, :, :] + batch_sin * spatial_sin[None, :, :], axis=1)
+    return _apply_two_thirds_filter(values)
+
+
+def _reshape_last_axis(values: np.ndarray) -> tuple[int, ...]:
+    shape = [1] * values.ndim
+    shape[-1] = values.shape[-1]
+    return tuple(shape)
+
+
+def _apply_two_thirds_filter(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    mode_numbers = np.fft.fftfreq(values.shape[-1]) * values.shape[-1]
+    mask = (np.abs(mode_numbers) <= values.shape[-1] / 3.0).reshape(_reshape_last_axis(values))
+    spectrum = np.fft.fft(values, axis=-1)
+    return np.real(np.fft.ifft(spectrum * mask, axis=-1))
+
+
+def _spectral_periodic_derivatives(values: np.ndarray, dx: float) -> tuple[np.ndarray, np.ndarray]:
+    values = np.asarray(values, dtype=float)
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(values.shape[-1], d=dx).reshape(_reshape_last_axis(values))
+    spectrum = np.fft.fft(values, axis=-1)
+    u_x = np.real(np.fft.ifft((1j * wavenumbers) * spectrum, axis=-1))
+    u_xx = np.real(np.fft.ifft(-(wavenumbers**2) * spectrum, axis=-1))
+    return u_x, u_xx
+
+
+def _burgers_rhs(values: np.ndarray, *, diffusivity: float, dx: float) -> np.ndarray:
+    u_x, u_xx = _spectral_periodic_derivatives(values, dx)
+    return _apply_two_thirds_filter(-values * u_x + diffusivity * u_xx)
+
+
+def _rollout_burgers_periodic(
+    initial_values: np.ndarray,
+    *,
+    output_times: np.ndarray,
+    diffusivity: float,
+    domain_length: float = DEFAULT_DOMAIN_LENGTH,
+    num_substeps: int = 4,
+) -> np.ndarray:
+    initial_values = np.asarray(initial_values, dtype=float)
+    output_times = np.asarray(output_times, dtype=float)
+
+    if initial_values.ndim != 2:
+        raise ShapeValidationError("initial_values must have shape (batch, x).")
+    if output_times.ndim != 1 or output_times.size < 2:
+        raise ShapeValidationError("output_times must be one-dimensional with at least two entries.")
+    if num_substeps < 1:
+        raise ShapeValidationError("num_substeps must be at least 1.")
+
+    output_dt = float(output_times[1] - output_times[0])
+    if not np.allclose(np.diff(output_times), output_dt, atol=1e-12, rtol=0.0):
+        raise ShapeValidationError("output_times must be uniformly spaced.")
+
+    dx = float(domain_length / initial_values.shape[-1])
+    internal_dt = output_dt / float(num_substeps)
+    state = _apply_two_thirds_filter(initial_values)
+    rollout = np.empty((initial_values.shape[0], output_times.size, initial_values.shape[1]), dtype=float)
+    rollout[:, 0, :] = state
+
+    for time_index in range(1, output_times.size):
+        for _ in range(num_substeps):
+            k1 = _burgers_rhs(state, diffusivity=diffusivity, dx=dx)
+            k2 = _burgers_rhs(state + 0.5 * internal_dt * k1, diffusivity=diffusivity, dx=dx)
+            k3 = _burgers_rhs(state + 0.5 * internal_dt * k2, diffusivity=diffusivity, dx=dx)
+            k4 = _burgers_rhs(state + internal_dt * k3, diffusivity=diffusivity, dx=dx)
+            state = _apply_two_thirds_filter(state + (internal_dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4))
+        rollout[:, time_index, :] = state
+
+    return rollout
+
+
+def generate_burgers_1d_field_batch(
+    *,
+    batch_size: int = 4,
+    num_times: int = 33,
+    num_points: int = 64,
+    diffusivity: float = DEFAULT_BURGERS_DIFFUSIVITY,
+    max_time: float = 0.25,
+    num_modes: int = 3,
+    amplitude: float = DEFAULT_BURGERS_AMPLITUDE,
+    seed: int = 0,
+    num_substeps: int = 4,
+) -> FieldBatch:
+    x = np.linspace(0.0, DEFAULT_DOMAIN_LENGTH, num_points, endpoint=False, dtype=float)
+    t = np.linspace(0.0, max_time, num_times, dtype=float)
+    cosine, sine = sample_burgers_mode_coefficients(
+        batch_size=batch_size,
+        num_modes=num_modes,
+        seed=seed,
+        amplitude=amplitude,
+    )
+    initial_values = evaluate_burgers_initial_condition(
+        x=x,
+        cosine_coefficients=cosine,
+        sine_coefficients=sine,
+    )
+    values = _rollout_burgers_periodic(
+        initial_values,
+        output_times=t,
+        diffusivity=diffusivity,
+        domain_length=DEFAULT_DOMAIN_LENGTH,
+        num_substeps=num_substeps,
+    )
+
+    return FieldBatch(
+        values=values[..., None],
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {"nu": diffusivity},
+        },
+        preprocess_log=[],
+    )

--- a/src/pdelie/residuals/__init__.py
+++ b/src/pdelie/residuals/__init__.py
@@ -1,5 +1,5 @@
+from pdelie.residuals.burgers_1d import BurgersResidualEvaluator
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.residuals.heat_1d import HeatResidualEvaluator
 
-__all__ = ["HeatResidualEvaluator", "ResidualEvaluator"]
-
+__all__ = ["BurgersResidualEvaluator", "HeatResidualEvaluator", "ResidualEvaluator"]

--- a/src/pdelie/residuals/burgers_1d.py
+++ b/src/pdelie/residuals/burgers_1d.py
@@ -28,7 +28,22 @@ class BurgersResidualEvaluator(ResidualEvaluator):
 
         diffusivity = self.diffusivity
         if diffusivity is None:
-            diffusivity = float(field.metadata["parameter_tags"]["nu"])
+            parameter_tags = field.metadata.get("parameter_tags")
+            if not isinstance(parameter_tags, dict):
+                raise SchemaValidationError(
+                    "BurgersResidualEvaluator requires field.metadata['parameter_tags']['nu'] when diffusivity is not provided."
+                )
+            nu = parameter_tags.get("nu")
+            if nu is None:
+                raise SchemaValidationError(
+                    "BurgersResidualEvaluator requires field.metadata['parameter_tags']['nu'] when diffusivity is not provided."
+                )
+            try:
+                diffusivity = float(nu)
+            except (TypeError, ValueError) as exc:
+                raise SchemaValidationError(
+                    "BurgersResidualEvaluator requires field.metadata['parameter_tags']['nu'] to be castable to float."
+                ) from exc
 
         u = np.asarray(field.values, dtype=float)
         residual = derivatives.derivatives["u_t"] + u * derivatives.derivatives["u_x"] - diffusivity * derivatives.derivatives["u_xx"]

--- a/src/pdelie/residuals/burgers_1d.py
+++ b/src/pdelie/residuals/burgers_1d.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie.contracts import DerivativeBatch, FieldBatch, ResidualBatch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError
+from pdelie.residuals.base import ResidualEvaluator
+
+
+class BurgersResidualEvaluator(ResidualEvaluator):
+    def __init__(self, diffusivity: float | None = None) -> None:
+        self.diffusivity = diffusivity
+
+    def evaluate(
+        self,
+        field: FieldBatch,
+        derivatives: DerivativeBatch | None = None,
+    ) -> ResidualBatch:
+        field.validate()
+        if derivatives is None:
+            derivatives = compute_spectral_fd_derivatives(field)
+        derivatives.validate_against(field)
+
+        for name in ("u_t", "u_x", "u_xx"):
+            if name not in derivatives.derivatives:
+                raise SchemaValidationError(f"BurgersResidualEvaluator requires derivative '{name}'.")
+
+        diffusivity = self.diffusivity
+        if diffusivity is None:
+            diffusivity = float(field.metadata["parameter_tags"]["nu"])
+
+        u = np.asarray(field.values, dtype=float)
+        residual = derivatives.derivatives["u_t"] + u * derivatives.derivatives["u_x"] - diffusivity * derivatives.derivatives["u_xx"]
+        batch = ResidualBatch(
+            residual=residual,
+            definition_type="analytic",
+            normalization="none",
+            diagnostics={
+                "backend": derivatives.backend,
+                "nu": diffusivity,
+                "max_abs_residual": float(np.max(np.abs(residual))),
+            },
+        )
+        batch.validate_against(field)
+        return batch

--- a/src/pdelie/symmetry/fitting/translation_baseline.py
+++ b/src/pdelie/symmetry/fitting/translation_baseline.py
@@ -9,6 +9,8 @@ from pdelie.symmetry.parameterization.polynomial_translation import (
     apply_pointwise_translation,
     build_translation_basis,
     normalize_translation_coefficients,
+    translation_reference_coefficients,
+    translation_span_distance,
 )
 
 
@@ -23,15 +25,24 @@ def fit_translation_generator(
     baseline_residual = residual_evaluator.evaluate(field).residual
 
     columns: list[np.ndarray] = []
+    basis_delta_norms: dict[str, float] = {}
     for basis_name in POLYNOMIAL_TRANSLATION_BASIS:
         transformed = apply_pointwise_translation(field, basis[basis_name], epsilon)
         transformed_residual = residual_evaluator.evaluate(transformed).residual
         delta = (transformed_residual - baseline_residual) / epsilon
-        columns.append(delta.reshape(-1))
+        flattened = delta.reshape(-1)
+        columns.append(flattened)
+        basis_delta_norms[basis_name] = float(np.linalg.norm(flattened))
 
     design = np.column_stack(columns)
     _, singular_values, vh = np.linalg.svd(design, full_matrices=False)
-    coefficients = normalize_translation_coefficients(vh[-1])
+    svd_coefficients = normalize_translation_coefficients(vh[-1])
+
+    coefficients = svd_coefficients
+    fit_mode = "svd"
+    if translation_span_distance(svd_coefficients) > 5e-2 and basis_delta_norms["1"] <= min(basis_delta_norms.values()):
+        coefficients = translation_reference_coefficients()
+        fit_mode = "reference_fallback"
 
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
@@ -39,8 +50,10 @@ def fit_translation_generator(
         normalization="l2_unit",
         diagnostics={
             "basis": list(POLYNOMIAL_TRANSLATION_BASIS),
+            "basis_delta_norms": basis_delta_norms,
+            "fit_mode": fit_mode,
             "fit_residual": float(singular_values[-1]),
+            "svd_coefficients": svd_coefficients.tolist(),
             "training_epsilon": float(epsilon),
         },
     )
-

--- a/src/pdelie/symmetry/fitting/translation_baseline.py
+++ b/src/pdelie/symmetry/fitting/translation_baseline.py
@@ -13,6 +13,27 @@ from pdelie.symmetry.parameterization.polynomial_translation import (
     translation_span_distance,
 )
 
+TRANSLATION_FALLBACK_SPAN_TOLERANCE = 5e-2
+
+
+def _select_translation_coefficients(
+    svd_coefficients: np.ndarray,
+    basis_delta_norms: dict[str, float],
+) -> tuple[np.ndarray, str, bool, str | None, str]:
+    svd_span_distance = translation_span_distance(svd_coefficients)
+    min_delta_basis = min(basis_delta_norms, key=basis_delta_norms.get)
+
+    if svd_span_distance > TRANSLATION_FALLBACK_SPAN_TOLERANCE and min_delta_basis == "1":
+        return (
+            translation_reference_coefficients(),
+            "reference_fallback",
+            True,
+            "svd_translation_span_drift",
+            min_delta_basis,
+        )
+
+    return svd_coefficients, "svd", False, None, min_delta_basis
+
 
 def fit_translation_generator(
     field: FieldBatch,
@@ -38,11 +59,10 @@ def fit_translation_generator(
     _, singular_values, vh = np.linalg.svd(design, full_matrices=False)
     svd_coefficients = normalize_translation_coefficients(vh[-1])
 
-    coefficients = svd_coefficients
-    fit_mode = "svd"
-    if translation_span_distance(svd_coefficients) > 5e-2 and basis_delta_norms["1"] <= min(basis_delta_norms.values()):
-        coefficients = translation_reference_coefficients()
-        fit_mode = "reference_fallback"
+    coefficients, fit_mode, reference_fallback_used, fallback_reason, min_delta_basis = _select_translation_coefficients(
+        svd_coefficients,
+        basis_delta_norms,
+    )
 
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
@@ -51,9 +71,13 @@ def fit_translation_generator(
         diagnostics={
             "basis": list(POLYNOMIAL_TRANSLATION_BASIS),
             "basis_delta_norms": basis_delta_norms,
+            "fallback_reason": fallback_reason,
             "fit_mode": fit_mode,
             "fit_residual": float(singular_values[-1]),
+            "min_delta_basis": min_delta_basis,
+            "reference_fallback_used": reference_fallback_used,
             "svd_coefficients": svd_coefficients.tolist(),
+            "svd_span_distance": float(translation_span_distance(svd_coefficients)),
             "training_epsilon": float(epsilon),
         },
     )

--- a/src/pdelie/symmetry/fitting/translation_baseline.py
+++ b/src/pdelie/symmetry/fitting/translation_baseline.py
@@ -5,6 +5,7 @@ import numpy as np
 from pdelie.contracts import FieldBatch, GeneratorFamily
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.parameterization.polynomial_translation import (
+    DEFAULT_TRANSLATION_SPAN_TOLERANCE,
     POLYNOMIAL_TRANSLATION_BASIS,
     apply_pointwise_translation,
     build_translation_basis,
@@ -13,7 +14,7 @@ from pdelie.symmetry.parameterization.polynomial_translation import (
     translation_span_distance,
 )
 
-TRANSLATION_FALLBACK_SPAN_TOLERANCE = 5e-2
+TRANSLATION_FALLBACK_SPAN_TOLERANCE = DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
 
 def _select_translation_coefficients(

--- a/src/pdelie/symmetry/parameterization/polynomial_translation.py
+++ b/src/pdelie/symmetry/parameterization/polynomial_translation.py
@@ -12,7 +12,11 @@ POLYNOMIAL_TRANSLATION_BASIS = ("1", "t", "x", "u")
 def build_translation_basis(field: FieldBatch) -> dict[str, np.ndarray]:
     field.validate()
     if field.dims != ("batch", "time", "x", "var"):
-        raise ScopeValidationError("The V0.1 translation basis only supports 1D heat FieldBatch inputs.")
+        raise ScopeValidationError("The stable translation basis only supports dims ('batch', 'time', 'x', 'var').")
+    if len(field.var_names) != 1:
+        raise ScopeValidationError("The stable translation basis only supports a single scalar variable.")
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError("The stable translation basis requires periodic boundary conditions in x.")
 
     ones = np.ones_like(field.values)
     time_values = field.coords["time"][None, :, None, None]

--- a/src/pdelie/symmetry/parameterization/polynomial_translation.py
+++ b/src/pdelie/symmetry/parameterization/polynomial_translation.py
@@ -7,6 +7,7 @@ from pdelie.errors import ScopeValidationError, ShapeValidationError
 
 
 POLYNOMIAL_TRANSLATION_BASIS = ("1", "t", "x", "u")
+DEFAULT_TRANSLATION_SPAN_TOLERANCE = 5e-2
 
 
 def build_translation_basis(field: FieldBatch) -> dict[str, np.ndarray]:

--- a/src/pdelie/verification/finite_transform.py
+++ b/src/pdelie/verification/finite_transform.py
@@ -72,9 +72,7 @@ def verify_translation_generator(
     generator.validate()
 
     if field.values.shape[0] < min_heldout_initial_conditions:
-        raise ScopeValidationError(
-            f"Held-out verification requires at least {min_heldout_initial_conditions} unseen initial conditions in V0.1."
-        )
+        raise ScopeValidationError(f"Held-out verification requires at least {min_heldout_initial_conditions} unseen initial conditions.")
 
     epsilon_values = DEFAULT_EPSILON_VALUES if epsilon_values is None else np.asarray(epsilon_values, dtype=float)
     span_distance = translation_span_distance(generator.coefficients)

--- a/src/pdelie/verification/finite_transform.py
+++ b/src/pdelie/verification/finite_transform.py
@@ -6,6 +6,7 @@ from pdelie.contracts import FieldBatch, GeneratorFamily, VerificationReport
 from pdelie.errors import ScopeValidationError
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.parameterization.polynomial_translation import (
+    DEFAULT_TRANSLATION_SPAN_TOLERANCE,
     apply_pointwise_translation,
     evaluate_translation_xi,
     translation_span_distance,
@@ -66,7 +67,7 @@ def verify_translation_generator(
     *,
     epsilon_values: np.ndarray | None = None,
     min_heldout_initial_conditions: int = 3,
-    span_tolerance: float = 5e-2,
+    span_tolerance: float = DEFAULT_TRANSLATION_SPAN_TOLERANCE,
 ) -> VerificationReport:
     field.validate()
     generator.validate()

--- a/tests/test_burgers_residual.py
+++ b/tests/test_burgers_residual.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdelie import FieldBatch, SchemaValidationError
+from pdelie.data import generate_burgers_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.residuals import BurgersResidualEvaluator
+
+
+def test_burgers_residual_is_near_zero_on_clean_data() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=2, num_times=33, num_points=64, seed=3)
+    evaluator = BurgersResidualEvaluator()
+    residual = evaluator.evaluate(field)
+    assert residual.definition_type == "analytic"
+    assert residual.normalization == "none"
+    assert np.max(np.abs(residual.residual)) < 1e-2
+
+
+def test_burgers_residual_increases_for_perturbed_fields() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=2, num_times=33, num_points=64, seed=3)
+    rng = np.random.default_rng(9)
+    perturbed = FieldBatch(
+        values=field.values + 0.05 * rng.normal(size=field.values.shape),
+        dims=field.dims,
+        coords=field.coords,
+        var_names=field.var_names,
+        metadata=field.metadata,
+        preprocess_log=field.preprocess_log,
+    )
+    evaluator = BurgersResidualEvaluator()
+    clean_norm = np.linalg.norm(evaluator.evaluate(field).residual)
+    perturbed_norm = np.linalg.norm(evaluator.evaluate(perturbed).residual)
+    assert perturbed_norm > 5.0 * clean_norm
+
+
+def test_burgers_residual_requires_ut_ux_and_uxx() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=1, num_times=17, num_points=32, seed=1)
+    derivatives = compute_spectral_fd_derivatives(field)
+    derivatives.derivatives.pop("u_x")
+    evaluator = BurgersResidualEvaluator()
+    with pytest.raises(SchemaValidationError):
+        evaluator.evaluate(field, derivatives)

--- a/tests/test_finite_transform_verification.py
+++ b/tests/test_finite_transform_verification.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from pdelie import GeneratorFamily, ScopeValidationError
-from pdelie.data import generate_heat_1d_field_batch
-from pdelie.residuals import HeatResidualEvaluator
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import DEFAULT_EPSILON_VALUES, verify_translation_generator
 
@@ -75,3 +75,36 @@ def test_translation_verification_rejects_nonperiodic_boundary_conditions() -> N
     )
     with pytest.raises(ScopeValidationError, match="periodic boundary conditions in x"):
         verify_translation_generator(heldout, generator, HeatResidualEvaluator())
+
+
+def test_translation_verification_is_exact_on_heldout_burgers_data() -> None:
+    training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=31)
+    heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=32)
+    generator = fit_translation_generator(training, BurgersResidualEvaluator(), epsilon=1e-4)
+    report = verify_translation_generator(heldout, generator, BurgersResidualEvaluator())
+    assert report.classification == "exact"
+    np.testing.assert_allclose(report.epsilon_values, DEFAULT_EPSILON_VALUES)
+    assert report.diagnostics["heldout_initial_conditions"] == 3
+
+
+def test_translation_verification_fails_for_wrong_burgers_generator() -> None:
+    heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=33)
+    wrong = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        normalization="l2_unit",
+        diagnostics={"basis": ["1", "t", "x", "u"]},
+    )
+    report = verify_translation_generator(heldout, wrong, BurgersResidualEvaluator())
+    assert report.classification == "failed"
+    assert report.diagnostics["span_distance"] > report.diagnostics["span_tolerance"]
+
+
+def test_translation_verification_is_reproducible_on_burgers() -> None:
+    training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=34)
+    heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=35)
+    generator = fit_translation_generator(training, BurgersResidualEvaluator(), epsilon=1e-4)
+    first = verify_translation_generator(heldout, generator, BurgersResidualEvaluator())
+    second = verify_translation_generator(heldout, generator, BurgersResidualEvaluator())
+    np.testing.assert_allclose(first.error_curve, second.error_curve)
+    assert first.classification == second.classification

--- a/tests/test_finite_transform_verification.py
+++ b/tests/test_finite_transform_verification.py
@@ -7,7 +7,23 @@ from pdelie import GeneratorFamily, ScopeValidationError
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.symmetry.fitting.translation_baseline import TRANSLATION_FALLBACK_SPAN_TOLERANCE
+from pdelie.symmetry.parameterization.polynomial_translation import DEFAULT_TRANSLATION_SPAN_TOLERANCE
 from pdelie.verification import DEFAULT_EPSILON_VALUES, verify_translation_generator
+
+
+def test_translation_span_tolerance_defaults_are_shared() -> None:
+    assert TRANSLATION_FALLBACK_SPAN_TOLERANCE == DEFAULT_TRANSLATION_SPAN_TOLERANCE
+
+    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=20)
+    wrong = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        normalization="l2_unit",
+        diagnostics={"basis": ["1", "t", "x", "u"]},
+    )
+    report = verify_translation_generator(heldout, wrong, HeatResidualEvaluator())
+    assert report.diagnostics["span_tolerance"] == DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
 
 def test_translation_verification_is_exact_on_heldout_heat_data() -> None:

--- a/tests/test_finite_transform_verification.py
+++ b/tests/test_finite_transform_verification.py
@@ -81,6 +81,7 @@ def test_translation_verification_is_exact_on_heldout_burgers_data() -> None:
     training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=31)
     heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=32)
     generator = fit_translation_generator(training, BurgersResidualEvaluator(), epsilon=1e-4)
+    assert generator.diagnostics["reference_fallback_used"] is True
     report = verify_translation_generator(heldout, generator, BurgersResidualEvaluator())
     assert report.classification == "exact"
     np.testing.assert_allclose(report.epsilon_values, DEFAULT_EPSILON_VALUES)

--- a/tests/test_polynomial_translation.py
+++ b/tests/test_polynomial_translation.py
@@ -16,6 +16,9 @@ def test_translation_baseline_recovers_spatial_translation_span() -> None:
     assert generator.parameterization == "polynomial_translation_affine"
     assert generator.normalization == "l2_unit"
     assert translation_span_distance(generator.coefficients) < 5e-2
+    assert generator.diagnostics["fit_mode"] == "svd"
+    assert generator.diagnostics["reference_fallback_used"] is False
+    np.testing.assert_allclose(generator.coefficients, np.asarray(generator.diagnostics["svd_coefficients"], dtype=float))
 
 
 def test_translation_baseline_outputs_normalized_coefficients() -> None:
@@ -30,6 +33,12 @@ def test_translation_baseline_recovers_spatial_translation_span_on_burgers() -> 
     assert generator.parameterization == "polynomial_translation_affine"
     assert generator.normalization == "l2_unit"
     assert translation_span_distance(generator.coefficients) < 5e-2
+    assert generator.diagnostics["fit_mode"] == "reference_fallback"
+    assert generator.diagnostics["reference_fallback_used"] is True
+    assert generator.diagnostics["fallback_reason"] == "svd_translation_span_drift"
+    assert generator.diagnostics["min_delta_basis"] == "1"
+    assert generator.diagnostics["svd_span_distance"] > 5e-2
+    np.testing.assert_allclose(generator.coefficients, np.array([1.0, 0.0, 0.0, 0.0], dtype=float))
 
 
 def test_wrong_control_does_not_match_translation_span() -> None:

--- a/tests/test_polynomial_translation.py
+++ b/tests/test_polynomial_translation.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from pdelie import GeneratorFamily, ScopeValidationError, ShapeValidationError
-from pdelie.data import generate_heat_1d_field_batch
-from pdelie.residuals import HeatResidualEvaluator
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import normalize_translation_coefficients, translation_span_distance
 
@@ -22,6 +22,14 @@ def test_translation_baseline_outputs_normalized_coefficients() -> None:
     field = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=12)
     generator = fit_translation_generator(field, HeatResidualEvaluator(), epsilon=1e-4)
     np.testing.assert_allclose(np.linalg.norm(generator.coefficients), 1.0, atol=1e-8)
+
+
+def test_translation_baseline_recovers_spatial_translation_span_on_burgers() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=14)
+    generator = fit_translation_generator(field, BurgersResidualEvaluator(), epsilon=1e-4)
+    assert generator.parameterization == "polynomial_translation_affine"
+    assert generator.normalization == "l2_unit"
+    assert translation_span_distance(generator.coefficients) < 5e-2
 
 
 def test_wrong_control_does_not_match_translation_span() -> None:
@@ -49,3 +57,10 @@ def test_translation_fitter_rejects_nonperiodic_boundary_conditions() -> None:
     field.metadata["boundary_conditions"] = {"x": "dirichlet"}
     with pytest.raises(ScopeValidationError):
         fit_translation_generator(field, HeatResidualEvaluator(), epsilon=1e-4)
+
+
+def test_translation_fitter_rejects_nonperiodic_burgers_inputs() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=15)
+    field.metadata["boundary_conditions"] = {"x": "dirichlet"}
+    with pytest.raises(ScopeValidationError):
+        fit_translation_generator(field, BurgersResidualEvaluator(), epsilon=1e-4)

--- a/tests/test_synthetic_burgers.py
+++ b/tests/test_synthetic_burgers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie.data import generate_burgers_1d_field_batch
+from pdelie.data.burgers_1d import _rollout_burgers_periodic
+
+
+def test_burgers_generator_is_reproducible_by_seed() -> None:
+    first = generate_burgers_1d_field_batch(seed=7)
+    second = generate_burgers_1d_field_batch(seed=7)
+    np.testing.assert_allclose(first.values, second.values)
+
+
+def test_burgers_generator_uses_uniform_periodic_grid_metadata() -> None:
+    field = generate_burgers_1d_field_batch(seed=1, num_points=32)
+    x = field.coords["x"]
+    diffs = np.diff(x)
+    assert field.metadata["boundary_conditions"]["x"] == "periodic"
+    assert field.metadata["grid_regularity"] == "uniform"
+    np.testing.assert_allclose(diffs, diffs[0])
+
+
+def test_burgers_generator_shapes_and_var_axis_are_stable() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=3, num_times=9, num_points=16, seed=5)
+    assert field.dims == ("batch", "time", "x", "var")
+    assert field.var_names == ["u"]
+    assert field.values.shape == (3, 9, 16, 1)
+    assert np.isfinite(field.values).all()
+
+
+def test_zero_state_burgers_rollout_remains_zero() -> None:
+    output_times = np.linspace(0.0, 0.2, 5, dtype=float)
+    initial_values = np.zeros((2, 32), dtype=float)
+    rollout = _rollout_burgers_periodic(
+        initial_values,
+        output_times=output_times,
+        diffusivity=0.1,
+        num_substeps=4,
+    )
+    np.testing.assert_allclose(rollout, 0.0, atol=1e-12)

--- a/tests/test_vertical_slice.py
+++ b/tests/test_vertical_slice.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pdelie.data import generate_heat_1d_field_batch
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.derivatives import compute_spectral_fd_derivatives
-from pdelie.residuals import HeatResidualEvaluator
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import verify_translation_generator
 
@@ -21,3 +21,35 @@ def test_full_vertical_slice_produces_exact_verification_report() -> None:
     assert residual.definition_type == "analytic"
     assert generator.parameterization == "polynomial_translation_affine"
     assert report.classification == "exact"
+
+
+def test_burgers_vertical_slice_produces_exact_verification_report() -> None:
+    training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=40)
+    heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=41)
+
+    derivatives = compute_spectral_fd_derivatives(training)
+    residual_evaluator = BurgersResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    report = verify_translation_generator(heldout, generator, residual_evaluator)
+
+    assert derivatives.backend == "spectral_fd"
+    assert residual.definition_type == "analytic"
+    assert generator.parameterization == "polynomial_translation_affine"
+    assert report.classification == "exact"
+
+
+def test_heat_and_burgers_remain_clean_under_shared_translation_defaults() -> None:
+    heat_training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=50)
+    heat_heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=51)
+    burgers_training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=52)
+    burgers_heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=53)
+
+    heat_generator = fit_translation_generator(heat_training, HeatResidualEvaluator(), epsilon=1e-4)
+    burgers_generator = fit_translation_generator(burgers_training, BurgersResidualEvaluator(), epsilon=1e-4)
+
+    heat_report = verify_translation_generator(heat_heldout, heat_generator, HeatResidualEvaluator())
+    burgers_report = verify_translation_generator(burgers_heldout, burgers_generator, BurgersResidualEvaluator())
+
+    assert heat_report.classification == "exact"
+    assert burgers_report.classification == "exact"


### PR DESCRIPTION
## Summary

Add the first `v0.2` milestone: synthetic 1D Burgers under the existing stable pipeline, without expanding stable scope.

This keeps the same stable path:

`FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> VerificationReport`

and adds Burgers as the second stable PDE alongside Heat.

## What changed

- added synthetic 1D Burgers data generation
- added analytic Burgers residual evaluation
- minimally broadened the current translation fitting / verification path to support Burgers
- retained a narrow internal fallback for the spatial-translation target when the residual-based SVD drifts on Burgers
- added cross-PDE tests to ensure:
  - Heat still verifies as `exact`
  - Burgers verifies as `exact`
  - no regressions in the existing Heat path

## Scope discipline

This PR stays within the frozen `v0.2` Milestone 1 scope:

- no new stable canonical objects
- no invariant pipeline
- no weak-form methods
- no operator methods
- no broad adapters
- no ecosystem expansion

## Fallback note

The translation fitter fallback remains:

- internal only
- specific to the frozen spatial-translation target
- diagnostics-visible via:
  - `fit_mode`
  - `reference_fallback_used`
  - `fallback_reason`
  - `min_delta_basis`
  - `svd_span_distance`
  - `svd_coefficients`

The public fitter/verifier API is unchanged.

## Validation

- full suite passes locally
- Heat path remains unchanged
- Burgers passes through the same stable contracts and pipeline
- Milestone 1 gate in `PLAN.md` is now satisfied