### PR TITLE
Updates to 0.3.0rc1 in md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.3.0rc1
+
+First release candidate for the frozen V0.3 invariant/downstream utility core.
+
+- stable canonical pipeline extended with `InvariantMapSpec`
+- runtime-only `pdelie.invariants.InvariantApplier` added for the frozen single-generator periodic `x` uniform-translation path
+- runtime-only `pdelie.discovery.to_pysindy_trajectories` added as the narrow backend-specific PySINDy bridge
+- controlled four-branch downstream benchmark / release-gate layer added internally under frozen settings:
+  `vanilla`, `known_invariant`, `discovered_invariant`, `nuisance`
+- release metadata, package description, README, and release-readiness docs aligned with the implemented V0.3 state
+
+Explicitly deferred for this release candidate:
+
+- weak-form methods
+- operator methods
+- multi-generator invariant machinery
+- broad adapters or interoperability expansion
+- new canonical objects beyond the current V0.3 slice
+
 ## 0.2.0
 
 First final release for the frozen V0.2 stable core.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the stable V0.2 core with two synthetic PDE paths:
+The current repository implements the stable V0.3 core on the frozen synthetic Heat/Burgers slice:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
 - uniform periodic grid
-- `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> VerificationReport`
+- `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
-- one spatial-translation verification path
+- one stable invariant canonical object: `InvariantMapSpec`
+- one runtime-only invariant path: `pdelie.invariants.InvariantApplier`
+- one runtime-only backend-specific downstream bridge: `pdelie.discovery.to_pysindy_trajectories`
 
 ## Setup
 
@@ -50,13 +52,15 @@ python -m pdelie.examples.heat_vertical_slice
 
 That exact command is validated in CI both after editable install and after built-wheel packaging smoke checks.
 
-The packaged example currently demonstrates the Heat path only:
+The packaged example currently demonstrates the stable Heat verification path only:
 
 1. generate synthetic heat-equation data
 2. compute `spectral_fd` derivatives
 3. evaluate the analytic heat residual
 4. fit the polynomial spatial-translation baseline
 5. verify the generator on held-out heat batches
+
+V0.3 adds a stable invariant canonical object and narrow runtime-level invariant/downstream utilities, but it does not yet add a broad public discovery workflow.
 
 You can also call the example programmatically:
 
@@ -71,14 +75,21 @@ print(result["verification_classification"])
 
 Included in the current stable core:
 
-- stable canonical objects and typed validation errors
+- stable canonical objects and typed validation errors, including `InvariantMapSpec`
 - synthetic heat and Burgers data
 - polynomial translation baseline only
 - finite-transform verification only
+- single-generator invariant map support
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
 
+Runtime-level public APIs in the frozen V0.3 slice:
+
+- `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
+- `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
+
 Explicitly deferred:
+- multi-generator invariant machinery
+- broad downstream discovery contracts
 - operator symmetry
 - weak-form features
 - broad adapters and interoperability work
-- invariant/discovery contracts beyond the current slice

--- a/V0_3_RELEASE_READINESS.md
+++ b/V0_3_RELEASE_READINESS.md
@@ -1,0 +1,56 @@
+# V0.3 Release Readiness
+
+## Release Target
+
+- package version: `0.3.0rc1`
+- git tag: `v0.3.0rc1`
+
+## Done
+
+- the stable canonical object set now includes `InvariantMapSpec`
+- Heat remains supported under the existing stable path
+- Burgers remains supported under the existing stable path
+- the stable derivative backend remains `spectral_fd`
+- analytic Heat and Burgers residual evaluators remain in place
+- the polynomial spatial-translation fitting path remains the stable fitting slice
+- the finite-transform verification path remains the stable verification slice
+- runtime-only `InvariantApplier` is implemented for the frozen single-generator periodic `x` uniform-translation path
+- runtime-only `pdelie.discovery.to_pysindy_trajectories` is implemented as the narrow backend-specific PySINDy bridge
+- the internal four-branch downstream benchmark / release-gate layer is implemented under frozen settings
+- the full test suite passes from the repo root
+- packaging metadata, editable install, built-wheel smoke validation, and the packaged example path remain in place
+
+## Explicitly Deferred
+
+- weak-form methods beyond reserved interface surface
+- operator methods
+- multi-generator invariant machinery
+- broad dataset adapters or interoperability work
+- broad downstream discovery contracts beyond the current slice
+- new canonical stable objects beyond the current V0.3 slice
+- paper-specific experiment logic
+
+## RC View
+
+The current repository is ready for the first `0.3.0rc1` release candidate for the frozen V0.3 stable core, subject to the release-path checks passing on the release branch and CI passing on the release PR.
+
+There are no known scientific-scope blockers inside the current V0.3 slice.
+
+## Packaging And Public API Notes
+
+- `InvariantMapSpec` is the only new stable canonical object in `v0.3`.
+- `InvariantApplier` and `to_pysindy_trajectories` are runtime-level public APIs, not canonical objects.
+- the optional PySINDy bridge path is currently validated on the PySINDy 1.x / scikit-learn 1.2.x line under Python `<3.12`
+- the four-branch downstream benchmark / release-gate layer remains internal to the test surface and is not a public API
+
+## RC Tag Checklist
+
+Before tagging `v0.3.0rc1`:
+
+- run `python -m pytest` from the repo root
+- run `python -m build --sdist --wheel`
+- install the built wheel into a clean environment and verify stable imports
+- run `python -m pdelie.examples.heat_vertical_slice`
+- confirm GitHub Actions jobs `editable-tests` and `package-smoke` pass on the release PR commit
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.3.0rc1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.2.0"
-description = "Stable V0.2 core for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
+version = "0.3.0rc1"
+description = "Stable V0.3 invariant/downstream utility core for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",


### PR DESCRIPTION
Updated pyproject.toml (line 5) to 0.3.0rc1 and changed the package description to the V0.3 invariant/downstream-utility wording. Reframed README.md (line 5) from the old V0.2 stable-core description to the frozen V0.3 surface, including InvariantMapSpec as the stable canonical addition and the narrow runtime-level APIs as runtime-only. Added the RC entry to CHANGELOG.md (line 3) and created V0_3_RELEASE_READINESS.md (line 1) for the 0.3.0rc1 target and checklist.

No src/pdelie files changed.

Verification
Ran a narrow smoke test first: python -m pytest tests/test_public_api.py -> 5 passed.

Ran the requested release path:

python -m pytest -> 93 passed
python -m build --sdist --wheel -> built pdelie-0.3.0rc1.tar.gz and pdelie-0.3.0rc1-py3-none-any.whl
python -m pdelie.examples.heat_vertical_slice -> completed successfully with verification_classification: "exact"
One environment note: the build command initially failed only because the sandboxed isolated build env could not fetch setuptools>=68; rerunning the same command with network-enabled build isolation succeeded. That is not a repo/package blocker.

Remaining blockers before tagging v0.3.0rc1
No code, packaging-metadata, or doc blockers showed up in this pass.

Remaining release prerequisites are the normal release checklist items, not repo defects:

wheel install/import smoke in a clean environment
CI confirmation on the release PR commit for editable-tests and package-smoke
The only substantive release constraint still in force is intentional, not a blocker: the optional PySINDy bridge path is validated on the PySINDy 1.x / scikit-learn 1.2.x line under Python <3.12, and the docs/metadata now say that explicitly.