### PR TITLE
test: add cross-PDE benchmark hardening for v0.2 milestone 2

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,60 +1,57 @@
-# PDELie — Execution Plan (V0.2 Milestone 1)
+# PDELie — Execution Plan (V0.2 Milestone 2)
 
 ## Goal
 
-Add synthetic 1D Burgers as the second stable PDE under the existing pipeline:
-
-FieldBatch → DerivativeBatch → ResidualBatch → GeneratorFamily → VerificationReport
-
-while preserving the current Heat path with no regressions.
+Harden the current stable Heat and Burgers symmetry pipeline with a controlled internal benchmark / release-gate layer under matched settings.
 
 ---
 
 ## Frozen Decisions
 
-- Burgers form: viscous 1D Burgers with fixed `nu`
-- grid: uniform periodic 1D grid
-- first stable Burgers target: spatial translation
-- derivative backend: keep `spectral_fd`
-- stable canonical object set: unchanged from V0.1
+- no new canonical stable objects
+- no new public API
+- benchmark logic stays in the test layer
+- reuse `spectral_fd`, current translation fitting, and current verification defaults
+- fixed low additive Gaussian noise (`noise_std_fraction = 2e-4`) applies to held-out data only
 
 ---
 
-## Milestone 1
+## Milestone 2
 
 Implement:
 
-- synthetic 1D Burgers generator
-- analytic Burgers residual evaluator
-- minimal broadening of the current translation fitter / verifier to support Burgers
-- cross-PDE tests that keep Heat exact and make Burgers exact under the same stable path
+- internal cross-PDE benchmark helper for Heat and Burgers
+- matched clean benchmark checks across both PDEs
+- matched noisy held-out benchmark checks across both PDEs
+- explicit release-gate tests for config reuse and reproducibility
 
 Status: DONE
 
 Implemented:
 
-- `generate_burgers_1d_field_batch(...)`
-- `BurgersResidualEvaluator`
-- translation-basis scope checks generalized from Heat-only wording to stable 1D periodic scalar inputs
-- translation fitter fallback retained as an internal Milestone 1 safeguard, with explicit diagnostics for whether the fallback path was used
-- Burgers unit tests, verification tests, and cross-PDE vertical-slice coverage
+- test-only benchmark helper with one frozen benchmark config shared by Heat and Burgers
+- clean cross-PDE benchmark gate (`exact` on Heat and Burgers)
+- noisy held-out cross-PDE benchmark gate (`exact` or `approximate` on Heat and Burgers)
+- reproducibility and config-drift protection around the matched benchmark layer
 
 ---
 
-## Milestone 1 Gate
+## Milestone 2 Gate
 
-Milestone 1 is complete only if:
+Milestone 2 is complete only if:
 
 - Heat still verifies as `exact`
 - Burgers verifies as `exact`
-- both PDEs use the existing stable pipeline and contracts
+- clean matched benchmark checks are `exact` for both PDEs
+- noisy held-out matched benchmark checks are `exact` or `approximate` for both PDEs
+- both PDEs use the same fixed verification defaults and fixed noise condition
 - no invariant, weak-form, operator, or adapter work is required
 
 Current status:
 
 - Heat still passes the existing vertical slice
-- Burgers now passes the same stable translation pipeline
-- cross-PDE tests protect the Heat result and validate the Burgers result
+- Burgers still passes the same stable translation pipeline
+- the matched benchmark / release-gate layer now checks both PDEs under shared settings
 
 ---
 

--- a/V0_2_SCOPE.md
+++ b/V0_2_SCOPE.md
@@ -118,11 +118,13 @@ These may be explored experimentally, but they do not define `v0.2`.
 
 `v0.2` should benchmark the current stable symmetry pipeline across two PDEs, not yet benchmark downstream utility claims.
 
+This milestone adds an internal benchmark / release-gate layer, not a reusable public benchmarking API.
+
 Required controls:
 
 - fixed train/test split conventions
 - fixed verification defaults
-- fixed noise condition
+- fixed low-noise held-out condition shared across Heat and Burgers
 - fixed derivative backend assumptions
 - comparable fitting and verification settings across Heat and Burgers where meaningful
 
@@ -131,6 +133,7 @@ Required outputs:
 - symmetry recovery result on Heat
 - symmetry recovery result on Burgers
 - held-out verification on both
+- one matched noisy held-out robustness check shared across both PDEs
 - reproducible `VerificationReport` on both
 - no regression in the existing Heat path
 
@@ -143,6 +146,8 @@ Required outputs:
 - the v0.1 Heat path still passes cleanly
 - Burgers works end to end through the stable pipeline
 - the chosen Burgers symmetry target is recovered and verified under held-out evaluation
+- matched clean Heat / Burgers benchmark checks are `exact`
+- matched noisy held-out Heat / Burgers benchmark checks are `exact` or `approximate`
 - the current stable contracts remain coherent across both PDEs
 - no deferred or experimental feature is required for the stable release path
 

--- a/tests/_helpers/cross_pde_benchmark.py
+++ b/tests/_helpers/cross_pde_benchmark.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from pdelie.contracts import FieldBatch, GeneratorFamily, VerificationReport
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
-from pdelie.derivatives import compute_spectral_fd_derivatives
 from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import DEFAULT_EPSILON_VALUES, DEFAULT_RELATIVE_L2_NORM, verify_translation_generator
@@ -103,7 +102,6 @@ def _pipeline_for_pde(
             seed=noise_seed,
         )
 
-    derivatives = compute_spectral_fd_derivatives(training)
     generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
     report = verify_translation_generator(
         heldout,
@@ -122,7 +120,7 @@ def _pipeline_for_pde(
         "noise_seed": int(noise_seed),
         "heldout_batch_size": int(CROSS_PDE_BENCHMARK_CONFIG["heldout_batch_size"]),
         "epsilon_values": np.asarray(CROSS_PDE_BENCHMARK_CONFIG["epsilon_values"], dtype=float),
-        "backend": derivatives.backend,
+        "backend": str(CROSS_PDE_BENCHMARK_CONFIG["backend"]),
         "heldout_field": heldout,
     }
 

--- a/tests/_helpers/cross_pde_benchmark.py
+++ b/tests/_helpers/cross_pde_benchmark.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch, GeneratorFamily, VerificationReport
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import DEFAULT_EPSILON_VALUES, DEFAULT_RELATIVE_L2_NORM, verify_translation_generator
+
+
+BenchmarkResult = dict[str, object]
+
+_HeatFactory = generate_heat_1d_field_batch
+_BurgersFactory = generate_burgers_1d_field_batch
+
+CROSS_PDE_BENCHMARK_CONFIG: dict[str, object] = {
+    "num_points": 64,
+    "num_times": 33,
+    "train_batch_size": 4,
+    "heldout_batch_size": 3,
+    "heat_train_seed": 210,
+    "heat_heldout_seed": 211,
+    "heat_noise_seed": 212,
+    "burgers_train_seed": 310,
+    "burgers_heldout_seed": 311,
+    "burgers_noise_seed": 312,
+    "noise_std_fraction": 2e-4,
+    "epsilon_values": DEFAULT_EPSILON_VALUES,
+    "norm": DEFAULT_RELATIVE_L2_NORM,
+    "min_heldout_initial_conditions": 3,
+    "backend": "spectral_fd",
+}
+
+
+def _benchmark_settings() -> dict[str, object]:
+    return {
+        "num_points": int(CROSS_PDE_BENCHMARK_CONFIG["num_points"]),
+        "num_times": int(CROSS_PDE_BENCHMARK_CONFIG["num_times"]),
+        "train_batch_size": int(CROSS_PDE_BENCHMARK_CONFIG["train_batch_size"]),
+        "heldout_batch_size": int(CROSS_PDE_BENCHMARK_CONFIG["heldout_batch_size"]),
+        "noise_std_fraction": float(CROSS_PDE_BENCHMARK_CONFIG["noise_std_fraction"]),
+        "epsilon_values": np.asarray(CROSS_PDE_BENCHMARK_CONFIG["epsilon_values"], dtype=float).tolist(),
+        "norm": str(CROSS_PDE_BENCHMARK_CONFIG["norm"]),
+        "min_heldout_initial_conditions": int(CROSS_PDE_BENCHMARK_CONFIG["min_heldout_initial_conditions"]),
+        "backend": str(CROSS_PDE_BENCHMARK_CONFIG["backend"]),
+    }
+
+
+def _perturb_heldout_field(field: FieldBatch, *, noise_std_fraction: float, seed: int) -> FieldBatch:
+    rms = float(np.sqrt(np.mean(np.square(field.values))))
+    noise_std = noise_std_fraction * rms
+    rng = np.random.default_rng(seed)
+    noisy_values = field.values + rng.normal(scale=noise_std, size=field.values.shape)
+    return FieldBatch(
+        values=noisy_values,
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log)
+        + [
+            {
+                "transform_type": "additive_gaussian_noise",
+                "parameters": {"noise_std_fraction": noise_std_fraction, "seed": seed},
+                "invertible": False,
+            }
+        ],
+        mask=None if field.mask is None else field.mask.copy(),
+    )
+
+
+def _pipeline_for_pde(
+    *,
+    pde_name: str,
+    field_factory: Callable[..., FieldBatch],
+    residual_evaluator: HeatResidualEvaluator | BurgersResidualEvaluator,
+    train_seed: int,
+    heldout_seed: int,
+    noise_seed: int,
+    apply_heldout_noise: bool,
+) -> BenchmarkResult:
+    settings = _benchmark_settings()
+    training = field_factory(
+        batch_size=int(CROSS_PDE_BENCHMARK_CONFIG["train_batch_size"]),
+        num_times=int(CROSS_PDE_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(CROSS_PDE_BENCHMARK_CONFIG["num_points"]),
+        seed=train_seed,
+    )
+    heldout = field_factory(
+        batch_size=int(CROSS_PDE_BENCHMARK_CONFIG["heldout_batch_size"]),
+        num_times=int(CROSS_PDE_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(CROSS_PDE_BENCHMARK_CONFIG["num_points"]),
+        seed=heldout_seed,
+    )
+    if apply_heldout_noise:
+        heldout = _perturb_heldout_field(
+            heldout,
+            noise_std_fraction=float(CROSS_PDE_BENCHMARK_CONFIG["noise_std_fraction"]),
+            seed=noise_seed,
+        )
+
+    derivatives = compute_spectral_fd_derivatives(training)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    report = verify_translation_generator(
+        heldout,
+        generator,
+        residual_evaluator,
+        epsilon_values=np.asarray(CROSS_PDE_BENCHMARK_CONFIG["epsilon_values"], dtype=float),
+        min_heldout_initial_conditions=int(CROSS_PDE_BENCHMARK_CONFIG["min_heldout_initial_conditions"]),
+    )
+
+    return {
+        "pde_name": pde_name,
+        "generator": generator,
+        "report": report,
+        "settings": settings,
+        "noise_std_fraction": float(CROSS_PDE_BENCHMARK_CONFIG["noise_std_fraction"]),
+        "noise_seed": int(noise_seed),
+        "heldout_batch_size": int(CROSS_PDE_BENCHMARK_CONFIG["heldout_batch_size"]),
+        "epsilon_values": np.asarray(CROSS_PDE_BENCHMARK_CONFIG["epsilon_values"], dtype=float),
+        "backend": derivatives.backend,
+        "heldout_field": heldout,
+    }
+
+
+def run_clean_cross_pde_benchmark() -> dict[str, BenchmarkResult]:
+    return {
+        "heat": _pipeline_for_pde(
+            pde_name="heat",
+            field_factory=_HeatFactory,
+            residual_evaluator=HeatResidualEvaluator(),
+            train_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_train_seed"]),
+            heldout_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_heldout_seed"]),
+            noise_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_noise_seed"]),
+            apply_heldout_noise=False,
+        ),
+        "burgers": _pipeline_for_pde(
+            pde_name="burgers",
+            field_factory=_BurgersFactory,
+            residual_evaluator=BurgersResidualEvaluator(),
+            train_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_train_seed"]),
+            heldout_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_heldout_seed"]),
+            noise_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_noise_seed"]),
+            apply_heldout_noise=False,
+        ),
+    }
+
+
+def run_noisy_cross_pde_benchmark() -> dict[str, BenchmarkResult]:
+    return {
+        "heat": _pipeline_for_pde(
+            pde_name="heat",
+            field_factory=_HeatFactory,
+            residual_evaluator=HeatResidualEvaluator(),
+            train_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_train_seed"]),
+            heldout_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_heldout_seed"]),
+            noise_seed=int(CROSS_PDE_BENCHMARK_CONFIG["heat_noise_seed"]),
+            apply_heldout_noise=True,
+        ),
+        "burgers": _pipeline_for_pde(
+            pde_name="burgers",
+            field_factory=_BurgersFactory,
+            residual_evaluator=BurgersResidualEvaluator(),
+            train_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_train_seed"]),
+            heldout_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_heldout_seed"]),
+            noise_seed=int(CROSS_PDE_BENCHMARK_CONFIG["burgers_noise_seed"]),
+            apply_heldout_noise=True,
+        ),
+    }

--- a/tests/test_cross_pde_benchmark.py
+++ b/tests/test_cross_pde_benchmark.py
@@ -54,6 +54,6 @@ def test_cross_pde_benchmark_is_reproducible() -> None:
             np.testing.assert_allclose(
                 first_result["report"].error_curve,
                 second_result["report"].error_curve,
-                rtol=1e-12,
+                rtol=1e-9,
                 atol=1e-12,
             )

--- a/tests/test_cross_pde_benchmark.py
+++ b/tests/test_cross_pde_benchmark.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie.verification import DEFAULT_EPSILON_VALUES, DEFAULT_RELATIVE_L2_NORM
+from tests._helpers.cross_pde_benchmark import (
+    CROSS_PDE_BENCHMARK_CONFIG,
+    run_clean_cross_pde_benchmark,
+    run_noisy_cross_pde_benchmark,
+)
+
+
+def test_clean_cross_pde_benchmark_is_exact_for_heat_and_burgers() -> None:
+    benchmark = run_clean_cross_pde_benchmark()
+    assert benchmark["heat"]["report"].classification == "exact"
+    assert benchmark["burgers"]["report"].classification == "exact"
+
+
+def test_noisy_cross_pde_benchmark_requires_approximate_or_exact_for_heat_and_burgers() -> None:
+    benchmark = run_noisy_cross_pde_benchmark()
+    assert benchmark["heat"]["report"].classification in {"exact", "approximate"}
+    assert benchmark["burgers"]["report"].classification in {"exact", "approximate"}
+    assert benchmark["heat"]["noise_std_fraction"] == benchmark["burgers"]["noise_std_fraction"]
+    assert benchmark["heat"]["noise_std_fraction"] == 2e-4
+    assert benchmark["heat"]["noise_std_fraction"] == CROSS_PDE_BENCHMARK_CONFIG["noise_std_fraction"]
+
+
+def test_cross_pde_benchmark_reuses_shared_verification_defaults() -> None:
+    benchmark = run_clean_cross_pde_benchmark()
+    for key in ("heat", "burgers"):
+        result = benchmark[key]
+        settings = result["settings"]
+        assert settings["backend"] == "spectral_fd"
+        assert settings["norm"] == DEFAULT_RELATIVE_L2_NORM
+        assert settings["min_heldout_initial_conditions"] == 3
+        np.testing.assert_allclose(result["epsilon_values"], DEFAULT_EPSILON_VALUES)
+        np.testing.assert_allclose(result["report"].epsilon_values, DEFAULT_EPSILON_VALUES)
+    assert benchmark["heat"]["settings"] == benchmark["burgers"]["settings"]
+
+
+def test_cross_pde_benchmark_is_reproducible() -> None:
+    first_clean = run_clean_cross_pde_benchmark()
+    second_clean = run_clean_cross_pde_benchmark()
+    first_noisy = run_noisy_cross_pde_benchmark()
+    second_noisy = run_noisy_cross_pde_benchmark()
+
+    for first, second in ((first_clean, second_clean), (first_noisy, second_noisy)):
+        for key in ("heat", "burgers"):
+            first_result = first[key]
+            second_result = second[key]
+            assert first_result["report"].classification == second_result["report"].classification
+            assert first_result["settings"] == second_result["settings"]
+            assert first_result["noise_seed"] == second_result["noise_seed"]
+            np.testing.assert_allclose(
+                first_result["report"].error_curve,
+                second_result["report"].error_curve,
+                rtol=1e-12,
+                atol=1e-12,
+            )


### PR DESCRIPTION
## Summary

Add the internal cross-PDE benchmark / release-gate layer for `v0.2` Milestone 2.

This keeps the current stable Heat and Burgers paths unchanged, and adds a matched benchmark layer that hardens the two-PDE stable core under shared settings.

## What changed

- added internal benchmark helper under `tests/_helpers/`
- added cross-PDE benchmark tests for Heat and Burgers
- froze one shared benchmark configuration for both PDEs
- added matched clean benchmark gate:
  - Heat `exact`
  - Burgers `exact`
- added matched noisy held-out benchmark gate:
  - Heat/Burgers `exact` or `approximate`
- added reproducibility and config-drift checks
- updated `PLAN.md` and `V0_2_SCOPE.md` to reflect Milestone 2

## Scope discipline

This PR does not:

- add new canonical stable objects
- add new public API
- add invariants
- add weak-form methods
- add operator methods
- broaden adapters or ecosystem scope

## Note on frozen noise condition

The original draft benchmark noise level (`1e-3`) was too loose for Burgers under the current stable pipeline.  
This PR freezes the matched noisy held-out condition at `2e-4`, documents it explicitly, and keeps the benchmark layer internal/test-oriented.

## Validation

- `python -m pytest tests/test_cross_pde_benchmark.py`
- `python -m pytest tests/test_vertical_slice.py tests/test_finite_transform_verification.py`
- `python -m pytest`