### PR TITLE
release: prepare v0.2.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.2.0rc1
+
+First release candidate for the frozen V0.2 stable core.
+
+- extends the stable core from Heat-only to matched Heat and Burgers coverage
+- stable pipeline remains:
+  `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> VerificationReport`
+- synthetic 1D Burgers added as the second stable PDE under the existing contracts
+- current translation fitting and finite-transform verification paths hardened across Heat and Burgers
+- matched cross-PDE benchmark / release-gate layer added in the test surface under shared defaults and shared low-noise held-out conditions
+- release metadata, packaging text, and user-facing docs aligned with the implemented V0.2 state
+
+Explicitly deferred for this release candidate:
+
+- invariant pipelines as a stable feature
+- weak-form methods
+- operator methods
+- broad adapters or interoperability expansion
+- new canonical objects beyond the current stable slice
+
 ## 0.1.0
 
 First final release for the frozen V0.1 MVP slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the stable V0.x core with two synthetic PDE paths:
+The current repository implements the stable V0.2 core with two synthetic PDE paths:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -19,7 +19,7 @@ From the repo root:
 
 ```bash
 conda env create -f environment.yml
-conda activate pdelie-v0_1
+conda activate pdelie
 ```
 
 ### Editable install
@@ -42,7 +42,7 @@ python -m pytest
 
 ## Minimal End-To-End Example
 
-Run the packaged MVP example module from the repo root:
+Run the packaged example module from the repo root:
 
 ```bash
 python -m pdelie.examples.heat_vertical_slice
@@ -69,12 +69,13 @@ print(result["verification_classification"])
 
 ## Current Scope
 
-Included in the current MVP:
+Included in the current stable core:
 
-- canonical V0.1 objects and typed validation errors
+- stable canonical objects and typed validation errors
 - synthetic heat and Burgers data
 - polynomial translation baseline only
 - finite-transform verification only
+- matched Heat/Burgers benchmark and release-gate checks in the test layer
 
 Explicitly deferred:
 - operator symmetry

--- a/V0_2_RELEASE_READINESS.md
+++ b/V0_2_RELEASE_READINESS.md
@@ -1,0 +1,55 @@
+# V0.2 Release Readiness
+
+## Release Target
+
+- package version: `0.2.0rc1`
+- git tag: `v0.2.0rc1`
+
+## Done
+
+- the stable canonical object set remains unchanged:
+  `FieldBatch`, `DerivativeBatch`, `ResidualBatch`, `ResidualEvaluator`,
+  `GeneratorFamily`, `VerificationReport`
+- Heat remains supported under the existing stable path
+- synthetic 1D Burgers is implemented as the second stable PDE
+- the stable derivative backend remains `spectral_fd`
+- analytic Heat and Burgers residual evaluators are implemented
+- the polynomial spatial-translation fitting path works across Heat and Burgers
+- the finite-transform verification path works across Heat and Burgers
+- the matched cross-PDE benchmark / release-gate layer is implemented in the test surface
+- the full test suite passes from the repo root
+- packaging, editable install, built-wheel smoke validation, and the packaged example path remain in place
+
+## Explicitly Deferred
+
+- invariant pipelines as a stable feature
+- weak-form methods beyond reserved interface surface
+- operator methods
+- broad dataset adapters or interoperability work
+- new canonical stable objects beyond the current slice
+- paper-specific experiment logic
+
+## Release-Candidate View
+
+The current repository is ready for the `0.2.0rc1` release candidate for the frozen V0.2 stable core, subject to the release-path checks passing on the release branch and CI passing on the release PR.
+
+There are no known scientific-scope blockers inside the current V0.2 slice.
+
+## Benchmark And Release-Gate Notes
+
+- Heat and Burgers are both required to pass the same stable pipeline.
+- Clean matched benchmark checks must classify as `exact` on both PDEs.
+- Matched noisy held-out benchmark checks must classify as `exact` or `approximate` on both PDEs.
+- The benchmark/release-gate layer remains internal to the test surface and is not a public API.
+
+## RC Tag Checklist
+
+Before tagging `v0.2.0rc1`:
+
+- run `python -m pytest` from the repo root
+- run `python -m build --sdist --wheel`
+- install the built wheel into a clean environment and verify stable imports
+- run `python -m pdelie.examples.heat_vertical_slice`
+- confirm GitHub Actions jobs `editable-tests` and `package-smoke` pass on the release PR commit
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.2.0rc1`

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pdelie-v0_1
+name: pdelie
 channels:
   - conda-forge
 dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.1.0"
-description = "Stable V0.1 vertical slice for PDE Lie symmetry discovery"
+version = "0.2.0rc1"
+description = "Stable V0.2 core for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24",


### PR DESCRIPTION
Prepare the v0.2.0rc1 release surface only.

This PR:
- bumps version metadata to 0.2.0rc1
- aligns README, changelog, environment, and release-readiness docs with the implemented V0.2 stable core
- does not add new scientific scope or API changes