### PR TITLE
Feat/v0 3 downstream bridge

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -21,6 +21,13 @@ Runtime public API for the frozen `v0.3` Milestone 1 slice:
 
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 
+Runtime public API for the frozen `v0.3` Milestone 2 slice:
+
+- `pdelie.discovery.to_pysindy_trajectories` for a backend-specific, narrow, flattened-trajectory PySINDy bridge
+
+Runtime-level APIs are versioned public APIs, but they are not canonical objects.
+They are backend-specific and may change with a version bump.
+
 These must not change without version bump.
 
 ---

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,30 @@
-# PDELie — Execution Plan (V0.3 Milestone 1)
+# PDELie — Execution Plan (V0.3)
 
-## Goal
+## Current Active Milestone
+
+**V0.3 Milestone 2 — Thin downstream bridge**
+
+This file is the active execution plan for the current `v0.3` release series.
+
+It should contain:
+
+- a short record of completed milestones
+- the frozen plan for the current active milestone
+- milestone-specific rules and gates
+
+It should **not** redefine package contracts or roadmap commitments. Those belong in:
+
+- `SPEC.md`
+- `CONTRACTS_AND_DEFAULTS.md`
+- `API_STABILITY.md`
+- `ROADMAP.md`
+- `V0_3_SCOPE.md`
+
+---
+
+## Milestone 1 — Invariant layer
+
+### Goal
 
 Add the first stable invariant layer in the narrowest possible form:
 
@@ -8,127 +32,131 @@ Add the first stable invariant layer in the narrowest possible form:
 
 for the **single-generator case only**, while preserving the current stable Heat and Burgers paths with no regressions.
 
-This milestone does **not** add downstream benchmarking yet.  
-It only adds the minimum invariant representation and runtime application layer required for the later `v0.3` downstream utility release.
+### Status
+
+**COMPLETE**
+
+### Implemented
+
+- `InvariantMapSpec` as a stable canonical object for the single-generator case
+- runtime `InvariantApplier`
+- one frozen invariant application path for the current stable symmetry slice
+- regression protection ensuring Heat and Burgers still pass the current stable symmetry pipeline
+- explicit typed scope-guard failures for unsupported invariant applications
+
+### Milestone 1 Gate
+
+Milestone 1 passed because:
+
+- `InvariantMapSpec` exists as a stable canonical object
+- `InvariantApplier` works end to end on the frozen single-generator path
+- transformed outputs remain valid `FieldBatch` objects
+- transform provenance is recorded
+- Heat and Burgers still pass the current stable symmetry pipeline
+- no downstream bridge was required
+- no deferred or experimental feature was required
 
 ---
 
-## Frozen Decisions
+## Milestone 2 — Thin downstream bridge
 
-- single-generator case only
+### Goal
+
+Add the smallest downstream utility path that proves the new invariant layer can feed one downstream workflow without expanding scope beyond the frozen `v0.3` axis.
+
+This milestone does **not** add the full downstream benchmark layer yet.  
+It adds only the minimum bridge required for the later controlled benchmark/release-gate milestone.
+
+### Frozen Decisions
+
+- one thin downstream bridge only
 - no new numerical backend
 - no weak-form methods
 - no operator methods
 - no broad adapters
-- no new public downstream API
-- `InvariantMapSpec` becomes stable in `v0.3`
-- `InvariantApplier` remains runtime-only
+- no broad benchmark expansion
+- no new stable canonical object unless absolutely required
 - stable PDEs remain:
   - Heat
   - Burgers
 - stable derivative backend remains:
   - `spectral_fd`
-- stable symmetry target remains translation-oriented for the first invariant path unless a minimal extension is explicitly required
+- stable symmetry/invariant path remains the current single-generator translation-oriented path
+- the downstream bridge may be narrow and backend-specific
+- the downstream bridge should remain as thin as possible, likely PySINDy first
 
----
-
-## Milestone 1
+### Milestone 2
 
 Implement:
 
-- `InvariantMapSpec` as a stable canonical object for the single-generator case
-- runtime `InvariantApplier`
-- one simple invariant application path for the current stable symmetry slice
-- regression protection ensuring Heat and Burgers still pass the current stable symmetry pipeline
+- one thin downstream bridge for the current invariant-transformed stable path
+- one minimal end-to-end downstream smoke path using the existing invariant layer
+- regression protection ensuring Heat and Burgers stable symmetry paths remain unchanged
+- explicit documentation of what the bridge does and does not guarantee
 
-This milestone is complete only if the invariant layer is:
+This milestone is complete only if the downstream bridge is:
 
 - contract-compliant
-- provenance-preserving
-- numerically stable enough for the frozen single-generator path
+- minimal in scope
 - non-disruptive to the existing stable core
+- sufficient for one later controlled benchmark path
 
 ---
 
 ## Required Components
 
-### 1. Stable `InvariantMapSpec`
+### 1. Thin downstream bridge
 
-Add a stable canonical object with at least:
+Add one narrow bridge, likely PySINDy-based, that can consume the current transformed data path.
 
-- `schema_version`
-- generator reference / generator metadata
-- construction method
-- parameters
-- domain validity (`local` / `global` / `unknown`)
-- inverse availability flag
-- diagnostics
-- serialization support:
-  - `.to_dict()`
-  - `.from_dict()`
+The bridge must:
 
-This object must remain narrow and must not assume multi-generator charts.
+- work with the current single-generator invariant layer
+- avoid becoming a general discovery framework
+- avoid introducing a new stable canonical result object unless absolutely necessary
+- avoid widening stable scope beyond one backend and one path
 
----
+### 2. One frozen utility path
 
-### 2. Runtime `InvariantApplier`
-
-Add a runtime utility that:
-
-- accepts an `InvariantMapSpec`
-- applies the transform to a `FieldBatch`
-- returns a transformed `FieldBatch`
-- appends the transform to `preprocess_log`
-
-`InvariantApplier` is not a canonical stable artifact; it is a runtime interface.
-
----
-
-### 3. One frozen application path
-
-Implement one minimal supported transform path for the current stable symmetry slice.
+Implement one minimal supported downstream path for the current stable symmetry slice.
 
 That path must:
 
 - work on the existing stable Heat/Burgers setting
-- preserve `FieldBatch` contract compliance
-- preserve provenance
+- preserve current contracts
+- remain provenance-aware where applicable
 - avoid introducing a new numerical regime
-- avoid pretending that global invariant charts are available when they are not
+- avoid implying broad downstream support that does not yet exist
 
-If the transform is only valid locally or approximately, that must be explicit in diagnostics.
-
----
-
-### 4. Regression protection
+### 3. Regression protection
 
 Keep the existing stable core intact:
 
 - Heat path still works
 - Burgers path still works
 - no regression in symmetry verification
-- no new canonical stable objects beyond what `v0.3` froze
+- no regression in invariant application
+- no new canonical stable objects unless absolutely necessary
 
 ---
 
 ## Exact Files To Create Or Modify
 
-Create:
+Likely create:
 
-- `src/pdelie/invariants/__init__.py`
-- `src/pdelie/invariants/spec.py`
-- `src/pdelie/invariants/apply.py`
-- `tests/test_invariant_map_spec.py`
-- `tests/test_invariant_applier.py`
+- one downstream bridge module in `src/pdelie/discovery/` or similarly narrow downstream location
+- one new focused test file for the bridge smoke path
 
-Modify only if required:
+Likely modify only if required:
 
-- `src/pdelie/contracts.py`
+- `src/pdelie/invariants/`
 - `src/pdelie/__init__.py`
+- `README.md`
 - `SPEC.md`
 - `CONTRACTS_AND_DEFAULTS.md`
 - `API_STABILITY.md`
 - `ROADMAP.md`
+- `V0_3_SCOPE.md`
 - `PLAN.md`
 
 Do **not** modify:
@@ -138,8 +166,9 @@ Do **not** modify:
 - residual evaluators
 - translation fitter logic
 - verification core
-- downstream bridge code
-- benchmark harness code
+- broad benchmark harness code
+- operator code
+- weak-form code
 
 unless a minimal contract-consistency fix is required.
 
@@ -147,55 +176,57 @@ unless a minimal contract-consistency fix is required.
 
 ## Minimal Test Plan
 
-### 1. Contract tests
+### 1. Bridge smoke tests
 
-Add tests for `InvariantMapSpec`:
+Add tests showing:
 
-- valid construction
-- required fields enforced
-- invalid domain-validity rejected
-- serialization round-trip
+- the downstream bridge can consume the current invariant-transformed path
+- the bridge behaves reproducibly under fixed inputs
+- invalid or unsupported uses fail with typed errors or explicit scope errors
 
-### 2. Runtime application tests
-
-Add tests for `InvariantApplier`:
-
-- transformed object remains a valid `FieldBatch`
-- `preprocess_log` is appended correctly
-- metadata / dims / coords stay contract-compliant
-- invalid input raises typed validation error
-
-### 3. Stable-path compatibility tests
+### 2. Stable-path compatibility tests
 
 Add tests showing:
 
 - Heat still passes existing stable path unchanged
 - Burgers still passes existing stable path unchanged
-- invariant application does not corrupt the current stable data model
+- invariant application still behaves as before
+- the bridge does not corrupt the current stable data model
 
-### 4. Reproducibility / diagnostics tests
+### 3. Narrow end-to-end utility test
 
-Add tests ensuring:
+Add one narrow test showing:
 
-- invariant application diagnostics are deterministic for fixed input
-- local/global validity is explicitly recorded
-- transform provenance is retained in the output `FieldBatch`
+- stable symmetry path
+- stable invariant path
+- thin downstream bridge path
+
+work together end to end for the frozen single-generator case
+
+### 4. Full regression check
+
+At milestone completion, run:
+
+- the narrow bridge tests
+- invariant tests
+- current Heat/Burgers stable tests
+- full `python -m pytest`
 
 ---
 
-## Milestone 1 Gate
+## Milestone 2 Gate
 
-Milestone 1 is complete only if:
+Milestone 2 is complete only if:
 
-- `InvariantMapSpec` exists as a stable canonical object
-- `InvariantApplier` works end to end on the frozen single-generator path
-- transformed outputs remain valid `FieldBatch` objects
-- transform provenance is recorded
+- one thin downstream bridge exists for the frozen stable path
+- the bridge works end to end on the single-generator invariant workflow
 - Heat and Burgers still pass the current stable symmetry pipeline
-- no downstream bridge is required yet
+- invariant application still passes unchanged
+- no broad benchmark layer is required yet
 - no deferred or experimental feature is required
+- no new stable canonical object was added unless unavoidable and explicitly documented
 
-If these are not satisfied, Milestone 1 is not complete.
+If these are not satisfied, Milestone 2 is not complete.
 
 ---
 
@@ -205,12 +236,14 @@ If these are not satisfied, Milestone 1 is not complete.
 - DO NOT add operator methods
 - DO NOT add broad adapters
 - DO NOT add multi-generator invariant machinery
-- DO NOT add downstream benchmark logic
-- DO NOT add a broad invariant public API
+- DO NOT add the full downstream benchmark layer in this milestone
+- DO NOT add a broad downstream public API
 - DO NOT change the current stable Heat/Burgers symmetry path unless required by a minimal contract-consistency fix
 
 ---
 
 ## Status
 
-Status: COMPLETE
+- Milestone 1: **COMPLETE**
+- Milestone 2: **TODO**
+- Milestone 3: **NOT STARTED**

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,16 +1,16 @@
 # PDELie — Execution Plan (V0.3)
 
-## Current Active Milestone
+## Current Release Phase
 
-**V0.3 Milestone 3 — Controlled downstream benchmark / release-gate layer**
+**Post–Milestone 3 RC hardening / release-surface alignment**
 
 This file is the active execution plan for the current `v0.3` release series.
 
 It should contain:
 
 - a short record of completed milestones
-- the frozen plan for the current active milestone
-- milestone-specific rules and gates
+- the frozen plan for the current release phase
+- release-phase-specific rules and gates
 
 It should **not** redefine package contracts or roadmap commitments. Those belong in:
 
@@ -352,3 +352,4 @@ Milestone 3 passed because:
 - Milestone 1: **COMPLETE**
 - Milestone 2: **COMPLETE**
 - Milestone 3: **COMPLETE**
+- Current phase: **RC hardening / release-surface alignment**

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.3 Milestone 2 — Thin downstream bridge**
+**V0.3 Milestone 3 — Controlled downstream benchmark / release-gate layer**
 
 This file is the active execution plan for the current `v0.3` release series.
 
@@ -249,15 +249,101 @@ Milestone 2 passed because:
 
 ---
 
+## Milestone 3 — Controlled downstream benchmark / release-gate layer
+
+### Goal
+
+Add the smallest controlled downstream benchmark and release-gate layer for the current stable symmetry, invariant, and runtime-only PySINDy bridge path.
+
+This milestone must stay internal to `tests/_helpers` and `tests/`.
+It must not add public API, new canonical objects, or broader downstream machinery.
+
+### Status
+
+**COMPLETE**
+
+### Frozen Decisions
+
+- one internal four-branch benchmark only:
+  - `vanilla`
+  - `known_invariant`
+  - `discovered_invariant`
+  - `nuisance`
+- no new public API
+- no new stable canonical object
+- no weak-form methods
+- no operator methods
+- no broad adapters
+- no benchmark zoo
+- use the current runtime-only `InvariantApplier` unchanged
+- use the current runtime-only PySINDy bridge unchanged
+- known and discovered branches are expected to be numerically equivalent in this milestone
+- the nuisance branch is the actual utility comparison branch
+- PySINDy configuration is frozen explicitly for the release gate
+
+### Implemented
+
+- internal helper `tests/_helpers/downstream_benchmark.py`
+- internal test module `tests/test_downstream_benchmark.py`
+- explicit frozen PySINDy configuration for fit/score
+- benchmark-local per-sample alignment using the frozen `argmax(values[0, 0, :, 0])` rule
+- reproducibility, matched-settings, known/discovered-equivalence, nuisance-distinctness, and release-gate tests
+
+### Exact Files Created Or Modified
+
+Created:
+
+- `tests/_helpers/downstream_benchmark.py`
+- `tests/test_downstream_benchmark.py`
+
+Modified:
+
+- `V0_3_SCOPE.md`
+- `PLAN.md`
+
+Do **not** modify:
+
+- `ROADMAP.md`
+- public API files
+- invariant/runtime bridge code
+
+unless a minimal contract-consistency fix is required.
+
+### Minimal Test Plan
+
+- run `tests/test_downstream_benchmark.py` first
+- then run the full suite with `pytest`
+- benchmark tests must confirm:
+  - reproducibility
+  - matched settings
+  - known/discovered trajectory equivalence
+  - nuisance branch distinctness
+  - release-gate ordering on Burgers against nuisance
+
+### Milestone 3 Completion Gate
+
+Milestone 3 passed because:
+
+- the four-branch internal benchmark runs on Heat and Burgers
+- settings are frozen and matched across branches
+- known and discovered branches are numerically equivalent in the frozen slice
+- the nuisance baseline is included and reproducible
+- the Burgers invariant-aware branches beat the nuisance branch under the frozen release-gate configuration
+- Heat and Burgers stable symmetry paths still pass unchanged
+- no public API and no stable canonical object were added
+
+---
+
 ## Rules
 
 - DO NOT add weak-form methods
 - DO NOT add operator methods
 - DO NOT add broad adapters
 - DO NOT add multi-generator invariant machinery
-- DO NOT add the full downstream benchmark layer in this milestone
 - DO NOT add a broad downstream public API
+- DO NOT add new stable canonical objects
 - DO NOT change the current stable Heat/Burgers symmetry path unless required by a minimal contract-consistency fix
+- DO NOT modify `ROADMAP.md` in this milestone
 
 ---
 
@@ -265,4 +351,4 @@ Milestone 2 passed because:
 
 - Milestone 1: **COMPLETE**
 - Milestone 2: **COMPLETE**
-- Milestone 3: **NOT STARTED**
+- Milestone 3: **COMPLETE**

--- a/PLAN.md
+++ b/PLAN.md
@@ -67,6 +67,10 @@ Add the smallest downstream utility path that proves the new invariant layer can
 This milestone does **not** add the full downstream benchmark layer yet.  
 It adds only the minimum bridge required for the later controlled benchmark/release-gate milestone.
 
+### Status
+
+**COMPLETE**
+
 ### Frozen Decisions
 
 - one thin downstream bridge only
@@ -82,15 +86,16 @@ It adds only the minimum bridge required for the later controlled benchmark/rele
 - stable derivative backend remains:
   - `spectral_fd`
 - stable symmetry/invariant path remains the current single-generator translation-oriented path
-- the downstream bridge may be narrow and backend-specific
-- the downstream bridge should remain as thin as possible, likely PySINDy first
+- the downstream bridge is runtime-only, backend-specific, and exposed only as `pdelie.discovery.to_pysindy_trajectories`
+- the flattened trajectory format is a bridge format only, not a PDELie canonical downstream representation
+- the downstream bridge remains as thin as possible, using PySINDy only for a fit smoke path
 
 ### Milestone 2
 
 Implement:
 
-- one thin downstream bridge for the current invariant-transformed stable path
-- one minimal end-to-end downstream smoke path using the existing invariant layer
+- one thin runtime-only PySINDy bridge for the current invariant-transformed stable path
+- one minimal end-to-end downstream fit smoke path using the existing invariant layer
 - regression protection ensuring Heat and Burgers stable symmetry paths remain unchanged
 - explicit documentation of what the bridge does and does not guarantee
 
@@ -107,7 +112,7 @@ This milestone is complete only if the downstream bridge is:
 
 ### 1. Thin downstream bridge
 
-Add one narrow bridge, likely PySINDy-based, that can consume the current transformed data path.
+Add one narrow bridge that consumes the current transformed data path.
 
 The bridge must:
 
@@ -115,6 +120,9 @@ The bridge must:
 - avoid becoming a general discovery framework
 - avoid introducing a new stable canonical result object unless absolutely necessary
 - avoid widening stable scope beyond one backend and one path
+- remain out of root `pdelie` imports
+- stay runtime-level only
+- use a flattened-trajectory bridge format only for PySINDy
 
 ### 2. One frozen utility path
 
@@ -140,22 +148,19 @@ Keep the existing stable core intact:
 
 ---
 
-## Exact Files To Create Or Modify
+## Exact Files Created Or Modified
 
-Likely create:
+Created:
 
-- one downstream bridge module in `src/pdelie/discovery/` or similarly narrow downstream location
-- one new focused test file for the bridge smoke path
+- `src/pdelie/discovery/__init__.py`
+- `src/pdelie/discovery/pysindy_bridge.py`
+- `tests/test_pysindy_bridge.py`
 
-Likely modify only if required:
+Modified:
 
-- `src/pdelie/invariants/`
-- `src/pdelie/__init__.py`
-- `README.md`
-- `SPEC.md`
-- `CONTRACTS_AND_DEFAULTS.md`
+- `pyproject.toml`
+- `tests/test_public_api.py`
 - `API_STABILITY.md`
-- `ROADMAP.md`
 - `V0_3_SCOPE.md`
 - `PLAN.md`
 
@@ -183,6 +188,7 @@ Add tests showing:
 - the downstream bridge can consume the current invariant-transformed path
 - the bridge behaves reproducibly under fixed inputs
 - invalid or unsupported uses fail with typed errors or explicit scope errors
+- the optional PySINDy dependency fails with a clear install hint when unavailable
 
 ### 2. Stable-path compatibility tests
 
@@ -210,7 +216,7 @@ At milestone completion, run:
 - the narrow bridge tests
 - invariant tests
 - current Heat/Burgers stable tests
-- full `python -m pytest`
+- full `pytest`
 
 ---
 
@@ -227,6 +233,19 @@ Milestone 2 is complete only if:
 - no new stable canonical object was added unless unavoidable and explicitly documented
 
 If these are not satisfied, Milestone 2 is not complete.
+
+### Milestone 2 Completion Gate
+
+Milestone 2 passed because:
+
+- one thin runtime-only downstream bridge exists for the frozen stable path
+- the bridge works end to end on the single-generator invariant workflow
+- the bridge remains out of root `pdelie` imports
+- no new stable canonical object was added
+- Heat and Burgers still pass the current stable symmetry pipeline
+- invariant application still passes unchanged
+- no full benchmark layer was required
+- no deferred or experimental feature was required
 
 ---
 
@@ -245,5 +264,5 @@ If these are not satisfied, Milestone 2 is not complete.
 ## Status
 
 - Milestone 1: **COMPLETE**
-- Milestone 2: **TODO**
+- Milestone 2: **COMPLETE**
 - Milestone 3: **NOT STARTED**

--- a/V0_3_SCOPE.md
+++ b/V0_3_SCOPE.md
@@ -52,6 +52,24 @@ Completed scope:
 
 This milestone added a backend-specific runtime bridge, not a canonical PDE-discovery representation.
 
+### Milestone 3 — Complete
+
+`v0.3` Milestone 3 is complete.
+
+Completed scope:
+
+- one internal four-branch downstream benchmark:
+  - vanilla
+  - known_invariant
+  - discovered_invariant
+  - nuisance
+- one frozen benchmark-local alignment rule for the current single-generator translation slice
+- one explicit frozen PySINDy configuration for the downstream release gate
+- reproducibility, matched-settings, and release-gate tests
+- no new public API and no new stable canonical object
+
+This milestone proves a controlled downstream utility signal for the current invariant/downstream path relative to a nuisance baseline. It does not claim broader discovery-quality superiority.
+
 ---
 
 ## Must Implement
@@ -119,7 +137,7 @@ for Heat and Burgers under the current stable translation-targeted symmetry slic
 
 - the known-invariant and discovered-invariant downstream paths both run end to end under the stable contracts
 - the benchmark is reproducible and matched
-- the discovered-invariant path is at least meaningfully distinguishable from a nuisance baseline under matched controls
+- the invariant-aware downstream path is at least meaningfully distinguishable from a nuisance baseline under matched controls
 - Heat and Burgers remain regression-free under the existing stable symmetry pipeline
 
 `v0.3` is a utility release, not yet a broad superiority-claim release.
@@ -154,7 +172,7 @@ Completed outcome:
 - transformed data from the current single-generator invariant path can feed one downstream workflow cleanly under stable contracts
 
 ### Milestone 3 — Controlled downstream benchmark / release-gate layer
-**Status:** Planned inside `v0.3`
+**Status:** Complete
 
 Frozen scope:
 - one controlled benchmark comparing:
@@ -169,8 +187,10 @@ Frozen scope:
 - no broad benchmark zoo
 - no new public benchmark API unless clearly justified
 
-Expected outcome:
+Completed outcome:
 - `v0.3` release gate can be stated in terms of a reproducible downstream utility benchmark, not just symmetry recovery
+- known_invariant and discovered_invariant are expected to be numerically equivalent in the frozen Milestone 3 slice
+- the nuisance baseline is the actual utility comparison branch for this release gate
 
 ---
 
@@ -238,7 +258,7 @@ Required outputs:
 The benchmark must distinguish:
 - correctness of the invariant/downstream mechanism
 - conditioning effects
-- genuine symmetry-related benefit
+- a controlled downstream utility signal relative to the nuisance baseline
 
 ---
 

--- a/V0_3_SCOPE.md
+++ b/V0_3_SCOPE.md
@@ -39,6 +39,19 @@ Completed scope:
 
 This milestone introduced the first stable invariant-layer contract without broadening the public API beyond the narrow single-generator path.
 
+### Milestone 2 — Complete
+
+`v0.3` Milestone 2 is complete.
+
+Completed scope:
+
+- runtime-only `pdelie.discovery.to_pysindy_trajectories`
+- one narrow flattened-trajectory bridge for PySINDy only
+- one minimal downstream fit smoke path for the current invariant-transformed stable slice
+- no new stable canonical object
+
+This milestone added a backend-specific runtime bridge, not a canonical PDE-discovery representation.
+
 ---
 
 ## Must Implement
@@ -126,7 +139,7 @@ Frozen scope:
 - no benchmark expansion yet
 
 ### Milestone 2 — Thin downstream bridge
-**Status:** Next committed step
+**Status:** Complete
 
 Frozen scope:
 - one thin downstream bridge only
@@ -137,7 +150,7 @@ Frozen scope:
 - no operator methods
 - no broad adapters
 
-Expected outcome:
+Completed outcome:
 - transformed data from the current single-generator invariant path can feed one downstream workflow cleanly under stable contracts
 
 ### Milestone 3 — Controlled downstream benchmark / release-gate layer

--- a/V0_3_SCOPE.md
+++ b/V0_3_SCOPE.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-`v0.3` is the smallest next release that expands PDELie in a disciplined way after the two-PDE stable core established in `v0.2`.
+`v0.3` is the first downstream-utility release for PDELie.
 
 It does **not** introduce a new numerical regime.  
 It does **not** widen the ecosystem surface broadly.  
@@ -10,9 +10,9 @@ It does **not** bring operator methods into the stable library.
 
 Instead, it asks a narrower and more important question:
 
-> Can the current stable symmetry pipeline support one minimal invariant/downstream utility path without widening stable scope beyond what is necessary?
+> Can the current stable symmetry pipeline support one minimal invariant/downstream utility path under controlled benchmark conditions?
 
-`v0.3` is therefore the first **downstream utility** release, not the first **broad ecosystem** release.
+`v0.3` is therefore the first **invariant/downstream utility** release, not the first **broad ecosystem** or **operator** release.
 
 The downstream target for `v0.3` is frozen as:
 
@@ -21,6 +21,23 @@ The downstream target for `v0.3` is frozen as:
 - one **controlled benchmark layer** only
 - Heat and Burgers remain the only stable PDEs
 - the current stable derivative backend remains `spectral_fd`
+
+---
+
+## Current State
+
+### Milestone 1 — Complete
+
+`v0.3` Milestone 1 is complete.
+
+Completed scope:
+
+- stable `InvariantMapSpec`
+- runtime-only `InvariantApplier`
+- one frozen invariant application path for the current stable symmetry slice
+- regression protection showing Heat and Burgers still pass the existing stable pipeline
+
+This milestone introduced the first stable invariant-layer contract without broadening the public API beyond the narrow single-generator path.
 
 ---
 
@@ -33,13 +50,12 @@ The downstream target for `v0.3` is frozen as:
 - polynomial generators only
 - single-generator invariant workflows only
 - one thin downstream bridge only
+- one controlled benchmark layer only
 - verification-first development
 - Heat and Burgers remain supported
 - no new numerical backend is required for the stable path
 
 ### Stable canonical objects for `v0.3`
-
-The stable canonical object set grows only where necessary for the first invariant/downstream utility release.
 
 Stable in `v0.3`:
 
@@ -77,8 +93,8 @@ for Heat and Burgers under the current stable translation-targeted symmetry slic
 ### Required components
 
 - one stable `InvariantMapSpec` for the single-generator case
-- one runtime `InvariantApplier` that applies the frozen single-generator invariant transform to a `FieldBatch`
-- one thin PySINDy bridge or equivalent downstream export path
+- one runtime `InvariantApplier`
+- one thin downstream bridge, likely PySINDy
 - one controlled benchmark comparing:
   - vanilla downstream path
   - known-invariant downstream path
@@ -93,32 +109,66 @@ for Heat and Burgers under the current stable translation-targeted symmetry slic
 - the discovered-invariant path is at least meaningfully distinguishable from a nuisance baseline under matched controls
 - Heat and Burgers remain regression-free under the existing stable symmetry pipeline
 
-`v0.3` is a utility release, not yet a “strong superiority claim” release.
+`v0.3` is a utility release, not yet a broad superiority-claim release.
 
 ---
 
-## Frozen Decisions
+## Frozen Milestones
 
-For the stable `v0.3` path:
+### Milestone 1 — Invariant layer
+**Status:** Complete
 
-- only the **single-generator** case is supported
-- the stable downstream bridge is **thin**, not a new discovery framework
-- benchmark logic may live in an internal helper / test-oriented layer unless and until a public API is justified
-- known-invariant and discovered-invariant paths must be compared under the same feature budget, regularization budget, and split policy
-- one nuisance baseline is mandatory
+Frozen scope:
+- stable `InvariantMapSpec`
+- runtime-only `InvariantApplier`
+- one narrow application path
+- no downstream bridge yet
+- no benchmark expansion yet
 
-If a broader invariant representation or richer downstream result object becomes necessary, that belongs to a later release unless the need is minimal and unavoidable.
+### Milestone 2 — Thin downstream bridge
+**Status:** Next committed step
+
+Frozen scope:
+- one thin downstream bridge only
+- no broad system-identification framework
+- no new canonical stable object unless absolutely required
+- no benchmark expansion yet beyond the minimal bridge smoke path
+- no weak-form methods
+- no operator methods
+- no broad adapters
+
+Expected outcome:
+- transformed data from the current single-generator invariant path can feed one downstream workflow cleanly under stable contracts
+
+### Milestone 3 — Controlled downstream benchmark / release-gate layer
+**Status:** Planned inside `v0.3`
+
+Frozen scope:
+- one controlled benchmark comparing:
+  - vanilla
+  - known-invariant
+  - discovered-invariant
+  - nuisance baseline
+- matched feature budget
+- matched regularization budget
+- matched split policy
+- reproducible benchmark outputs
+- no broad benchmark zoo
+- no new public benchmark API unless clearly justified
+
+Expected outcome:
+- `v0.3` release gate can be stated in terms of a reproducible downstream utility benchmark, not just symmetry recovery
 
 ---
 
 ## Development Order
 
 1. freeze `v0.3` scope
-2. define and implement `InvariantMapSpec` for the single-generator case
-3. add runtime `InvariantApplier`
+2. implement `InvariantMapSpec`
+3. implement `InvariantApplier`
 4. add one thin downstream bridge
 5. add the controlled downstream benchmark layer
-6. add nuisance/conditioning control baseline
+6. add nuisance / conditioning control baseline
 7. add release-gate tests and documentation
 
 ---
@@ -186,7 +236,7 @@ The benchmark must distinguish:
 - the `v0.2` Heat path still passes cleanly
 - the `v0.2` Burgers path still passes cleanly
 - the single-generator `InvariantMapSpec` and `InvariantApplier` work end to end on the frozen stable path
-- the downstream bridge works for the frozen stable task
+- the thin downstream bridge works for the frozen stable task
 - the controlled benchmark runs reproducibly under matched settings
 - the nuisance baseline is included
 - no deferred or experimental feature is required for the stable release path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,12 @@ dependencies = [
 [project.optional-dependencies]
 downstream = [
   "pysindy>=1.7.5,<2",
+  "scikit-learn>=1.2.2,<1.3",
 ]
 test = [
   "build>=1.2",
   "pysindy>=1.7.5,<2",
+  "scikit-learn>=1.2.2,<1.3",
   "pytest>=7.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,18 @@ dependencies = [
   "numpy>=1.24,<2",
 ]
 
+# Optional downstream bridge path is currently validated on the
+# PySINDy 1.x / scikit-learn 1.2.x line only.
+# Broader Python 3.12+ compatibility is intentionally not claimed until validated.
 [project.optional-dependencies]
 downstream = [
-  "pysindy>=1.7.5,<2",
-  "scikit-learn>=1.2.2,<1.3",
+  "pysindy>=1.7.5,<2; python_version < '3.12'",
+  "scikit-learn>=1.2.2,<1.3; python_version < '3.12'",
 ]
 test = [
   "build>=1.2",
-  "pysindy>=1.7.5,<2",
-  "scikit-learn>=1.2.2,<1.3",
+  "pysindy>=1.7.5,<2; python_version < '3.12'",
+  "scikit-learn>=1.2.2,<1.3; python_version < '3.12'",
   "pytest>=7.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,16 @@ version = "0.2.0"
 description = "Stable V0.2 core for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
-  "numpy>=1.24",
+  "numpy>=1.24,<2",
 ]
 
 [project.optional-dependencies]
+downstream = [
+  "pysindy>=1.7.5,<2",
+]
 test = [
   "build>=1.2",
+  "pysindy>=1.7.5,<2",
   "pytest>=7.4",
 ]
 

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,0 +1,3 @@
+from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
+
+__all__ = ["to_pysindy_trajectories"]

--- a/src/pdelie/discovery/pysindy_bridge.py
+++ b/src/pdelie/discovery/pysindy_bridge.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Runtime-only bridge helpers for narrow backend-specific downstream workflows.
+
+This module intentionally does not define PDELie canonical objects.
+The flattened trajectory format exposed here is a PySINDy bridge format only,
+not PDELie's canonical downstream or PDE-discovery representation.
+"""
+
+import importlib
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch
+from pdelie.errors import ScopeValidationError
+
+
+def _validate_supported_field(field: FieldBatch) -> None:
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError(
+            "to_pysindy_trajectories only supports dims ('batch', 'time', 'x', 'var') in V0.3 Milestone 2."
+        )
+    if len(field.var_names) != 1:
+        raise ScopeValidationError(
+            "to_pysindy_trajectories only supports a single scalar variable in V0.3 Milestone 2."
+        )
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError("to_pysindy_trajectories requires periodic boundary conditions in x.")
+
+
+def _require_pysindy():
+    try:
+        return importlib.import_module("pysindy")
+    except (ModuleNotFoundError, ImportError, ValueError) as exc:
+        raise ImportError(
+            "PySINDy is required for the runtime downstream smoke helper. "
+            "Install pdelie[downstream] or pdelie[test]."
+        ) from exc
+
+
+def _fit_pysindy_smoke(
+    trajectory: np.ndarray,
+    time_values: np.ndarray,
+    feature_names: list[str],
+):
+    pysindy = _require_pysindy()
+    model = pysindy.SINDy(feature_names=list(feature_names))
+    model.fit(np.asarray(trajectory, dtype=float), t=np.asarray(time_values, dtype=float))
+    return model, np.asarray(model.coefficients(), dtype=float)
+
+
+def to_pysindy_trajectories(field: FieldBatch) -> tuple[list[np.ndarray], np.ndarray, list[str]]:
+    field.validate()
+    _validate_supported_field(field)
+
+    num_times = field.values.shape[field.dims.index("time")]
+    num_points = field.values.shape[field.dims.index("x")]
+    trajectories = [
+        np.asarray(field.values[batch_index], dtype=float).reshape(num_times, -1).copy()
+        for batch_index in range(field.values.shape[0])
+    ]
+    time_values = np.asarray(field.coords["time"], dtype=float).copy()
+    feature_names = [f"{field.var_names[0]}__x_index_{x_index}" for x_index in range(num_points)]
+    return trajectories, time_values, feature_names

--- a/tests/_helpers/downstream_benchmark.py
+++ b/tests/_helpers/downstream_benchmark.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+
+import numpy as np
+
+from pdelie import FieldBatch, GeneratorFamily, InvariantMapSpec
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.discovery import to_pysindy_trajectories
+from pdelie.invariants import InvariantApplier
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+
+
+BenchmarkBranchResult = dict[str, object]
+BenchmarkResult = dict[str, object]
+
+_HeatFactory = generate_heat_1d_field_batch
+_BurgersFactory = generate_burgers_1d_field_batch
+_BENCHMARK_BRANCHES = (
+    "vanilla",
+    "known_invariant",
+    "discovered_invariant",
+    "nuisance",
+)
+
+DOWNSTREAM_BENCHMARK_CONFIG: dict[str, object] = {
+    "num_points": 64,
+    "num_times": 33,
+    "train_batch_size": 4,
+    "heldout_batch_size": 3,
+    "branch_names": list(_BENCHMARK_BRANCHES),
+    "alignment_rule": "shift = x[argmax(values[0, 0, :, 0])] - x[0]",
+    "heat_train_seed": 210,
+    "heat_heldout_seed": 211,
+    "heat_nuisance_train_shift_seed": 212,
+    "heat_nuisance_heldout_shift_seed": 213,
+    "burgers_train_seed": 310,
+    "burgers_heldout_seed": 311,
+    "burgers_nuisance_train_shift_seed": 312,
+    "burgers_nuisance_heldout_shift_seed": 313,
+    "pysindy_model": {
+        "optimizer": {
+            "threshold": 0.1,
+            "alpha": 0.05,
+            "max_iter": 20,
+            "normalize_columns": False,
+            "fit_intercept": False,
+            "copy_X": True,
+            "verbose": False,
+        },
+        "feature_library": {
+            "degree": 2,
+            "include_interaction": True,
+            "interaction_only": False,
+            "include_bias": True,
+            "order": "C",
+            "library_ensemble": False,
+        },
+        "differentiation_method": {
+            "order": 2,
+            "d": 1,
+            "axis": 0,
+            "is_uniform": False,
+            "drop_endpoints": False,
+            "periodic": False,
+        },
+        "discrete_time": False,
+    },
+    "pysindy_fit": {
+        "multiple_trajectories": True,
+        "unbias": True,
+        "quiet": True,
+        "ensemble": False,
+        "library_ensemble": False,
+        "replace": True,
+        "n_candidates_to_drop": 1,
+        "n_subset": None,
+        "n_models": None,
+        "ensemble_aggregator": None,
+    },
+    "pysindy_score": {
+        "multiple_trajectories": True,
+        "metric": "r2_score",
+    },
+}
+
+
+def _benchmark_settings() -> dict[str, object]:
+    model_config = dict(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_model"])
+    return {
+        "num_points": int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"]),
+        "num_times": int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"]),
+        "train_batch_size": int(DOWNSTREAM_BENCHMARK_CONFIG["train_batch_size"]),
+        "heldout_batch_size": int(DOWNSTREAM_BENCHMARK_CONFIG["heldout_batch_size"]),
+        "branch_names": list(DOWNSTREAM_BENCHMARK_CONFIG["branch_names"]),
+        "alignment_rule": str(DOWNSTREAM_BENCHMARK_CONFIG["alignment_rule"]),
+        "pysindy_model": {
+            "optimizer": dict(model_config["optimizer"]),
+            "feature_library": dict(model_config["feature_library"]),
+            "differentiation_method": dict(model_config["differentiation_method"]),
+            "discrete_time": bool(model_config["discrete_time"]),
+        },
+        "pysindy_fit": dict(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_fit"]),
+        "pysindy_score": dict(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_score"]),
+    }
+
+
+def _require_downstream_dependencies():
+    try:
+        pysindy = importlib.import_module("pysindy")
+        sklearn_metrics = importlib.import_module("sklearn.metrics")
+    except (ModuleNotFoundError, ImportError, ValueError) as exc:
+        raise ImportError(
+            "PySINDy downstream benchmark requires pdelie[test] or pdelie[downstream]."
+        ) from exc
+    return pysindy, sklearn_metrics.r2_score
+
+
+def _known_translation_generator_metadata() -> dict[str, object]:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        normalization="l2_unit",
+        diagnostics={"basis": ["1", "t", "x", "u"]},
+    )
+    return generator.to_dict()
+
+
+def _single_sample_fields(field: FieldBatch) -> list[FieldBatch]:
+    return [
+        FieldBatch(
+            values=field.values[index : index + 1].copy(),
+            dims=field.dims,
+            coords={name: coord.copy() for name, coord in field.coords.items()},
+            var_names=list(field.var_names),
+            metadata=dict(field.metadata),
+            preprocess_log=list(field.preprocess_log),
+            mask=None if field.mask is None else field.mask[index : index + 1].copy(),
+        )
+        for index in range(field.values.shape[field.dims.index("batch")])
+    ]
+
+
+def _make_invariant_spec(generator_metadata: dict[str, object], shift: float) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=generator_metadata,
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": float(shift)},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+
+def _apply_alignment(
+    sample_fields: list[FieldBatch],
+    generator_metadata: dict[str, object],
+) -> tuple[list[FieldBatch], list[float]]:
+    applier = InvariantApplier()
+    transformed_fields: list[FieldBatch] = []
+    shifts: list[float] = []
+    for sample in sample_fields:
+        x = sample.coords["x"]
+        peak_index = int(np.argmax(sample.values[0, 0, :, 0]))
+        shift = float(x[peak_index] - x[0])
+        transformed_fields.append(applier.apply(sample, _make_invariant_spec(generator_metadata, shift)))
+        shifts.append(shift)
+    return transformed_fields, shifts
+
+
+def _apply_nuisance_shifts(
+    sample_fields: list[FieldBatch],
+    generator_metadata: dict[str, object],
+    *,
+    seed: int,
+) -> tuple[list[FieldBatch], list[float]]:
+    applier = InvariantApplier()
+    rng = np.random.default_rng(seed)
+    transformed_fields: list[FieldBatch] = []
+    shifts: list[float] = []
+    for sample in sample_fields:
+        shift = float(rng.choice(sample.coords["x"]))
+        transformed_fields.append(applier.apply(sample, _make_invariant_spec(generator_metadata, shift)))
+        shifts.append(shift)
+    return transformed_fields, shifts
+
+
+def _bridge_sample_fields(
+    sample_fields: list[FieldBatch],
+) -> tuple[list[np.ndarray], np.ndarray, list[str]]:
+    trajectories: list[np.ndarray] = []
+    shared_time_values: np.ndarray | None = None
+    shared_feature_names: list[str] | None = None
+    for sample in sample_fields:
+        sample_trajectories, time_values, feature_names = to_pysindy_trajectories(sample)
+        if len(sample_trajectories) != 1:
+            raise AssertionError("Single-sample bridge must yield exactly one trajectory.")
+        trajectories.append(sample_trajectories[0])
+        if shared_time_values is None:
+            shared_time_values = np.asarray(time_values, dtype=float).copy()
+            shared_feature_names = list(feature_names)
+            continue
+        if not np.allclose(shared_time_values, time_values):
+            raise AssertionError("All benchmark sample fields must share identical time coordinates.")
+        if shared_feature_names != feature_names:
+            raise AssertionError("All benchmark sample fields must share identical feature names.")
+    if shared_time_values is None or shared_feature_names is None:
+        raise AssertionError("Benchmark branches must include at least one sample field.")
+    return trajectories, shared_time_values, shared_feature_names
+
+
+def _build_pysindy_model(feature_names: list[str]):
+    pysindy, _ = _require_downstream_dependencies()
+    model_config = dict(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_model"])
+    return pysindy.SINDy(
+        optimizer=pysindy.STLSQ(**dict(model_config["optimizer"])),
+        feature_library=pysindy.PolynomialLibrary(**dict(model_config["feature_library"])),
+        differentiation_method=pysindy.FiniteDifference(**dict(model_config["differentiation_method"])),
+        feature_names=list(feature_names),
+        discrete_time=bool(model_config["discrete_time"]),
+    )
+
+
+def _fit_and_score_branch(
+    train_fields: list[FieldBatch],
+    heldout_fields: list[FieldBatch],
+) -> tuple[float, list[np.ndarray], list[np.ndarray], np.ndarray, list[str]]:
+    _, r2_score = _require_downstream_dependencies()
+    train_trajectories, train_time_values, train_feature_names = _bridge_sample_fields(train_fields)
+    heldout_trajectories, heldout_time_values, heldout_feature_names = _bridge_sample_fields(heldout_fields)
+    if not np.allclose(train_time_values, heldout_time_values):
+        raise AssertionError("Training and held-out branches must share identical time coordinates.")
+    if train_feature_names != heldout_feature_names:
+        raise AssertionError("Training and held-out branches must share identical feature names.")
+
+    model = _build_pysindy_model(train_feature_names)
+    model.fit(
+        train_trajectories,
+        t=train_time_values,
+        **dict(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_fit"]),
+    )
+    score = float(
+        model.score(
+            heldout_trajectories,
+            t=train_time_values,
+            multiple_trajectories=bool(DOWNSTREAM_BENCHMARK_CONFIG["pysindy_score"]["multiple_trajectories"]),
+            metric=r2_score,
+        )
+    )
+    return (
+        score,
+        train_trajectories,
+        heldout_trajectories,
+        train_time_values,
+        train_feature_names,
+    )
+
+
+def _build_branch_result(
+    *,
+    train_fields: list[FieldBatch],
+    heldout_fields: list[FieldBatch],
+    train_shifts: list[float],
+    heldout_shifts: list[float],
+    train_shift_seed: int | None,
+    heldout_shift_seed: int | None,
+) -> tuple[BenchmarkBranchResult, np.ndarray, list[str]]:
+    score, train_trajectories, heldout_trajectories, time_values, feature_names = _fit_and_score_branch(
+        train_fields,
+        heldout_fields,
+    )
+    return (
+        {
+            "score": score,
+            "train_trajectories": train_trajectories,
+            "heldout_trajectories": heldout_trajectories,
+            "train_shifts": list(train_shifts),
+            "heldout_shifts": list(heldout_shifts),
+            "train_shift_seed": train_shift_seed,
+            "heldout_shift_seed": heldout_shift_seed,
+        },
+        time_values,
+        feature_names,
+    )
+
+
+def _pipeline_for_pde(
+    *,
+    pde_name: str,
+    field_factory: Callable[..., FieldBatch],
+    residual_evaluator: HeatResidualEvaluator | BurgersResidualEvaluator,
+    train_seed: int,
+    heldout_seed: int,
+    nuisance_train_shift_seed: int,
+    nuisance_heldout_shift_seed: int,
+) -> BenchmarkResult:
+    training_field = field_factory(
+        batch_size=int(DOWNSTREAM_BENCHMARK_CONFIG["train_batch_size"]),
+        num_times=int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"]),
+        seed=train_seed,
+    )
+    heldout_field = field_factory(
+        batch_size=int(DOWNSTREAM_BENCHMARK_CONFIG["heldout_batch_size"]),
+        num_times=int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"]),
+        seed=heldout_seed,
+    )
+    training_samples = _single_sample_fields(training_field)
+    heldout_samples = _single_sample_fields(heldout_field)
+
+    known_generator_metadata = _known_translation_generator_metadata()
+    discovered_generator_metadata = fit_translation_generator(
+        training_field,
+        residual_evaluator,
+        epsilon=1e-4,
+    ).to_dict()
+
+    known_training_fields, known_training_shifts = _apply_alignment(training_samples, known_generator_metadata)
+    known_heldout_fields, known_heldout_shifts = _apply_alignment(heldout_samples, known_generator_metadata)
+    discovered_training_fields, discovered_training_shifts = _apply_alignment(
+        training_samples,
+        discovered_generator_metadata,
+    )
+    discovered_heldout_fields, discovered_heldout_shifts = _apply_alignment(
+        heldout_samples,
+        discovered_generator_metadata,
+    )
+    nuisance_training_fields, nuisance_training_shifts = _apply_nuisance_shifts(
+        training_samples,
+        known_generator_metadata,
+        seed=nuisance_train_shift_seed,
+    )
+    nuisance_heldout_fields, nuisance_heldout_shifts = _apply_nuisance_shifts(
+        heldout_samples,
+        known_generator_metadata,
+        seed=nuisance_heldout_shift_seed,
+    )
+
+    branch_inputs = {
+        "vanilla": (
+            training_samples,
+            heldout_samples,
+            [],
+            [],
+            None,
+            None,
+        ),
+        "known_invariant": (
+            known_training_fields,
+            known_heldout_fields,
+            known_training_shifts,
+            known_heldout_shifts,
+            None,
+            None,
+        ),
+        "discovered_invariant": (
+            discovered_training_fields,
+            discovered_heldout_fields,
+            discovered_training_shifts,
+            discovered_heldout_shifts,
+            None,
+            None,
+        ),
+        "nuisance": (
+            nuisance_training_fields,
+            nuisance_heldout_fields,
+            nuisance_training_shifts,
+            nuisance_heldout_shifts,
+            nuisance_train_shift_seed,
+            nuisance_heldout_shift_seed,
+        ),
+    }
+
+    shared_time_values: np.ndarray | None = None
+    shared_feature_names: list[str] | None = None
+    branch_results: dict[str, BenchmarkBranchResult] = {}
+    for branch_name in _BENCHMARK_BRANCHES:
+        branch_result, time_values, feature_names = _build_branch_result(
+            train_fields=branch_inputs[branch_name][0],
+            heldout_fields=branch_inputs[branch_name][1],
+            train_shifts=branch_inputs[branch_name][2],
+            heldout_shifts=branch_inputs[branch_name][3],
+            train_shift_seed=branch_inputs[branch_name][4],
+            heldout_shift_seed=branch_inputs[branch_name][5],
+        )
+        if shared_time_values is None:
+            shared_time_values = time_values.copy()
+            shared_feature_names = list(feature_names)
+        else:
+            if not np.allclose(shared_time_values, time_values):
+                raise AssertionError("All benchmark branches must share identical time coordinates.")
+            if shared_feature_names != feature_names:
+                raise AssertionError("All benchmark branches must share identical feature names.")
+        branch_results[branch_name] = branch_result
+
+    if shared_time_values is None or shared_feature_names is None:
+        raise AssertionError("Benchmark must produce shared time values and feature names.")
+
+    return {
+        "pde_name": pde_name,
+        "settings": _benchmark_settings(),
+        "data_seeds": {
+            "train_seed": train_seed,
+            "heldout_seed": heldout_seed,
+            "nuisance_train_shift_seed": nuisance_train_shift_seed,
+            "nuisance_heldout_shift_seed": nuisance_heldout_shift_seed,
+        },
+        "time_values": shared_time_values,
+        "feature_names": shared_feature_names,
+        "branches": branch_results,
+    }
+
+
+def run_downstream_benchmark() -> dict[str, BenchmarkResult]:
+    _require_downstream_dependencies()
+    return {
+        "heat": _pipeline_for_pde(
+            pde_name="heat",
+            field_factory=_HeatFactory,
+            residual_evaluator=HeatResidualEvaluator(),
+            train_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["heat_train_seed"]),
+            heldout_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["heat_heldout_seed"]),
+            nuisance_train_shift_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["heat_nuisance_train_shift_seed"]),
+            nuisance_heldout_shift_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["heat_nuisance_heldout_shift_seed"]),
+        ),
+        "burgers": _pipeline_for_pde(
+            pde_name="burgers",
+            field_factory=_BurgersFactory,
+            residual_evaluator=BurgersResidualEvaluator(),
+            train_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["burgers_train_seed"]),
+            heldout_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["burgers_heldout_seed"]),
+            nuisance_train_shift_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["burgers_nuisance_train_shift_seed"]),
+            nuisance_heldout_shift_seed=int(DOWNSTREAM_BENCHMARK_CONFIG["burgers_nuisance_heldout_shift_seed"]),
+        ),
+    }

--- a/tests/test_downstream_benchmark.py
+++ b/tests/test_downstream_benchmark.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests._helpers.downstream_benchmark import DOWNSTREAM_BENCHMARK_CONFIG, run_downstream_benchmark
+
+
+def _run_benchmark_or_skip():
+    try:
+        return run_downstream_benchmark()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+
+def _assert_trajectories_allclose(first: list[np.ndarray], second: list[np.ndarray]) -> None:
+    assert len(first) == len(second)
+    for first_trajectory, second_trajectory in zip(first, second):
+        np.testing.assert_allclose(first_trajectory, second_trajectory, rtol=1e-9, atol=1e-12)
+
+
+@pytest.fixture(scope="module")
+def downstream_benchmark():
+    return _run_benchmark_or_skip()
+
+
+def test_downstream_benchmark_is_reproducible() -> None:
+    first = _run_benchmark_or_skip()
+    second = _run_benchmark_or_skip()
+
+    for pde_name in ("heat", "burgers"):
+        first_result = first[pde_name]
+        second_result = second[pde_name]
+        assert first_result["settings"] == second_result["settings"]
+        assert first_result["data_seeds"] == second_result["data_seeds"]
+        np.testing.assert_allclose(first_result["time_values"], second_result["time_values"], rtol=1e-9, atol=1e-12)
+        assert first_result["feature_names"] == second_result["feature_names"]
+
+        for branch_name in DOWNSTREAM_BENCHMARK_CONFIG["branch_names"]:
+            first_branch = first_result["branches"][branch_name]
+            second_branch = second_result["branches"][branch_name]
+            assert first_branch["train_shift_seed"] == second_branch["train_shift_seed"]
+            assert first_branch["heldout_shift_seed"] == second_branch["heldout_shift_seed"]
+            assert first_branch["train_shifts"] == second_branch["train_shifts"]
+            assert first_branch["heldout_shifts"] == second_branch["heldout_shifts"]
+            assert first_branch["score"] == pytest.approx(second_branch["score"])
+            _assert_trajectories_allclose(first_branch["train_trajectories"], second_branch["train_trajectories"])
+            _assert_trajectories_allclose(first_branch["heldout_trajectories"], second_branch["heldout_trajectories"])
+
+
+def test_downstream_benchmark_uses_matched_settings_and_branch_structure(downstream_benchmark) -> None:
+    expected_branches = tuple(DOWNSTREAM_BENCHMARK_CONFIG["branch_names"])
+    assert downstream_benchmark["heat"]["settings"] == downstream_benchmark["burgers"]["settings"]
+
+    for pde_name in ("heat", "burgers"):
+        result = downstream_benchmark[pde_name]
+        assert result["pde_name"] == pde_name
+        assert tuple(result["branches"]) == expected_branches
+        assert len(result["time_values"]) == int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"])
+        assert len(result["feature_names"]) == int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"])
+
+        for branch_name in expected_branches:
+            branch = result["branches"][branch_name]
+            assert len(branch["train_trajectories"]) == int(DOWNSTREAM_BENCHMARK_CONFIG["train_batch_size"])
+            assert len(branch["heldout_trajectories"]) == int(DOWNSTREAM_BENCHMARK_CONFIG["heldout_batch_size"])
+            for trajectory in branch["train_trajectories"]:
+                assert trajectory.shape == (
+                    int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"]),
+                    int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"]),
+                )
+            for trajectory in branch["heldout_trajectories"]:
+                assert trajectory.shape == (
+                    int(DOWNSTREAM_BENCHMARK_CONFIG["num_times"]),
+                    int(DOWNSTREAM_BENCHMARK_CONFIG["num_points"]),
+                )
+
+
+def test_downstream_benchmark_known_and_discovered_branches_are_equivalent(downstream_benchmark) -> None:
+    for pde_name in ("heat", "burgers"):
+        known = downstream_benchmark[pde_name]["branches"]["known_invariant"]
+        discovered = downstream_benchmark[pde_name]["branches"]["discovered_invariant"]
+
+        assert known["train_shifts"] == discovered["train_shifts"]
+        assert known["heldout_shifts"] == discovered["heldout_shifts"]
+        assert known["score"] == pytest.approx(discovered["score"])
+        _assert_trajectories_allclose(known["train_trajectories"], discovered["train_trajectories"])
+        _assert_trajectories_allclose(known["heldout_trajectories"], discovered["heldout_trajectories"])
+
+
+def test_downstream_benchmark_nuisance_branch_is_reproducible_and_distinct(downstream_benchmark) -> None:
+    for pde_name in ("heat", "burgers"):
+        known = downstream_benchmark[pde_name]["branches"]["known_invariant"]
+        nuisance = downstream_benchmark[pde_name]["branches"]["nuisance"]
+
+        assert nuisance["train_shift_seed"] is not None
+        assert nuisance["heldout_shift_seed"] is not None
+        assert nuisance["train_shifts"] != known["train_shifts"]
+        assert nuisance["heldout_shifts"] != known["heldout_shifts"]
+        assert any(
+            not np.allclose(known_trajectory, nuisance_trajectory)
+            for known_trajectory, nuisance_trajectory in zip(
+                known["train_trajectories"],
+                nuisance["train_trajectories"],
+            )
+        )
+        assert any(
+            not np.allclose(known_trajectory, nuisance_trajectory)
+            for known_trajectory, nuisance_trajectory in zip(
+                known["heldout_trajectories"],
+                nuisance["heldout_trajectories"],
+            )
+        )
+
+
+def test_downstream_benchmark_release_gate_is_satisfied(downstream_benchmark) -> None:
+    for pde_name in ("heat", "burgers"):
+        for branch_name in DOWNSTREAM_BENCHMARK_CONFIG["branch_names"]:
+            branch = downstream_benchmark[pde_name]["branches"][branch_name]
+            assert np.isfinite(branch["score"])
+
+    heat_known = downstream_benchmark["heat"]["branches"]["known_invariant"]["score"]
+    heat_discovered = downstream_benchmark["heat"]["branches"]["discovered_invariant"]["score"]
+    assert heat_known == pytest.approx(heat_discovered)
+
+    burgers_known = downstream_benchmark["burgers"]["branches"]["known_invariant"]["score"]
+    burgers_discovered = downstream_benchmark["burgers"]["branches"]["discovered_invariant"]["score"]
+    burgers_nuisance = downstream_benchmark["burgers"]["branches"]["nuisance"]["score"]
+
+    assert burgers_known == pytest.approx(burgers_discovered)
+    assert burgers_known > burgers_nuisance
+    assert burgers_discovered > burgers_nuisance

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,7 @@ from pdelie import (
     ResidualEvaluator,
     VerificationReport,
 )
+from pdelie.discovery import to_pysindy_trajectories
 from pdelie.invariants import InvariantApplier
 
 
@@ -24,10 +25,12 @@ def test_stable_public_api_is_importable() -> None:
     assert InvariantMapSpec is not None
     assert VerificationReport is not None
     assert InvariantApplier is not None
+    assert to_pysindy_trajectories is not None
 
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
+    assert not hasattr(pdelie, "to_pysindy_trajectories")
 
 
 def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> None:
@@ -35,3 +38,10 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
 
     assert hasattr(invariants_module, "InvariantApplier")
     assert not hasattr(invariants_module, "InvariantMapSpec")
+
+
+def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> None:
+    discovery_module = importlib.import_module("pdelie.discovery")
+
+    assert hasattr(discovery_module, "to_pysindy_trajectories")
+    assert not hasattr(discovery_module, "_fit_pysindy_smoke")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,8 +12,6 @@ from pdelie import (
     ResidualEvaluator,
     VerificationReport,
 )
-from pdelie.discovery import to_pysindy_trajectories
-from pdelie.invariants import InvariantApplier
 
 
 def test_stable_public_api_is_importable() -> None:
@@ -24,6 +22,12 @@ def test_stable_public_api_is_importable() -> None:
     assert GeneratorFamily is not None
     assert InvariantMapSpec is not None
     assert VerificationReport is not None
+
+
+def test_runtime_package_api_is_importable() -> None:
+    from pdelie.discovery import to_pysindy_trajectories
+    from pdelie.invariants import InvariantApplier
+
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
 

--- a/tests/test_pysindy_bridge.py
+++ b/tests/test_pysindy_bridge.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pdelie import FieldBatch, InvariantMapSpec, ScopeValidationError
+from pdelie.errors import SchemaValidationError
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.discovery import to_pysindy_trajectories
+from pdelie.invariants import InvariantApplier
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+
+
+def _make_invariant_spec(generator_metadata: dict[str, object], shift: float) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=generator_metadata,
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": shift},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+
+def test_to_pysindy_trajectories_converts_heat_field_deterministically() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=80)
+
+    first_trajectories, first_time_values, first_feature_names = to_pysindy_trajectories(field)
+    second_trajectories, second_time_values, second_feature_names = to_pysindy_trajectories(field)
+
+    assert len(first_trajectories) == 3
+    assert len(second_trajectories) == 3
+    for first, second in zip(first_trajectories, second_trajectories):
+        assert first.shape == (33, 64)
+        np.testing.assert_allclose(first, second)
+    np.testing.assert_allclose(first_time_values, field.coords["time"])
+    np.testing.assert_allclose(first_time_values, second_time_values)
+    assert first_feature_names == second_feature_names
+    assert first_feature_names[0] == "u__x_index_0"
+    assert first_feature_names[-1] == "u__x_index_63"
+
+
+def test_to_pysindy_trajectories_converts_burgers_field_deterministically() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=81)
+
+    trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+
+    assert len(trajectories) == 2
+    for trajectory in trajectories:
+        assert trajectory.shape == (17, 16)
+    np.testing.assert_allclose(time_values, field.coords["time"])
+    assert feature_names == [f"u__x_index_{index}" for index in range(16)]
+
+
+def test_to_pysindy_trajectories_rejects_non_periodic_fields() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=82)
+    field.metadata["boundary_conditions"] = {"x": "dirichlet"}
+
+    with pytest.raises(ScopeValidationError, match="requires periodic boundary conditions in x"):
+        to_pysindy_trajectories(field)
+
+
+def test_to_pysindy_trajectories_rejects_unsupported_dims() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=83)
+    reduced_field = FieldBatch(
+        values=field.values[:, 0, :, :],
+        dims=("batch", "x", "var"),
+        coords={"x": field.coords["x"].copy()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None if field.mask is None else field.mask[:, 0, :, :].copy(),
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports dims"):
+        to_pysindy_trajectories(reduced_field)
+
+
+def test_to_pysindy_trajectories_rejects_multi_variable_fields() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=84)
+    stacked_values = np.concatenate((field.values, field.values), axis=-1)
+    multi_var_field = FieldBatch(
+        values=stacked_values,
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=["u", "v"],
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None if field.mask is None else np.concatenate((field.mask, field.mask), axis=-1),
+    )
+
+    with pytest.raises(ScopeValidationError, match="only supports a single scalar variable"):
+        to_pysindy_trajectories(multi_var_field)
+
+
+def test_to_pysindy_trajectories_requires_time_coordinates() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=87)
+    invalid_field = FieldBatch.from_dict(field.to_dict())
+    del invalid_field.coords["time"]
+
+    with pytest.raises(SchemaValidationError, match=r"Missing coordinate arrays for dims: \['time'\]"):
+        to_pysindy_trajectories(invalid_field)
+
+
+def test_pysindy_smoke_helper_raises_clear_error_when_dependency_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge_module = importlib.import_module("pdelie.discovery.pysindy_bridge")
+    real_import_module = importlib.import_module
+
+    def _fake_import_module(name: str, package: str | None = None):
+        if name == "pysindy":
+            raise ModuleNotFoundError("No module named 'pysindy'")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(bridge_module.importlib, "import_module", _fake_import_module)
+
+    with pytest.raises(ImportError, match=r"Install pdelie\[downstream\] or pdelie\[test\]"):
+        bridge_module._fit_pysindy_smoke(
+            np.zeros((4, 3), dtype=float),
+            np.linspace(0.0, 0.3, 4),
+            ["u__x_index_0", "u__x_index_1", "u__x_index_2"],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_factory", "residual_evaluator", "seed"),
+    (
+        (generate_heat_1d_field_batch, HeatResidualEvaluator(), 85),
+        (generate_burgers_1d_field_batch, BurgersResidualEvaluator(), 86),
+    ),
+)
+def test_invariant_path_feeds_minimal_pysindy_fit_smoke(
+    field_factory,
+    residual_evaluator,
+    seed: int,
+) -> None:
+    bridge_module = importlib.import_module("pdelie.discovery.pysindy_bridge")
+    try:
+        bridge_module._require_pysindy()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+    field = field_factory(batch_size=2, num_times=17, num_points=16, seed=seed)
+    generator = fit_translation_generator(field, residual_evaluator, epsilon=1e-4)
+    spec = _make_invariant_spec(generator.to_dict(), shift=float(field.coords["x"][1]))
+    transformed = InvariantApplier().apply(field, spec)
+    trajectories, time_values, feature_names = to_pysindy_trajectories(transformed)
+
+    first_model, first_coefficients = bridge_module._fit_pysindy_smoke(
+        trajectories[0],
+        time_values,
+        feature_names,
+    )
+    second_model, second_coefficients = bridge_module._fit_pysindy_smoke(
+        trajectories[0],
+        time_values,
+        feature_names,
+    )
+
+    assert first_model is not None
+    assert second_model is not None
+    assert first_coefficients.size > 0
+    assert second_coefficients.size > 0
+    assert np.all(np.isfinite(first_coefficients))
+    assert np.all(np.isfinite(second_coefficients))
+    np.testing.assert_allclose(first_coefficients, second_coefficients)


### PR DESCRIPTION
## Summary

This PR completes the remaining `v0.3` implementation milestones by adding:

- the thin runtime-only downstream bridge (`M2`)
- the controlled downstream benchmark / release-gate layer (`M3`)

The scope stays within the frozen `v0.3` axis:
single-generator invariants → thin downstream utility → controlled internal benchmark. 

## What changed

### V0.3 Milestone 2
- added a runtime-only PySINDy bridge:
  - `pdelie.discovery.to_pysindy_trajectories`
- kept the bridge narrow and backend-specific
- did not add any new stable canonical objects
- kept the bridge out of root `pdelie` imports
- added tests for:
  - deterministic conversion
  - typed scope/schema failures
  - optional dependency behavior
  - invariant-to-bridge fit smoke path

### V0.3 Milestone 3
- added an internal four-branch downstream benchmark layer in `tests/_helpers` and `tests/`
- branches:
  - `vanilla`
  - `known_invariant`
  - `discovered_invariant`
  - `nuisance`
- froze the benchmark-local alignment rule and PySINDy config
- added reproducibility, matched-settings, known/discovered equivalence, nuisance-distinctness, and release-gate tests
- kept all benchmark logic internal and test-only

## Scope discipline

This PR does **not**:

- add weak-form methods
- add operator methods
- add broad adapters
- add new stable canonical objects
- add a public benchmark API
- broaden the stable Heat/Burgers symmetry path

The stable public surface remains disciplined:
- `InvariantMapSpec` is stable
- `InvariantApplier` remains runtime-only
- `to_pysindy_trajectories` is runtime-level, backend-specific, and narrow 

## Benchmark claim

The M3 benchmark proves a **controlled downstream utility signal** for the current frozen slice relative to a nuisance baseline. It does **not** claim broad PDE-discovery superiority.

In the frozen M3 slice:
- `known_invariant` and `discovered_invariant` are expected to be numerically equivalent
- the nuisance branch is the actual comparison branch
- the benchmark remains internal to the test surface only 

## Validation

- full test suite passes locally
- milestone-specific tests pass
- no contract drift or public-API drift introduced
- Heat and Burgers stable paths remain regression-free

## Docs updated

- `API_STABILITY.md`
- `V0_3_SCOPE.md`
- `PLAN.md`

## Result

This PR makes `v0.3` feature-complete from an implementation perspective:
- M1 complete
- M2 complete
- M3 complete

The next step after merge should be **v0.3 release-surface alignment / RC hardening**, not additional feature work. 