### PR TITLE
Feat/v0 3 invariant map m1

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -8,9 +8,18 @@
 - ResidualBatch
 - ResidualEvaluator
 - GeneratorFamily (polynomial only)
+- InvariantMapSpec (single-generator only)
 - VerificationReport
 - basic verification tools
 - typed validation errors (`PDELieValidationError`, `SchemaValidationError`, `ShapeValidationError`, `ScopeValidationError`)
+
+Stable public import path for the invariant canonical object:
+
+- `pdelie.InvariantMapSpec`
+
+Runtime public API for the frozen `v0.3` Milestone 1 slice:
+
+- `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 
 These must not change without version bump.
 
@@ -22,6 +31,7 @@ These must not change without version bump.
 - weak-form methods
 - operator symmetry
 - advanced invariant maps
+- multi-generator invariant machinery
 
 These may change without warning.
 

--- a/CONTRACTS_AND_DEFAULTS.md
+++ b/CONTRACTS_AND_DEFAULTS.md
@@ -131,7 +131,34 @@ GeneratorFamily(
 
 ---
 
-## 1.6 VerificationReport
+## 1.6 InvariantMapSpec
+
+~~~python
+InvariantMapSpec(
+    schema_version: str,
+    generator_metadata: Dict[str, Any],
+    construction_method: str,
+    parameters: Dict[str, Any],
+    domain_validity: str,
+    inverse_available: bool,
+    diagnostics: Dict[str, Any]
+)
+~~~
+
+### Required rules
+
+- `domain_validity ∈ {"local", "global", "unknown"}`
+- `generator_metadata` MUST include a non-empty `parameterization`
+- non-global maps MUST include explicit validity diagnostics
+- approximate maps MUST include explicit approximation diagnostics
+
+Runtime-only, not canonical:
+
+- `InvariantApplier`
+
+---
+
+## 1.7 VerificationReport
 
 ~~~python
 VerificationReport(

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,64 +1,216 @@
-# PDELie — Execution Plan (V0.2 Milestone 2)
+# PDELie — Execution Plan (V0.3 Milestone 1)
 
 ## Goal
 
-Harden the current stable Heat and Burgers symmetry pipeline with a controlled internal benchmark / release-gate layer under matched settings.
+Add the first stable invariant layer in the narrowest possible form:
+
+`FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> InvariantApplier`
+
+for the **single-generator case only**, while preserving the current stable Heat and Burgers paths with no regressions.
+
+This milestone does **not** add downstream benchmarking yet.  
+It only adds the minimum invariant representation and runtime application layer required for the later `v0.3` downstream utility release.
 
 ---
 
 ## Frozen Decisions
 
-- no new canonical stable objects
-- no new public API
-- benchmark logic stays in the test layer
-- reuse `spectral_fd`, current translation fitting, and current verification defaults
-- fixed low additive Gaussian noise (`noise_std_fraction = 2e-4`) applies to held-out data only
+- single-generator case only
+- no new numerical backend
+- no weak-form methods
+- no operator methods
+- no broad adapters
+- no new public downstream API
+- `InvariantMapSpec` becomes stable in `v0.3`
+- `InvariantApplier` remains runtime-only
+- stable PDEs remain:
+  - Heat
+  - Burgers
+- stable derivative backend remains:
+  - `spectral_fd`
+- stable symmetry target remains translation-oriented for the first invariant path unless a minimal extension is explicitly required
 
 ---
 
-## Milestone 2
+## Milestone 1
 
 Implement:
 
-- internal cross-PDE benchmark helper for Heat and Burgers
-- matched clean benchmark checks across both PDEs
-- matched noisy held-out benchmark checks across both PDEs
-- explicit release-gate tests for config reuse and reproducibility
+- `InvariantMapSpec` as a stable canonical object for the single-generator case
+- runtime `InvariantApplier`
+- one simple invariant application path for the current stable symmetry slice
+- regression protection ensuring Heat and Burgers still pass the current stable symmetry pipeline
 
-Status: DONE
+This milestone is complete only if the invariant layer is:
 
-Implemented:
-
-- test-only benchmark helper with one frozen benchmark config shared by Heat and Burgers
-- clean cross-PDE benchmark gate (`exact` on Heat and Burgers)
-- noisy held-out cross-PDE benchmark gate (`exact` or `approximate` on Heat and Burgers)
-- reproducibility and config-drift protection around the matched benchmark layer
+- contract-compliant
+- provenance-preserving
+- numerically stable enough for the frozen single-generator path
+- non-disruptive to the existing stable core
 
 ---
 
-## Milestone 2 Gate
+## Required Components
 
-Milestone 2 is complete only if:
+### 1. Stable `InvariantMapSpec`
 
-- Heat still verifies as `exact`
-- Burgers verifies as `exact`
-- clean matched benchmark checks are `exact` for both PDEs
-- noisy held-out matched benchmark checks are `exact` or `approximate` for both PDEs
-- both PDEs use the same fixed verification defaults and fixed noise condition
-- no invariant, weak-form, operator, or adapter work is required
+Add a stable canonical object with at least:
 
-Current status:
+- `schema_version`
+- generator reference / generator metadata
+- construction method
+- parameters
+- domain validity (`local` / `global` / `unknown`)
+- inverse availability flag
+- diagnostics
+- serialization support:
+  - `.to_dict()`
+  - `.from_dict()`
 
-- Heat still passes the existing vertical slice
-- Burgers still passes the same stable translation pipeline
-- the matched benchmark / release-gate layer now checks both PDEs under shared settings
+This object must remain narrow and must not assume multi-generator charts.
+
+---
+
+### 2. Runtime `InvariantApplier`
+
+Add a runtime utility that:
+
+- accepts an `InvariantMapSpec`
+- applies the transform to a `FieldBatch`
+- returns a transformed `FieldBatch`
+- appends the transform to `preprocess_log`
+
+`InvariantApplier` is not a canonical stable artifact; it is a runtime interface.
+
+---
+
+### 3. One frozen application path
+
+Implement one minimal supported transform path for the current stable symmetry slice.
+
+That path must:
+
+- work on the existing stable Heat/Burgers setting
+- preserve `FieldBatch` contract compliance
+- preserve provenance
+- avoid introducing a new numerical regime
+- avoid pretending that global invariant charts are available when they are not
+
+If the transform is only valid locally or approximately, that must be explicit in diagnostics.
+
+---
+
+### 4. Regression protection
+
+Keep the existing stable core intact:
+
+- Heat path still works
+- Burgers path still works
+- no regression in symmetry verification
+- no new canonical stable objects beyond what `v0.3` froze
+
+---
+
+## Exact Files To Create Or Modify
+
+Create:
+
+- `src/pdelie/invariants/__init__.py`
+- `src/pdelie/invariants/spec.py`
+- `src/pdelie/invariants/apply.py`
+- `tests/test_invariant_map_spec.py`
+- `tests/test_invariant_applier.py`
+
+Modify only if required:
+
+- `src/pdelie/contracts.py`
+- `src/pdelie/__init__.py`
+- `SPEC.md`
+- `CONTRACTS_AND_DEFAULTS.md`
+- `API_STABILITY.md`
+- `ROADMAP.md`
+- `PLAN.md`
+
+Do **not** modify:
+
+- data generation modules
+- derivative backend modules
+- residual evaluators
+- translation fitter logic
+- verification core
+- downstream bridge code
+- benchmark harness code
+
+unless a minimal contract-consistency fix is required.
+
+---
+
+## Minimal Test Plan
+
+### 1. Contract tests
+
+Add tests for `InvariantMapSpec`:
+
+- valid construction
+- required fields enforced
+- invalid domain-validity rejected
+- serialization round-trip
+
+### 2. Runtime application tests
+
+Add tests for `InvariantApplier`:
+
+- transformed object remains a valid `FieldBatch`
+- `preprocess_log` is appended correctly
+- metadata / dims / coords stay contract-compliant
+- invalid input raises typed validation error
+
+### 3. Stable-path compatibility tests
+
+Add tests showing:
+
+- Heat still passes existing stable path unchanged
+- Burgers still passes existing stable path unchanged
+- invariant application does not corrupt the current stable data model
+
+### 4. Reproducibility / diagnostics tests
+
+Add tests ensuring:
+
+- invariant application diagnostics are deterministic for fixed input
+- local/global validity is explicitly recorded
+- transform provenance is retained in the output `FieldBatch`
+
+---
+
+## Milestone 1 Gate
+
+Milestone 1 is complete only if:
+
+- `InvariantMapSpec` exists as a stable canonical object
+- `InvariantApplier` works end to end on the frozen single-generator path
+- transformed outputs remain valid `FieldBatch` objects
+- transform provenance is recorded
+- Heat and Burgers still pass the current stable symmetry pipeline
+- no downstream bridge is required yet
+- no deferred or experimental feature is required
+
+If these are not satisfied, Milestone 1 is not complete.
 
 ---
 
 ## Rules
 
-- DO NOT add invariants in this milestone
 - DO NOT add weak-form methods
 - DO NOT add operator methods
-- DO NOT broaden adapters or ecosystem scope
-- DO NOT add new canonical stable objects unless forced by a later milestone
+- DO NOT add broad adapters
+- DO NOT add multi-generator invariant machinery
+- DO NOT add downstream benchmark logic
+- DO NOT add a broad invariant public API
+- DO NOT change the current stable Heat/Burgers symmetry path unless required by a minimal contract-consistency fix
+
+---
+
+## Status
+
+Status: TODO

--- a/PLAN.md
+++ b/PLAN.md
@@ -213,4 +213,4 @@ If these are not satisfied, Milestone 1 is not complete.
 
 ## Status
 
-Status: TODO
+Status: COMPLETE

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,9 +35,7 @@ FieldBatch
 → DerivativeBatch
 → ResidualBatch (via ResidualEvaluator)
 → GeneratorFamily
-→ InvariantMap
-→ InvariantLibrary
-→ DiscoveryResult
+→ InvariantMapSpec
 → VerificationReport
 ```
 
@@ -98,20 +96,18 @@ Defines symmetry target.
 
 ---
 
-## InvariantMap
+## InvariantMapSpec
 
-- generator(s)
-- mapping definition
-- validity (local/global)
+- single-generator metadata
+- construction method
+- parameters
+- validity (local/global/unknown)
+- inverse availability
+- diagnostics
 
----
+Runtime-only for the stable `v0.3` Milestone 1 slice:
 
-## DiscoveryResult
-
-- discovered model
-- coefficients
-- feature library
-- validation metrics
+- `InvariantApplier`
 
 ---
 

--- a/V0_3_SCOPE.md
+++ b/V0_3_SCOPE.md
@@ -1,0 +1,223 @@
+# V0.3 Scope
+
+## Summary
+
+`v0.3` is the smallest next release that expands PDELie in a disciplined way after the two-PDE stable core established in `v0.2`.
+
+It does **not** introduce a new numerical regime.  
+It does **not** widen the ecosystem surface broadly.  
+It does **not** bring operator methods into the stable library.
+
+Instead, it asks a narrower and more important question:
+
+> Can the current stable symmetry pipeline support one minimal invariant/downstream utility path without widening stable scope beyond what is necessary?
+
+`v0.3` is therefore the first **downstream utility** release, not the first **broad ecosystem** release.
+
+The downstream target for `v0.3` is frozen as:
+
+- a **single-generator** invariant workflow only
+- a **thin downstream bridge** only
+- one **controlled benchmark layer** only
+- Heat and Burgers remain the only stable PDEs
+- the current stable derivative backend remains `spectral_fd`
+
+---
+
+## Must Implement
+
+### Stable scope for `v0.3`
+
+- uniform rectilinear grids only
+- synthetic PDE data only
+- polynomial generators only
+- single-generator invariant workflows only
+- one thin downstream bridge only
+- verification-first development
+- Heat and Burgers remain supported
+- no new numerical backend is required for the stable path
+
+### Stable canonical objects for `v0.3`
+
+The stable canonical object set grows only where necessary for the first invariant/downstream utility release.
+
+Stable in `v0.3`:
+
+- `FieldBatch`
+- `DerivativeBatch`
+- `ResidualBatch`
+- `ResidualEvaluator`
+- `GeneratorFamily`
+- `VerificationReport`
+- `InvariantMapSpec`
+
+Runtime-only, not canonical:
+
+- `InvariantApplier`
+
+Still not stable in `v0.3`:
+
+- `InvariantLibrary`
+- `DiscoveryResult`
+
+No other canonical objects should become stable in `v0.3` unless absolutely necessary to support the frozen invariant/downstream path.
+
+---
+
+## Concrete `v0.3` Target
+
+Add one minimal end-to-end stable downstream path on top of the existing stable symmetry core.
+
+The stable conceptual path becomes:
+
+`FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> InvariantApplier -> downstream bridge -> VerificationReport`
+
+for Heat and Burgers under the current stable translation-targeted symmetry slice.
+
+### Required components
+
+- one stable `InvariantMapSpec` for the single-generator case
+- one runtime `InvariantApplier` that applies the frozen single-generator invariant transform to a `FieldBatch`
+- one thin PySINDy bridge or equivalent downstream export path
+- one controlled benchmark comparing:
+  - vanilla downstream path
+  - known-invariant downstream path
+  - discovered-invariant downstream path
+  - one nuisance / conditioning baseline
+- one release-gate layer that keeps all settings matched across benchmark branches
+
+### Required scientific result
+
+- the known-invariant and discovered-invariant downstream paths both run end to end under the stable contracts
+- the benchmark is reproducible and matched
+- the discovered-invariant path is at least meaningfully distinguishable from a nuisance baseline under matched controls
+- Heat and Burgers remain regression-free under the existing stable symmetry pipeline
+
+`v0.3` is a utility release, not yet a “strong superiority claim” release.
+
+---
+
+## Frozen Decisions
+
+For the stable `v0.3` path:
+
+- only the **single-generator** case is supported
+- the stable downstream bridge is **thin**, not a new discovery framework
+- benchmark logic may live in an internal helper / test-oriented layer unless and until a public API is justified
+- known-invariant and discovered-invariant paths must be compared under the same feature budget, regularization budget, and split policy
+- one nuisance baseline is mandatory
+
+If a broader invariant representation or richer downstream result object becomes necessary, that belongs to a later release unless the need is minimal and unavoidable.
+
+---
+
+## Development Order
+
+1. freeze `v0.3` scope
+2. define and implement `InvariantMapSpec` for the single-generator case
+3. add runtime `InvariantApplier`
+4. add one thin downstream bridge
+5. add the controlled downstream benchmark layer
+6. add nuisance/conditioning control baseline
+7. add release-gate tests and documentation
+
+---
+
+## Explicitly Deferred
+
+The following are **not** part of stable `v0.3` scope:
+
+- weak-form derivatives as a stable backend
+- multi-generator invariant charts
+- `InvariantLibrary` as a stable contract
+- `DiscoveryResult` as a stable contract
+- broad system-identification framework work beyond one thin bridge
+- broad adapters (PDEBench, The Well, etc.) as release-defining work
+- operator symmetry
+- NeuralOperator integration
+- nonuniform rectilinear support in stable derivative code
+- multiple downstream backends
+- broad benchmark zoo
+- manuscript-specific experiment logic
+
+These may be explored experimentally, but they do not define `v0.3`.
+
+---
+
+## Benchmark Rules for `v0.3`
+
+`v0.3` should benchmark the first stable downstream utility path, not yet claim broad downstream dominance.
+
+Required controls:
+
+- fixed train/test split conventions
+- fixed verification defaults
+- fixed noise condition where applicable
+- fixed feature budget
+- fixed regularization budget
+- fixed derivative backend assumptions
+- identical benchmark settings across:
+  - vanilla
+  - known-invariant
+  - discovered-invariant
+  - nuisance baseline
+
+Required outputs:
+
+- downstream result for vanilla path
+- downstream result for known-invariant path
+- downstream result for discovered-invariant path
+- downstream result for one nuisance baseline
+- held-out evaluation under matched settings
+- reproducible benchmark outputs
+- no regression in the existing Heat/Burgers symmetry paths
+
+The benchmark must distinguish:
+- correctness of the invariant/downstream mechanism
+- conditioning effects
+- genuine symmetry-related benefit
+
+---
+
+## Release Gate
+
+`v0.3` is releasable only if:
+
+- the `v0.2` Heat path still passes cleanly
+- the `v0.2` Burgers path still passes cleanly
+- the single-generator `InvariantMapSpec` and `InvariantApplier` work end to end on the frozen stable path
+- the downstream bridge works for the frozen stable task
+- the controlled benchmark runs reproducibly under matched settings
+- the nuisance baseline is included
+- no deferred or experimental feature is required for the stable release path
+- the current stable contracts remain coherent after adding the first invariant/downstream layer
+
+If these conditions are not met, `v0.3` is not complete.
+
+---
+
+## Non-goals
+
+`v0.3` is **not**:
+
+- the release where weak-form methods become stable
+- the release where PDELie becomes a broad ecosystem hub
+- the release where operator methods become part of the stable library
+- the release where full invariant machinery becomes stable
+- the release where downstream discovery becomes a broad multi-backend framework
+
+It is the release where PDELie proves that its current stable symmetry core can support one disciplined invariant/downstream utility path.
+
+---
+
+## Next Expansion After `v0.3`
+
+If `v0.3` succeeds, the next credible stable step is one of:
+
+- broader invariant machinery
+- broader downstream semantics
+- broader numerics
+
+but still **not automatically** operator methods or broad ecosystem expansion.
+
+Those decisions belong to `v0.4+`, not `v0.3`.

--- a/src/pdelie/__init__.py
+++ b/src/pdelie/__init__.py
@@ -2,6 +2,7 @@ from pdelie.contracts import (
     DerivativeBatch,
     FieldBatch,
     GeneratorFamily,
+    InvariantMapSpec,
     ResidualBatch,
     VerificationReport,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "DerivativeBatch",
     "FieldBatch",
     "GeneratorFamily",
+    "InvariantMapSpec",
     "PDELieValidationError",
     "ResidualBatch",
     "ResidualEvaluator",
@@ -25,4 +27,3 @@ __all__ = [
     "ShapeValidationError",
     "VerificationReport",
 ]
-

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -23,6 +23,7 @@ REQUIRED_METADATA_KEYS = (
 ALLOWED_DERIVATIVE_BACKENDS = frozenset({"spectral_fd", "spectral", "finite", "weak"})
 ALLOWED_RESIDUAL_TYPES = frozenset({"analytic", "weak", "surrogate", "operator"})
 ALLOWED_CLASSIFICATIONS = frozenset({"exact", "approximate", "failed"})
+ALLOWED_DOMAIN_VALIDITIES = frozenset({"local", "global", "unknown"})
 SPATIAL_DIMS = ("x", "y", "z")
 
 
@@ -363,6 +364,77 @@ class GeneratorFamily:
             parameterization=str(payload["parameterization"]),
             coefficients=np.asarray(payload["coefficients"], dtype=float),
             normalization=str(payload["normalization"]),
+            diagnostics=dict(payload["diagnostics"]),
+        )
+
+
+@dataclass(slots=True)
+class InvariantMapSpec:
+    schema_version: str = "0.1"
+    generator_metadata: dict[str, Any] = None  # type: ignore[assignment]
+    construction_method: str = ""
+    parameters: dict[str, Any] = None  # type: ignore[assignment]
+    domain_validity: str = ""
+    inverse_available: bool = False
+    diagnostics: dict[str, Any] = None  # type: ignore[assignment]
+
+    SCHEMA_VERSION: ClassVar[str] = "0.1"
+
+    def __post_init__(self) -> None:
+        self.generator_metadata = dict(_validate_mapping(self.generator_metadata, "generator_metadata"))
+        self.parameters = dict(_validate_mapping(self.parameters, "parameters"))
+        self.diagnostics = dict(_validate_mapping(self.diagnostics, "diagnostics"))
+        self.validate()
+
+    def validate(self) -> None:
+        if self.schema_version != self.SCHEMA_VERSION:
+            raise SchemaValidationError("Unsupported InvariantMapSpec schema_version.")
+        if not self.generator_metadata:
+            raise SchemaValidationError("generator_metadata must not be empty.")
+        parameterization = self.generator_metadata.get("parameterization")
+        if not isinstance(parameterization, str) or not parameterization:
+            raise SchemaValidationError("generator_metadata must include a non-empty 'parameterization'.")
+        if not isinstance(self.construction_method, str) or not self.construction_method:
+            raise SchemaValidationError("construction_method must be a non-empty string.")
+        if self.domain_validity not in ALLOWED_DOMAIN_VALIDITIES:
+            raise SchemaValidationError(f"Unsupported domain_validity: {self.domain_validity}.")
+        if not isinstance(self.inverse_available, bool):
+            raise SchemaValidationError("inverse_available must be a boolean.")
+
+        approximate = self.diagnostics.get("approximate", False)
+        if not isinstance(approximate, bool):
+            raise SchemaValidationError("diagnostics['approximate'] must be a boolean when provided.")
+        if self.domain_validity != "global":
+            validity_note = self.diagnostics.get("validity_note")
+            if not isinstance(validity_note, str) or not validity_note:
+                raise SchemaValidationError("Non-global invariant specs must include diagnostics['validity_note'].")
+        if approximate:
+            approximation_note = self.diagnostics.get("approximation_note")
+            if not isinstance(approximation_note, str) or not approximation_note:
+                raise SchemaValidationError("Approximate invariant specs must include diagnostics['approximation_note'].")
+
+        _validate_json_round_trip(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "generator_metadata": _json_safe(self.generator_metadata),
+            "construction_method": self.construction_method,
+            "parameters": _json_safe(self.parameters),
+            "domain_validity": self.domain_validity,
+            "inverse_available": self.inverse_available,
+            "diagnostics": _json_safe(self.diagnostics),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "InvariantMapSpec":
+        return cls(
+            schema_version=str(payload["schema_version"]),
+            generator_metadata=dict(payload["generator_metadata"]),
+            construction_method=str(payload["construction_method"]),
+            parameters=dict(payload["parameters"]),
+            domain_validity=str(payload["domain_validity"]),
+            inverse_available=bool(payload["inverse_available"]),
             diagnostics=dict(payload["diagnostics"]),
         )
 

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -428,13 +428,19 @@ class InvariantMapSpec:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "InvariantMapSpec":
+        inverse_available = payload["inverse_available"]
+        if not isinstance(inverse_available, bool):
+            raise SchemaValidationError(
+                "InvariantMapSpec.inverse_available must be a boolean"
+            )
+
         return cls(
             schema_version=str(payload["schema_version"]),
             generator_metadata=dict(payload["generator_metadata"]),
             construction_method=str(payload["construction_method"]),
             parameters=dict(payload["parameters"]),
             domain_validity=str(payload["domain_validity"]),
-            inverse_available=bool(payload["inverse_available"]),
+            inverse_available=inverse_available,
             diagnostics=dict(payload["diagnostics"]),
         )
 

--- a/src/pdelie/invariants/__init__.py
+++ b/src/pdelie/invariants/__init__.py
@@ -1,0 +1,3 @@
+from pdelie.invariants.apply import InvariantApplier
+
+__all__ = ["InvariantApplier"]

--- a/src/pdelie/invariants/apply.py
+++ b/src/pdelie/invariants/apply.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch, InvariantMapSpec
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+def _validate_supported_field(field: FieldBatch) -> None:
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError("InvariantApplier only supports dims ('batch', 'time', 'x', 'var') in V0.3 Milestone 1.")
+    if len(field.var_names) != 1:
+        raise ScopeValidationError("InvariantApplier only supports a single scalar variable in V0.3 Milestone 1.")
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError("InvariantApplier requires periodic boundary conditions in x.")
+
+
+def _shift_field_values(field: FieldBatch, shift: float) -> np.ndarray:
+    x = field.coords["x"]
+    dx = float(x[1] - x[0])
+    x_axis = field.dims.index("x")
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(x.size, d=dx)
+    phase = np.exp(-1j * wavenumbers * shift)
+    reshape = [1] * field.values.ndim
+    reshape[x_axis] = x.size
+    return np.real(
+        np.fft.ifft(np.fft.fft(field.values, axis=x_axis) * phase.reshape(tuple(reshape)), axis=x_axis)
+    )
+
+
+def _copy_mapping(value: dict[str, Any]) -> dict[str, Any]:
+    return {str(key): item for key, item in value.items()}
+
+
+class InvariantApplier:
+    def apply(self, field: FieldBatch, spec: InvariantMapSpec) -> FieldBatch:
+        field.validate()
+        spec.validate()
+        _validate_supported_field(field)
+
+        if spec.generator_metadata["parameterization"] != "polynomial_translation_affine":
+            raise ScopeValidationError(
+                "InvariantApplier only supports polynomial_translation_affine generators in V0.3 Milestone 1."
+            )
+        if spec.construction_method != "uniform_translation":
+            raise ScopeValidationError(
+                "InvariantApplier only supports the 'uniform_translation' construction_method in V0.3 Milestone 1."
+            )
+        if spec.domain_validity != "global":
+            raise ScopeValidationError("InvariantApplier only supports global invariant specs in V0.3 Milestone 1.")
+        if spec.diagnostics.get("approximate", False):
+            raise ScopeValidationError("InvariantApplier does not support approximate invariant specs in V0.3 Milestone 1.")
+
+        axis = spec.parameters.get("axis", "x")
+        if axis != "x":
+            raise ScopeValidationError("InvariantApplier only supports translation along x in V0.3 Milestone 1.")
+
+        if "shift" not in spec.parameters:
+            raise SchemaValidationError("uniform_translation invariant parameters must include 'shift'.")
+        try:
+            shift = float(spec.parameters["shift"])
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError("uniform_translation invariant parameter 'shift' must be numeric.") from exc
+        if not np.isfinite(shift):
+            raise SchemaValidationError("uniform_translation invariant parameter 'shift' must be finite.")
+
+        shifted_values = _shift_field_values(field, shift)
+        preprocess_entry = {
+            "operation": "invariant_apply",
+            "construction_method": spec.construction_method,
+            "generator_metadata": _copy_mapping(spec.generator_metadata),
+            "parameters": _copy_mapping(spec.parameters),
+            "domain_validity": spec.domain_validity,
+            "inverse_available": spec.inverse_available,
+            "diagnostics": _copy_mapping(spec.diagnostics),
+        }
+
+        return FieldBatch(
+            values=shifted_values,
+            dims=field.dims,
+            coords={name: coord.copy() for name, coord in field.coords.items()},
+            var_names=list(field.var_names),
+            metadata=dict(field.metadata),
+            preprocess_log=[*field.preprocess_log, preprocess_entry],
+            mask=None if field.mask is None else field.mask.copy(),
+        )

--- a/src/pdelie/invariants/apply.py
+++ b/src/pdelie/invariants/apply.py
@@ -17,16 +17,30 @@ def _validate_supported_field(field: FieldBatch) -> None:
         raise ScopeValidationError("InvariantApplier requires periodic boundary conditions in x.")
 
 
+def _apply_uniform_translation(
+    values: np.ndarray,
+    axis: int,
+    grid_size: int,
+    dx: float,
+    shift: float,
+) -> np.ndarray:
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(grid_size, d=dx)
+    phase = np.exp(-1j * wavenumbers * shift)
+    reshape = [1] * values.ndim
+    reshape[axis] = grid_size
+    return np.real(np.fft.ifft(np.fft.fft(values, axis=axis) * phase.reshape(tuple(reshape)), axis=axis))
+
+
 def _shift_field_values(field: FieldBatch, shift: float) -> np.ndarray:
     x = field.coords["x"]
     dx = float(x[1] - x[0])
     x_axis = field.dims.index("x")
-    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(x.size, d=dx)
-    phase = np.exp(-1j * wavenumbers * shift)
-    reshape = [1] * field.values.ndim
-    reshape[x_axis] = x.size
-    return np.real(
-        np.fft.ifft(np.fft.fft(field.values, axis=x_axis) * phase.reshape(tuple(reshape)), axis=x_axis)
+    return _apply_uniform_translation(
+        values=field.values,
+        axis=x_axis,
+        grid_size=x.size,
+        dx=dx,
+        shift=shift,
     )
 
 

--- a/src/pdelie/invariants/spec.py
+++ b/src/pdelie/invariants/spec.py
@@ -1,0 +1,3 @@
+from pdelie.contracts import InvariantMapSpec
+
+__all__ = ["InvariantMapSpec"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Enables imports like `tests._helpers.cross_pde_benchmark` under plain `pytest`.

--- a/tests/_helpers/__init__.py
+++ b/tests/_helpers/__init__.py
@@ -1,0 +1,1 @@
+# Test helper package for benchmark fixtures and shared test utilities.

--- a/tests/test_invariant_applier.py
+++ b/tests/test_invariant_applier.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdelie import FieldBatch, GeneratorFamily, InvariantMapSpec, SchemaValidationError, ScopeValidationError
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.invariants import InvariantApplier
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+
+
+def make_translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        normalization="l2_unit",
+        diagnostics={"basis": ["1", "t", "x", "u"]},
+    )
+
+
+def make_invariant_map_spec(
+    *,
+    shift: float = 0.25,
+    domain_validity: str = "global",
+    diagnostics: dict[str, object] | None = None,
+) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": shift},
+        domain_validity=domain_validity,
+        inverse_available=True,
+        diagnostics={} if diagnostics is None else diagnostics,
+    )
+
+
+def test_invariant_applier_returns_valid_field_batch_and_appends_provenance() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=60)
+    spec = make_invariant_map_spec(shift=float(field.coords["x"][1]))
+
+    transformed = InvariantApplier().apply(field, spec)
+
+    transformed.validate()
+    np.testing.assert_allclose(transformed.coords["x"], field.coords["x"])
+    np.testing.assert_allclose(transformed.coords["time"], field.coords["time"])
+    assert transformed.dims == field.dims
+    assert transformed.var_names == field.var_names
+    assert transformed.metadata == field.metadata
+    assert len(transformed.preprocess_log) == len(field.preprocess_log) + 1
+    assert transformed.preprocess_log[-1]["operation"] == "invariant_apply"
+    assert transformed.preprocess_log[-1]["construction_method"] == "uniform_translation"
+    assert transformed.preprocess_log[-1]["domain_validity"] == "global"
+    assert transformed.preprocess_log[-1]["parameters"]["shift"] == pytest.approx(float(field.coords["x"][1]))
+    assert field.preprocess_log == []
+
+    derivatives = compute_spectral_fd_derivatives(transformed)
+    residual = HeatResidualEvaluator().evaluate(transformed, derivatives)
+    assert residual.residual.shape == transformed.values.shape
+
+
+def test_invariant_applier_is_reproducible_and_preserves_diagnostics() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=61)
+    spec = make_invariant_map_spec(diagnostics={"source": "test"})
+    applier = InvariantApplier()
+
+    first = applier.apply(field, spec)
+    second = applier.apply(field, spec)
+
+    np.testing.assert_allclose(first.values, second.values)
+    assert first.preprocess_log[-1] == second.preprocess_log[-1]
+    assert first.preprocess_log[-1]["diagnostics"] == {"source": "test"}
+
+
+def test_invariant_applier_rejects_non_global_specs() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=62)
+    spec = make_invariant_map_spec(
+        domain_validity="local",
+        diagnostics={"validity_note": "Only small shifts are supported in this local chart."},
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports global invariant specs"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_approximate_specs() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=67)
+    spec = make_invariant_map_spec(
+        diagnostics={
+            "approximate": True,
+            "approximation_note": "The invariant is only approximate under this fitted construction.",
+        }
+    )
+
+    with pytest.raises(ScopeValidationError, match="does not support approximate invariant specs"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_unsupported_parameterizations() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=68)
+    spec = InvariantMapSpec(
+        generator_metadata={
+            "schema_version": "0.1",
+            "parameterization": "polynomial_scaling_affine",
+            "coefficients": [1.0],
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        },
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": 0.25},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports polynomial_translation_affine generators"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_unsupported_construction_methods() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=69)
+    spec = InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="pointwise_translation",
+        parameters={"axis": "x", "shift": 0.25},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports the 'uniform_translation' construction_method"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_unsupported_axes() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=70)
+    spec = InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "y", "shift": 0.25},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports translation along x"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_missing_shift_parameter() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=71)
+    spec = InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x"},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(SchemaValidationError, match="must include 'shift'"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_non_numeric_shift_parameter() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=72)
+    spec = InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": "abc"},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(SchemaValidationError, match="must be numeric"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_non_finite_shift_parameter() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=73)
+    spec = InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": np.nan},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+    with pytest.raises(SchemaValidationError, match="must be finite"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_non_periodic_fields() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=74)
+    field.metadata["boundary_conditions"] = {"x": "dirichlet"}
+    spec = make_invariant_map_spec()
+
+    with pytest.raises(ScopeValidationError, match="requires periodic boundary conditions in x"):
+        InvariantApplier().apply(field, spec)
+
+
+def test_invariant_applier_rejects_unsupported_dims() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=75)
+    reduced_field = FieldBatch(
+        values=field.values[:, 0, :, :],
+        dims=("batch", "x", "var"),
+        coords={"x": field.coords["x"].copy()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None if field.mask is None else field.mask[:, 0, :, :].copy(),
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports dims"):
+        InvariantApplier().apply(reduced_field, make_invariant_map_spec())
+
+
+def test_invariant_applier_rejects_multi_variable_fields() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=76)
+    stacked_values = np.concatenate((field.values, field.values), axis=-1)
+    multi_var_field = FieldBatch(
+        values=stacked_values,
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=["u", "v"],
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None if field.mask is None else np.concatenate((field.mask, field.mask), axis=-1),
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports a single scalar variable"):
+        InvariantApplier().apply(multi_var_field, make_invariant_map_spec())
+
+
+def test_heat_and_burgers_stable_symmetry_paths_remain_exact() -> None:
+    heat_training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=63)
+    heat_heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=64)
+    burgers_training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=65)
+    burgers_heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=66)
+
+    heat_generator = fit_translation_generator(heat_training, HeatResidualEvaluator(), epsilon=1e-4)
+    burgers_generator = fit_translation_generator(burgers_training, BurgersResidualEvaluator(), epsilon=1e-4)
+
+    heat_report = verify_translation_generator(heat_heldout, heat_generator, HeatResidualEvaluator())
+    burgers_report = verify_translation_generator(burgers_heldout, burgers_generator, BurgersResidualEvaluator())
+
+    assert heat_report.classification == "exact"
+    assert burgers_report.classification == "exact"

--- a/tests/test_invariant_map_spec.py
+++ b/tests/test_invariant_map_spec.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from pdelie import GeneratorFamily, InvariantMapSpec, SchemaValidationError
+
+
+def make_translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        normalization="l2_unit",
+        diagnostics={"basis": ["1", "t", "x", "u"]},
+    )
+
+
+def make_invariant_map_spec(
+    *,
+    domain_validity: str = "global",
+    diagnostics: dict[str, object] | None = None,
+) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=make_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": 0.25},
+        domain_validity=domain_validity,
+        inverse_available=True,
+        diagnostics={} if diagnostics is None else diagnostics,
+    )
+
+
+def test_invariant_map_spec_round_trip_is_json_safe() -> None:
+    spec = make_invariant_map_spec()
+    payload = spec.to_dict()
+    json.dumps(payload)
+
+    round_trip = InvariantMapSpec.from_dict(payload)
+    assert round_trip.construction_method == spec.construction_method
+    assert round_trip.domain_validity == spec.domain_validity
+    assert round_trip.inverse_available is spec.inverse_available
+    assert round_trip.generator_metadata["parameterization"] == "polynomial_translation_affine"
+    assert round_trip.parameters["shift"] == spec.parameters["shift"]
+
+
+def test_invariant_map_spec_rejects_invalid_domain_validity() -> None:
+    with pytest.raises(SchemaValidationError, match="Unsupported domain_validity"):
+        make_invariant_map_spec(domain_validity="regional")
+
+
+def test_invariant_map_spec_requires_validity_note_for_non_global_specs() -> None:
+    with pytest.raises(SchemaValidationError, match="diagnostics\\['validity_note'\\]"):
+        make_invariant_map_spec(domain_validity="local")
+
+
+def test_invariant_map_spec_allows_non_global_specs_with_explicit_validity_note() -> None:
+    spec = make_invariant_map_spec(
+        domain_validity="local",
+        diagnostics={"validity_note": "Only a local chart is established for this construction."},
+    )
+
+    assert spec.domain_validity == "local"
+    assert spec.diagnostics["validity_note"] == "Only a local chart is established for this construction."
+
+
+def test_invariant_map_spec_requires_approximation_note_for_approximate_specs() -> None:
+    with pytest.raises(SchemaValidationError, match="diagnostics\\['approximation_note'\\]"):
+        make_invariant_map_spec(diagnostics={"approximate": True})
+
+
+def test_invariant_map_spec_allows_approximate_specs_with_explicit_approximation_note() -> None:
+    spec = make_invariant_map_spec(
+        diagnostics={
+            "approximate": True,
+            "approximation_note": "The invariant is only approximate under this fitted construction.",
+        }
+    )
+
+    assert spec.diagnostics["approximate"] is True
+    assert spec.diagnostics["approximation_note"] == "The invariant is only approximate under this fitted construction."
+
+
+def test_invariant_map_spec_is_importable_from_package_root() -> None:
+    assert InvariantMapSpec is not None

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import importlib
+
+import pdelie
 from pdelie import (
     DerivativeBatch,
     FieldBatch,
     GeneratorFamily,
+    InvariantMapSpec,
     ResidualBatch,
     ResidualEvaluator,
     VerificationReport,
 )
+from pdelie.invariants import InvariantApplier
 
 
 def test_stable_public_api_is_importable() -> None:
@@ -16,4 +21,17 @@ def test_stable_public_api_is_importable() -> None:
     assert ResidualBatch is not None
     assert ResidualEvaluator is not None
     assert GeneratorFamily is not None
+    assert InvariantMapSpec is not None
     assert VerificationReport is not None
+    assert InvariantApplier is not None
+
+
+def test_root_package_does_not_export_runtime_invariant_applier() -> None:
+    assert not hasattr(pdelie, "InvariantApplier")
+
+
+def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> None:
+    invariants_module = importlib.import_module("pdelie.invariants")
+
+    assert hasattr(invariants_module, "InvariantApplier")
+    assert not hasattr(invariants_module, "InvariantMapSpec")


### PR DESCRIPTION
# Summary
This PR implements V0.3 Milestone 1 only: the first stable invariant layer in the narrowest frozen form.

It adds the single-generator invariant path:

`FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> InvariantApplier`

without adding downstream bridge work, benchmark expansion, weak-form methods, operator methods, or multi-generator invariant machinery.

## What changed
- Added stable canonical object `InvariantMapSpec`
- Added runtime-only `InvariantApplier`
- Implemented one supported invariant application path only:
single-generator periodic `x` `uniform_translation` for the current stable translation slice
- Ensured transformed outputs remain valid `FieldBatch` objects
- Appended invariant transform provenance to `preprocess_log`
- Tightened scope guards so out-of-scope invariant uses fail with typed `SchemaValidationError` or `ScopeValidationError`
- Clarified stable public API/import paths for the invariant milestone surface

## Contract/API notes
- Stable canonical addition: `pdelie.InvariantMapSpec`
- Runtime public API for this milestone: `pdelie.invariants.InvariantApplier`
- `InvariantMapSpec` is JSON-serializable and supports `.to_dict()` / `.from_dict()`
- Non-global specs require explicit `diagnostics["validity_note"]`
- Approximate specs require explicit `diagnostics["approximation_note"]`