### PR TITLE
Feat/v0 4 generatorfamily basis spec

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -7,11 +7,17 @@
 - `DerivativeBatch.backend="spectral_fd"`
 - ResidualBatch
 - ResidualEvaluator
-- GeneratorFamily (polynomial only)
+- GeneratorFamily (polynomial only; canonical `v0.4` family semantics with explicit `basis_spec`)
 - InvariantMapSpec (single-generator only)
 - VerificationReport
 - basic verification tools
 - typed validation errors (`PDELieValidationError`, `SchemaValidationError`, `ShapeValidationError`, `ScopeValidationError`)
+
+Stable `GeneratorFamily` note:
+
+- canonical `v0.4` output uses `schema_version = "0.2"` and family-shaped 2D coefficients
+- direct construction is canonical-only and requires explicit `basis_spec`
+- legacy `0.1` single-generator translation payloads are a narrow `from_dict()` compatibility path only
 
 Stable public import path for the invariant canonical object:
 

--- a/CONTRACTS_AND_DEFAULTS.md
+++ b/CONTRACTS_AND_DEFAULTS.md
@@ -156,8 +156,33 @@ GeneratorFamily(
   - `normalization`
   - optional `generator_names`
 - `diagnostics` is optional and non-authoritative
-- legacy `0.1` single-generator translation payloads may be accepted as compatibility input only
+- direct construction without `basis_spec` is invalid in `v0.4`
+- legacy `0.1` single-generator translation payloads may be accepted via `GeneratorFamily.from_dict()` only
 - compatibility input MUST upgrade to canonical `0.2` output on serialization
+
+### Canonical translation compatibility target
+
+~~~json
+{
+  "schema_version": "0.2",
+  "parameterization": "polynomial_translation_affine",
+  "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+  "basis_spec": {
+    "variables": ["t", "x", "u"],
+    "component_names": ["xi"],
+    "basis_terms": [
+      {"label": "1", "powers": [0, 0, 0]},
+      {"label": "t", "powers": [1, 0, 0]},
+      {"label": "x", "powers": [0, 1, 0]},
+      {"label": "u", "powers": [0, 0, 1]}
+    ],
+    "component_ordering": ["xi"],
+    "term_ordering": ["1", "t", "x", "u"],
+    "layout": "component_major"
+  },
+  "normalization": "l2_unit"
+}
+~~~
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -52,10 +52,10 @@ This milestone is representation-only.
 - canonical `schema_version` for family output is `"0.2"`
 - canonical `coefficients` shape is 2D
 - canonical `basis_spec` is required in `v0.4` output
-- legacy 1D translation payloads remain accepted as backward-compatible input
+- direct construction without `basis_spec` is invalid
 - canonical core is `parameterization + coefficients + basis_spec + normalization + optional generator_names`
 - `to_dict()` always emits canonical `"0.2"` output
-- `from_dict()` performs legacy translation upgrade only in the explicit supported case
+- `from_dict()` performs legacy translation upgrade only for the explicit `0.1` single-generator translation payload
 - diagnostics are non-authoritative
 - no fitting in M1
 - no symbolic display in M1
@@ -68,7 +68,7 @@ This milestone is representation-only.
 - `GeneratorFamily` contract update with `basis_spec`
 - explicit schema-version policy note prepared for `CONTRACTS_AND_DEFAULTS.md`
 - validation rules for canonical family-shaped coefficients
-- explicit legacy translation upgrade path
+- explicit `from_dict()`-only legacy translation upgrade path
 - deterministic basis ordering rules
 - explicit component/term interpretation rules
 - regression protection for current translation-based uses
@@ -81,7 +81,8 @@ Milestone 1 is complete only if:
 - existing single-generator translation workflows still validate
 - canonical family serialization is defined and tested
 - legacy input upgrades cleanly to canonical family output
-- missing or invalid `basis_spec` fails with typed validation errors
+- direct construction missing `basis_spec` fails with typed validation errors
+- non-legacy payloads missing `basis_spec` fail with typed validation errors
 - diagnostics remain non-authoritative
 - no new canonical object is introduced
 - no public downstream or invariant semantics are broadened

--- a/SPEC.md
+++ b/SPEC.md
@@ -90,11 +90,24 @@ Defines symmetry target.
 ## GeneratorFamily
 
 - parameterization type
+- schema_version (`"0.2"` for canonical `v0.4` family output)
 - family-shaped coefficients
-- basis_spec
+- explicit basis_spec
 - normalization
 - optional generator names
 - diagnostics are non-authoritative summaries/provenance
+
+Canonical meaning depends only on:
+
+- schema_version
+- parameterization
+- coefficients
+- basis_spec
+- normalization
+- optional generator names
+
+`v0.4` direct construction is canonical-only.
+Legacy single-generator translation payloads are a narrow `from_dict()` compatibility path only.
 
 ---
 

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -135,7 +135,8 @@ Coefficient interpretation rule:
 
 ### Legacy compatibility and canonical serialization
 
-- legacy `0.1` single-generator translation payloads remain accepted as backward-compatible input
+- direct construction without `basis_spec` is invalid in `v0.4`
+- legacy `0.1` single-generator translation payloads remain accepted only via `GeneratorFamily.from_dict()`
 - legacy payloads without `basis_spec` are accepted only when they match the frozen translation parameterization
 - those payloads are upgraded in memory to canonical `0.2` family form
 - `to_dict()` always emits canonical `0.2` output
@@ -144,6 +145,30 @@ Coefficient interpretation rule:
 - round-trip tests must cover:
   - legacy input -> canonical in-memory form -> canonical output
   - canonical input -> canonical output
+
+Frozen canonical translation compatibility target:
+
+```json
+{
+  "schema_version": "0.2",
+  "parameterization": "polynomial_translation_affine",
+  "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+  "basis_spec": {
+    "variables": ["t", "x", "u"],
+    "component_names": ["xi"],
+    "basis_terms": [
+      {"label": "1", "powers": [0, 0, 0]},
+      {"label": "t", "powers": [1, 0, 0]},
+      {"label": "x", "powers": [0, 1, 0]},
+      {"label": "u", "powers": [0, 0, 1]}
+    ],
+    "component_ordering": ["xi"],
+    "term_ordering": ["1", "t", "x", "u"],
+    "layout": "component_major"
+  },
+  "normalization": "l2_unit"
+}
+```
 
 ---
 

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -483,8 +483,19 @@ class GeneratorFamily:
         parameterization = str(payload["parameterization"])
         coefficients = np.asarray(payload["coefficients"], dtype=float)
         normalization = str(payload["normalization"])
-        diagnostics = dict(payload.get("diagnostics", {}))
-        generator_names = None if payload.get("generator_names") is None else list(payload["generator_names"])
+        raw_diagnostics = payload.get("diagnostics")
+        if raw_diagnostics is None:
+            diagnostics = {}
+        else:
+            diagnostics = dict(_validate_mapping(raw_diagnostics, "diagnostics"))
+
+        raw_generator_names = payload.get("generator_names")
+        if raw_generator_names is None:
+            generator_names = None
+        elif isinstance(raw_generator_names, (list, tuple)):
+            generator_names = list(raw_generator_names)
+        else:
+            raise SchemaValidationError("generator_names must be a list or tuple when provided.")
 
         if schema_version == "0.1":
             if (

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -25,6 +25,15 @@ ALLOWED_RESIDUAL_TYPES = frozenset({"analytic", "weak", "surrogate", "operator"}
 ALLOWED_CLASSIFICATIONS = frozenset({"exact", "approximate", "failed"})
 ALLOWED_DOMAIN_VALIDITIES = frozenset({"local", "global", "unknown"})
 SPATIAL_DIMS = ("x", "y", "z")
+GENERATOR_FAMILY_LAYOUT = "component_major"
+GENERATOR_FAMILY_REQUIRED_BASIS_SPEC_FIELDS = (
+    "variables",
+    "component_names",
+    "basis_terms",
+    "component_ordering",
+    "term_ordering",
+    "layout",
+)
 
 
 def _to_numpy(value: Any) -> np.ndarray:
@@ -84,6 +93,92 @@ def _validate_dims_order(dims: tuple[str, ...]) -> None:
     expected_prefix = [dim for dim in SPATIAL_DIMS if dim in spatial]
     if spatial != expected_prefix:
         raise SchemaValidationError("Spatial dims must be ordered as x, y, z.")
+
+
+def _validate_string_list(value: Any, name: str) -> list[str]:
+    if not isinstance(value, (list, tuple)) or len(value) == 0:
+        raise SchemaValidationError(f"{name} must be a non-empty list of strings.")
+    normalized = [str(item) for item in value]
+    if any(not item for item in normalized):
+        raise SchemaValidationError(f"{name} entries must be non-empty strings.")
+    if len(set(normalized)) != len(normalized):
+        raise SchemaValidationError(f"{name} entries must be unique.")
+    return normalized
+
+
+def _normalize_basis_spec(value: Any) -> dict[str, Any]:
+    if value is None:
+        raise SchemaValidationError("basis_spec must be provided for canonical GeneratorFamily payloads.")
+    basis_spec = dict(_validate_mapping(value, "basis_spec"))
+    missing_fields = [field for field in GENERATOR_FAMILY_REQUIRED_BASIS_SPEC_FIELDS if field not in basis_spec]
+    if missing_fields:
+        raise SchemaValidationError(f"basis_spec is missing required fields: {missing_fields}.")
+
+    variables = _validate_string_list(basis_spec["variables"], "basis_spec['variables']")
+    component_names = _validate_string_list(basis_spec["component_names"], "basis_spec['component_names']")
+
+    raw_basis_terms = basis_spec["basis_terms"]
+    if not isinstance(raw_basis_terms, (list, tuple)) or len(raw_basis_terms) == 0:
+        raise SchemaValidationError("basis_spec['basis_terms'] must be a non-empty list.")
+
+    basis_terms: list[dict[str, Any]] = []
+    term_labels: list[str] = []
+    for index, raw_term in enumerate(raw_basis_terms):
+        term = dict(_validate_mapping(raw_term, f"basis_spec['basis_terms'][{index}]"))
+        if "label" not in term or "powers" not in term:
+            raise SchemaValidationError("Each basis_spec['basis_terms'] entry must include 'label' and 'powers'.")
+        label = str(term["label"])
+        if not label:
+            raise SchemaValidationError("basis_spec['basis_terms'] labels must be non-empty strings.")
+        powers = term["powers"]
+        if not isinstance(powers, (list, tuple)) or len(powers) != len(variables):
+            raise SchemaValidationError("basis_spec['basis_terms'] powers must match the variables length.")
+        normalized_powers: list[int] = []
+        for power in powers:
+            if isinstance(power, bool) or not isinstance(power, (int, np.integer)):
+                raise SchemaValidationError("basis_spec['basis_terms'] powers must be integers.")
+            normalized_powers.append(int(power))
+        basis_terms.append({"label": label, "powers": normalized_powers})
+        term_labels.append(label)
+
+    if len(set(term_labels)) != len(term_labels):
+        raise SchemaValidationError("basis_spec['basis_terms'] labels must be unique.")
+
+    component_ordering = _validate_string_list(basis_spec["component_ordering"], "basis_spec['component_ordering']")
+    term_ordering = _validate_string_list(basis_spec["term_ordering"], "basis_spec['term_ordering']")
+    layout = str(basis_spec["layout"])
+
+    if component_ordering != component_names:
+        raise SchemaValidationError("basis_spec['component_ordering'] must exactly match component_names.")
+    if term_ordering != term_labels:
+        raise SchemaValidationError("basis_spec['term_ordering'] must exactly match basis_terms labels in order.")
+    if layout != GENERATOR_FAMILY_LAYOUT:
+        raise SchemaValidationError(f"basis_spec['layout'] must be '{GENERATOR_FAMILY_LAYOUT}'.")
+
+    return {
+        "variables": variables,
+        "component_names": component_names,
+        "basis_terms": basis_terms,
+        "component_ordering": component_ordering,
+        "term_ordering": term_ordering,
+        "layout": layout,
+    }
+
+
+def _translation_generator_basis_spec() -> dict[str, Any]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": GENERATOR_FAMILY_LAYOUT,
+    }
 
 
 @dataclass(slots=True)
@@ -320,51 +415,109 @@ class ResidualBatch:
 
 @dataclass(slots=True)
 class GeneratorFamily:
-    schema_version: str = "0.1"
+    schema_version: str = "0.2"
     parameterization: str = ""
     coefficients: np.ndarray = None  # type: ignore[assignment]
+    basis_spec: dict[str, Any] = None  # type: ignore[assignment]
     normalization: str = ""
+    generator_names: list[str] | None = None
     diagnostics: dict[str, Any] = None  # type: ignore[assignment]
 
-    SCHEMA_VERSION: ClassVar[str] = "0.1"
+    SCHEMA_VERSION: ClassVar[str] = "0.2"
 
     def __post_init__(self) -> None:
         self.coefficients = _to_numpy(self.coefficients)
-        self.diagnostics = dict(_validate_mapping(self.diagnostics, "diagnostics"))
+        self.basis_spec = _normalize_basis_spec(self.basis_spec)
+        if self.generator_names is not None:
+            if not isinstance(self.generator_names, (list, tuple)):
+                raise SchemaValidationError("generator_names must be a list of strings when provided.")
+            self.generator_names = [str(name) for name in self.generator_names]
+        if self.diagnostics is None:
+            self.diagnostics = {}
+        else:
+            self.diagnostics = dict(_validate_mapping(self.diagnostics, "diagnostics"))
         self.validate()
 
     def validate(self) -> None:
         if self.schema_version != self.SCHEMA_VERSION:
             raise SchemaValidationError("Unsupported GeneratorFamily schema_version.")
-        if self.coefficients.ndim != 1 or self.coefficients.size == 0:
-            raise ShapeValidationError("coefficients must be a non-empty one-dimensional array.")
+        if self.coefficients.ndim != 2 or 0 in self.coefficients.shape:
+            raise ShapeValidationError("coefficients must be a non-empty two-dimensional array.")
         if not isinstance(self.parameterization, str) or not self.parameterization:
             raise SchemaValidationError("parameterization must be a non-empty string.")
         if not isinstance(self.normalization, str) or not self.normalization:
             raise SchemaValidationError("normalization must be a non-empty string.")
+        expected_width = len(self.basis_spec["component_names"]) * len(self.basis_spec["basis_terms"])
+        if self.coefficients.shape[1] != expected_width:
+            raise ShapeValidationError("coefficients width must match component_names x basis_terms.")
+        if self.generator_names is not None:
+            if len(self.generator_names) != self.coefficients.shape[0]:
+                raise ShapeValidationError("generator_names length must match the number of generators.")
+            if any(not name for name in self.generator_names):
+                raise SchemaValidationError("generator_names entries must be non-empty strings.")
         if self.normalization == "l2_unit":
-            norm = np.linalg.norm(self.coefficients)
-            if not np.isclose(norm, 1.0, atol=1e-8):
-                raise ShapeValidationError("l2_unit generators must have unit L2 norm.")
+            row_norms = np.linalg.norm(self.coefficients, axis=1)
+            if not np.allclose(row_norms, 1.0, atol=1e-8):
+                raise ShapeValidationError("l2_unit generators must have unit L2 norm row-wise.")
         _validate_json_round_trip(self.to_dict())
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "schema_version": self.schema_version,
             "parameterization": self.parameterization,
             "coefficients": _json_safe(self.coefficients),
+            "basis_spec": _json_safe(self.basis_spec),
             "normalization": self.normalization,
             "diagnostics": _json_safe(self.diagnostics),
         }
+        if self.generator_names is not None:
+            payload["generator_names"] = list(self.generator_names)
+        return payload
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "GeneratorFamily":
+        schema_version = str(payload["schema_version"])
+        parameterization = str(payload["parameterization"])
+        coefficients = np.asarray(payload["coefficients"], dtype=float)
+        normalization = str(payload["normalization"])
+        diagnostics = dict(payload.get("diagnostics", {}))
+        generator_names = None if payload.get("generator_names") is None else list(payload["generator_names"])
+
+        if schema_version == "0.1":
+            if (
+                parameterization != "polynomial_translation_affine"
+                or "basis_spec" in payload
+                or payload.get("generator_names") is not None
+                or coefficients.ndim != 1
+                or coefficients.size != 4
+            ):
+                raise SchemaValidationError(
+                    "Legacy GeneratorFamily compatibility is only supported for single-generator "
+                    "polynomial_translation_affine payloads without basis_spec."
+                )
+            return cls(
+                schema_version=cls.SCHEMA_VERSION,
+                parameterization=parameterization,
+                coefficients=coefficients.reshape(1, -1),
+                basis_spec=_translation_generator_basis_spec(),
+                normalization=normalization,
+                generator_names=generator_names,
+                diagnostics=diagnostics,
+            )
+
+        if schema_version != cls.SCHEMA_VERSION:
+            raise SchemaValidationError("Unsupported GeneratorFamily schema_version.")
+        if "basis_spec" not in payload:
+            raise SchemaValidationError("basis_spec is required for canonical GeneratorFamily payloads.")
+
         return cls(
-            schema_version=str(payload["schema_version"]),
-            parameterization=str(payload["parameterization"]),
-            coefficients=np.asarray(payload["coefficients"], dtype=float),
-            normalization=str(payload["normalization"]),
-            diagnostics=dict(payload["diagnostics"]),
+            schema_version=schema_version,
+            parameterization=parameterization,
+            coefficients=coefficients,
+            basis_spec=dict(_validate_mapping(payload["basis_spec"], "basis_spec")),
+            normalization=normalization,
+            generator_names=generator_names,
+            diagnostics=diagnostics,
         )
 
 

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -137,7 +137,10 @@ def _normalize_basis_spec(value: Any) -> dict[str, Any]:
         for power in powers:
             if isinstance(power, bool) or not isinstance(power, (int, np.integer)):
                 raise SchemaValidationError("basis_spec['basis_terms'] powers must be integers.")
-            normalized_powers.append(int(power))
+            normalized_power = int(power)
+            if normalized_power < 0:
+                raise SchemaValidationError("basis_spec['basis_terms'] powers must be nonnegative integers.")
+            normalized_powers.append(normalized_power)
         basis_terms.append({"label": label, "powers": normalized_powers})
         term_labels.append(label)
 

--- a/src/pdelie/symmetry/fitting/translation_baseline.py
+++ b/src/pdelie/symmetry/fitting/translation_baseline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pdelie.contracts import FieldBatch, GeneratorFamily
+from pdelie.contracts import FieldBatch, GeneratorFamily, _translation_generator_basis_spec
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.parameterization.polynomial_translation import (
     DEFAULT_TRANSLATION_SPAN_TOLERANCE,
@@ -67,7 +67,8 @@ def fit_translation_generator(
 
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=coefficients,
+        coefficients=coefficients.reshape(1, -1),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={
             "basis": list(POLYNOMIAL_TRANSLATION_BASIS),

--- a/src/pdelie/symmetry/parameterization/polynomial_translation.py
+++ b/src/pdelie/symmetry/parameterization/polynomial_translation.py
@@ -10,6 +10,21 @@ POLYNOMIAL_TRANSLATION_BASIS = ("1", "t", "x", "u")
 DEFAULT_TRANSLATION_SPAN_TOLERANCE = 5e-2
 
 
+def _coerce_translation_coefficients(coefficients: np.ndarray) -> np.ndarray:
+    coefficients = np.asarray(coefficients, dtype=float)
+    if coefficients.ndim == 1 and coefficients.size == len(POLYNOMIAL_TRANSLATION_BASIS):
+        return coefficients
+    if coefficients.ndim == 2 and coefficients.shape == (1, len(POLYNOMIAL_TRANSLATION_BASIS)):
+        return coefficients[0]
+    if coefficients.ndim == 2 and coefficients.shape[0] != 1:
+        raise ShapeValidationError("Stable translation helpers only support a single translation generator row.")
+    raise ShapeValidationError(
+        "Translation coefficients must be a one-dimensional array of length "
+        f"{len(POLYNOMIAL_TRANSLATION_BASIS)} or a two-dimensional single-row array "
+        f"of shape (1, {len(POLYNOMIAL_TRANSLATION_BASIS)})."
+    )
+
+
 def build_translation_basis(field: FieldBatch) -> dict[str, np.ndarray]:
     field.validate()
     if field.dims != ("batch", "time", "x", "var"):
@@ -31,11 +46,7 @@ def build_translation_basis(field: FieldBatch) -> dict[str, np.ndarray]:
 
 
 def normalize_translation_coefficients(coefficients: np.ndarray) -> np.ndarray:
-    coefficients = np.asarray(coefficients, dtype=float)
-    if coefficients.ndim != 1 or coefficients.size != len(POLYNOMIAL_TRANSLATION_BASIS):
-        raise ShapeValidationError(
-            f"Translation coefficients must be a one-dimensional array of length {len(POLYNOMIAL_TRANSLATION_BASIS)}."
-        )
+    coefficients = _coerce_translation_coefficients(coefficients)
     norm = np.linalg.norm(coefficients)
     if norm == 0.0:
         raise ShapeValidationError("Translation coefficients must not be the zero vector.")

--- a/src/pdelie/verification/finite_transform.py
+++ b/src/pdelie/verification/finite_transform.py
@@ -7,6 +7,7 @@ from pdelie.errors import ScopeValidationError
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.parameterization.polynomial_translation import (
     DEFAULT_TRANSLATION_SPAN_TOLERANCE,
+    _coerce_translation_coefficients,
     apply_pointwise_translation,
     evaluate_translation_xi,
     translation_span_distance,
@@ -75,17 +76,18 @@ def verify_translation_generator(
     if field.values.shape[0] < min_heldout_initial_conditions:
         raise ScopeValidationError(f"Held-out verification requires at least {min_heldout_initial_conditions} unseen initial conditions.")
 
+    translation_coefficients = _coerce_translation_coefficients(generator.coefficients)
     epsilon_values = DEFAULT_EPSILON_VALUES if epsilon_values is None else np.asarray(epsilon_values, dtype=float)
-    span_distance = translation_span_distance(generator.coefficients)
+    span_distance = translation_span_distance(translation_coefficients)
     baseline_residual = residual_evaluator.evaluate(field).residual
 
-    xi = evaluate_translation_xi(field, generator.coefficients)
+    xi = evaluate_translation_xi(field, translation_coefficients)
     use_uniform_translation = span_distance <= span_tolerance
     batch_errors: list[list[float]] = []
 
     for epsilon in epsilon_values:
         if use_uniform_translation:
-            transformed = _apply_uniform_translation(field, float(epsilon * generator.coefficients[0]))
+            transformed = _apply_uniform_translation(field, float(epsilon * translation_coefficients[0]))
         else:
             transformed = apply_pointwise_translation(field, xi, float(epsilon))
 

--- a/tests/_helpers/downstream_benchmark.py
+++ b/tests/_helpers/downstream_benchmark.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import numpy as np
 
 from pdelie import FieldBatch, GeneratorFamily, InvariantMapSpec
+from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.discovery import to_pysindy_trajectories
 from pdelie.invariants import InvariantApplier
@@ -122,19 +123,7 @@ def _known_translation_generator_metadata() -> dict[str, object]:
     generator = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
-        basis_spec={
-            "variables": ["t", "x", "u"],
-            "component_names": ["xi"],
-            "basis_terms": [
-                {"label": "1", "powers": [0, 0, 0]},
-                {"label": "t", "powers": [1, 0, 0]},
-                {"label": "x", "powers": [0, 1, 0]},
-                {"label": "u", "powers": [0, 0, 1]},
-            ],
-            "component_ordering": ["xi"],
-            "term_ordering": ["1", "t", "x", "u"],
-            "layout": "component_major",
-        },
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )

--- a/tests/_helpers/downstream_benchmark.py
+++ b/tests/_helpers/downstream_benchmark.py
@@ -121,9 +121,22 @@ def _require_downstream_dependencies():
 def _known_translation_generator_metadata() -> dict[str, object]:
     generator = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+        basis_spec={
+            "variables": ["t", "x", "u"],
+            "component_names": ["xi"],
+            "basis_terms": [
+                {"label": "1", "powers": [0, 0, 0]},
+                {"label": "t", "powers": [1, 0, 0]},
+                {"label": "x", "powers": [0, 1, 0]},
+                {"label": "u", "powers": [0, 0, 1]},
+            ],
+            "component_ordering": ["xi"],
+            "term_ordering": ["1", "t", "x", "u"],
+            "layout": "component_major",
+        },
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     return generator.to_dict()
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -15,6 +15,7 @@ from pdelie import (
     ShapeValidationError,
     VerificationReport,
 )
+from pdelie.contracts import _translation_generator_basis_spec
 
 
 def make_field_batch(*, x_coords: np.ndarray | None = None) -> FieldBatch:
@@ -35,24 +36,6 @@ def make_field_batch(*, x_coords: np.ndarray | None = None) -> FieldBatch:
         },
         preprocess_log=[],
     )
-
-
-def translation_basis_spec() -> dict[str, object]:
-    return {
-        "variables": ["t", "x", "u"],
-        "component_names": ["xi"],
-        "basis_terms": [
-            {"label": "1", "powers": [0, 0, 0]},
-            {"label": "t", "powers": [1, 0, 0]},
-            {"label": "x", "powers": [0, 1, 0]},
-            {"label": "u", "powers": [0, 0, 1]},
-        ],
-        "component_ordering": ["xi"],
-        "term_ordering": ["1", "t", "x", "u"],
-        "layout": "component_major",
-    }
-
-
 def test_field_batch_round_trip_is_json_safe() -> None:
     field = make_field_batch()
     payload = field.to_dict()
@@ -133,7 +116,7 @@ def test_generator_family_requires_unit_norm_when_marked_l2_unit() -> None:
         GeneratorFamily(
             parameterization="polynomial_translation_affine",
             coefficients=np.array([[2.0, 0.0, 0.0, 0.0]]),
-            basis_spec=translation_basis_spec(),
+            basis_spec=_translation_generator_basis_spec(),
             normalization="l2_unit",
             diagnostics={},
         )
@@ -153,11 +136,11 @@ def test_generator_family_from_dict_upgrades_legacy_translation_payload_to_canon
 
     assert generator.schema_version == "0.2"
     np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
-    assert generator.basis_spec == translation_basis_spec()
+    assert generator.basis_spec == _translation_generator_basis_spec()
     assert generator.generator_names is None
     assert payload["schema_version"] == "0.2"
     assert payload["coefficients"] == [[1.0, 0.0, 0.0, 0.0]]
-    assert payload["basis_spec"] == translation_basis_spec()
+    assert payload["basis_spec"] == _translation_generator_basis_spec()
     json.dumps(payload)
 
 
@@ -166,7 +149,7 @@ def test_generator_family_accepts_canonical_family_payload() -> None:
         "schema_version": "0.2",
         "parameterization": "polynomial_translation_affine",
         "coefficients": [[1.0, 0.0, 0.0, 0.0]],
-        "basis_spec": translation_basis_spec(),
+        "basis_spec": _translation_generator_basis_spec(),
         "normalization": "l2_unit",
         "diagnostics": {},
     }
@@ -175,7 +158,7 @@ def test_generator_family_accepts_canonical_family_payload() -> None:
 
     assert generator.schema_version == "0.2"
     np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
-    assert generator.basis_spec == translation_basis_spec()
+    assert generator.basis_spec == _translation_generator_basis_spec()
 
 
 def test_generator_family_rejects_missing_basis_spec_on_direct_construction() -> None:
@@ -206,14 +189,14 @@ def test_generator_family_rejects_incompatible_coefficient_shape_for_basis_spec(
         GeneratorFamily(
             parameterization="polynomial_translation_affine",
             coefficients=np.array([[1.0, 0.0, 0.0]]),
-            basis_spec=translation_basis_spec(),
+            basis_spec=_translation_generator_basis_spec(),
             normalization="l2_unit",
             diagnostics={},
         )
 
 
 def test_generator_family_rejects_invalid_component_ordering() -> None:
-    basis_spec = translation_basis_spec()
+    basis_spec = _translation_generator_basis_spec()
     basis_spec["component_ordering"] = ["tau"]
 
     with pytest.raises(SchemaValidationError, match="component_ordering"):
@@ -227,7 +210,7 @@ def test_generator_family_rejects_invalid_component_ordering() -> None:
 
 
 def test_generator_family_rejects_invalid_term_ordering() -> None:
-    basis_spec = translation_basis_spec()
+    basis_spec = _translation_generator_basis_spec()
     basis_spec["term_ordering"] = ["t", "1", "x", "u"]
 
     with pytest.raises(SchemaValidationError, match="term_ordering"):
@@ -236,6 +219,61 @@ def test_generator_family_rejects_invalid_term_ordering() -> None:
             coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
             basis_spec=basis_spec,
             normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_duplicate_component_names() -> None:
+    basis_spec = _translation_generator_basis_spec()
+    basis_spec["component_names"] = ["xi", "xi"]
+
+    with pytest.raises(SchemaValidationError, match="component_names"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0] * 8]),
+            basis_spec=basis_spec,
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_duplicate_basis_term_labels() -> None:
+    basis_spec = _translation_generator_basis_spec()
+    basis_spec["basis_terms"][1]["label"] = "1"
+    basis_spec["term_ordering"] = ["1", "1", "x", "u"]
+
+    with pytest.raises(SchemaValidationError, match="labels must be unique"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            basis_spec=basis_spec,
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_negative_basis_term_power() -> None:
+    basis_spec = _translation_generator_basis_spec()
+    basis_spec["basis_terms"][0]["powers"] = [-1, 0, 0]
+
+    with pytest.raises(SchemaValidationError, match="nonnegative integers"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            basis_spec=basis_spec,
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_mismatched_generator_names_length() -> None:
+    with pytest.raises(ShapeValidationError, match="generator_names length must match"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            basis_spec=_translation_generator_basis_spec(),
+            normalization="l2_unit",
+            generator_names=["g0", "g1"],
             diagnostics={},
         )
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -161,6 +161,55 @@ def test_generator_family_accepts_canonical_family_payload() -> None:
     assert generator.basis_spec == _translation_generator_basis_spec()
 
 
+def test_generator_family_from_dict_treats_missing_or_null_diagnostics_as_empty_mapping() -> None:
+    payload = {
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+        "basis_spec": _translation_generator_basis_spec(),
+        "normalization": "l2_unit",
+        "diagnostics": None,
+    }
+
+    generator = GeneratorFamily.from_dict(payload)
+
+    assert generator.diagnostics == {}
+
+    del payload["diagnostics"]
+    generator = GeneratorFamily.from_dict(payload)
+
+    assert generator.diagnostics == {}
+
+
+def test_generator_family_from_dict_rejects_non_mapping_diagnostics() -> None:
+    with pytest.raises(SchemaValidationError, match="diagnostics must be a mapping"):
+        GeneratorFamily.from_dict(
+            {
+                "schema_version": "0.2",
+                "parameterization": "polynomial_translation_affine",
+                "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+                "basis_spec": _translation_generator_basis_spec(),
+                "normalization": "l2_unit",
+                "diagnostics": "not-a-mapping",
+            }
+        )
+
+
+def test_generator_family_from_dict_rejects_non_sequence_generator_names() -> None:
+    with pytest.raises(SchemaValidationError, match="generator_names must be a list or tuple"):
+        GeneratorFamily.from_dict(
+            {
+                "schema_version": "0.2",
+                "parameterization": "polynomial_translation_affine",
+                "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+                "basis_spec": _translation_generator_basis_spec(),
+                "normalization": "l2_unit",
+                "diagnostics": {},
+                "generator_names": "gen",
+            }
+        )
+
+
 def test_generator_family_rejects_missing_basis_spec_on_direct_construction() -> None:
     with pytest.raises(SchemaValidationError, match="basis_spec must be provided"):
         GeneratorFamily(

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -37,6 +37,22 @@ def make_field_batch(*, x_coords: np.ndarray | None = None) -> FieldBatch:
     )
 
 
+def translation_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
 def test_field_batch_round_trip_is_json_safe() -> None:
     field = make_field_batch()
     payload = field.to_dict()
@@ -116,9 +132,111 @@ def test_generator_family_requires_unit_norm_when_marked_l2_unit() -> None:
     with pytest.raises(ShapeValidationError):
         GeneratorFamily(
             parameterization="polynomial_translation_affine",
-            coefficients=np.array([2.0, 0.0, 0.0, 0.0]),
+            coefficients=np.array([[2.0, 0.0, 0.0, 0.0]]),
+            basis_spec=translation_basis_spec(),
             normalization="l2_unit",
-            diagnostics={"basis": ["1", "t", "x", "u"]},
+            diagnostics={},
+        )
+
+
+def test_generator_family_from_dict_upgrades_legacy_translation_payload_to_canonical_family() -> None:
+    legacy_payload = {
+        "schema_version": "0.1",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [1.0, 0.0, 0.0, 0.0],
+        "normalization": "l2_unit",
+        "diagnostics": {"basis": ["1", "t", "x", "u"]},
+    }
+
+    generator = GeneratorFamily.from_dict(legacy_payload)
+    payload = generator.to_dict()
+
+    assert generator.schema_version == "0.2"
+    np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+    assert generator.basis_spec == translation_basis_spec()
+    assert generator.generator_names is None
+    assert payload["schema_version"] == "0.2"
+    assert payload["coefficients"] == [[1.0, 0.0, 0.0, 0.0]]
+    assert payload["basis_spec"] == translation_basis_spec()
+    json.dumps(payload)
+
+
+def test_generator_family_accepts_canonical_family_payload() -> None:
+    payload = {
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+        "basis_spec": translation_basis_spec(),
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+    generator = GeneratorFamily.from_dict(payload)
+
+    assert generator.schema_version == "0.2"
+    np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+    assert generator.basis_spec == translation_basis_spec()
+
+
+def test_generator_family_rejects_missing_basis_spec_on_direct_construction() -> None:
+    with pytest.raises(SchemaValidationError, match="basis_spec must be provided"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_missing_basis_spec_on_non_legacy_payload() -> None:
+    with pytest.raises(SchemaValidationError, match="basis_spec is required"):
+        GeneratorFamily.from_dict(
+            {
+                "schema_version": "0.2",
+                "parameterization": "polynomial_translation_affine",
+                "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+                "normalization": "l2_unit",
+                "diagnostics": {},
+            }
+        )
+
+
+def test_generator_family_rejects_incompatible_coefficient_shape_for_basis_spec() -> None:
+    with pytest.raises(ShapeValidationError, match="coefficients width must match"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0]]),
+            basis_spec=translation_basis_spec(),
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_invalid_component_ordering() -> None:
+    basis_spec = translation_basis_spec()
+    basis_spec["component_ordering"] = ["tau"]
+
+    with pytest.raises(SchemaValidationError, match="component_ordering"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            basis_spec=basis_spec,
+            normalization="l2_unit",
+            diagnostics={},
+        )
+
+
+def test_generator_family_rejects_invalid_term_ordering() -> None:
+    basis_spec = translation_basis_spec()
+    basis_spec["term_ordering"] = ["t", "1", "x", "u"]
+
+    with pytest.raises(SchemaValidationError, match="term_ordering"):
+        GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+            basis_spec=basis_spec,
+            normalization="l2_unit",
+            diagnostics={},
         )
 
 

--- a/tests/test_finite_transform_verification.py
+++ b/tests/test_finite_transform_verification.py
@@ -4,28 +4,13 @@ import numpy as np
 import pytest
 
 from pdelie import GeneratorFamily, ScopeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.fitting.translation_baseline import TRANSLATION_FALLBACK_SPAN_TOLERANCE
 from pdelie.symmetry.parameterization.polynomial_translation import DEFAULT_TRANSLATION_SPAN_TOLERANCE
 from pdelie.verification import DEFAULT_EPSILON_VALUES, verify_translation_generator
-
-
-def translation_basis_spec() -> dict[str, object]:
-    return {
-        "variables": ["t", "x", "u"],
-        "component_names": ["xi"],
-        "basis_terms": [
-            {"label": "1", "powers": [0, 0, 0]},
-            {"label": "t", "powers": [1, 0, 0]},
-            {"label": "x", "powers": [0, 1, 0]},
-            {"label": "u", "powers": [0, 0, 1]},
-        ],
-        "component_ordering": ["xi"],
-        "term_ordering": ["1", "t", "x", "u"],
-        "layout": "component_major",
-    }
 
 
 def test_translation_span_tolerance_defaults_are_shared() -> None:
@@ -35,7 +20,7 @@ def test_translation_span_tolerance_defaults_are_shared() -> None:
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )
@@ -58,7 +43,7 @@ def test_translation_verification_fails_for_wrong_generator() -> None:
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )
@@ -104,7 +89,7 @@ def test_translation_verification_rejects_nonperiodic_boundary_conditions() -> N
     generator = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )
@@ -128,7 +113,7 @@ def test_translation_verification_fails_for_wrong_burgers_generator() -> None:
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )

--- a/tests/test_finite_transform_verification.py
+++ b/tests/test_finite_transform_verification.py
@@ -12,15 +12,32 @@ from pdelie.symmetry.parameterization.polynomial_translation import DEFAULT_TRAN
 from pdelie.verification import DEFAULT_EPSILON_VALUES, verify_translation_generator
 
 
+def translation_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
 def test_translation_span_tolerance_defaults_are_shared() -> None:
     assert TRANSLATION_FALLBACK_SPAN_TOLERANCE == DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
     heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=20)
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     report = verify_translation_generator(heldout, wrong, HeatResidualEvaluator())
     assert report.diagnostics["span_tolerance"] == DEFAULT_TRANSLATION_SPAN_TOLERANCE
@@ -40,9 +57,10 @@ def test_translation_verification_fails_for_wrong_generator() -> None:
     heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=23)
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     report = verify_translation_generator(heldout, wrong, HeatResidualEvaluator())
     assert report.classification == "failed"
@@ -85,9 +103,10 @@ def test_translation_verification_rejects_nonperiodic_boundary_conditions() -> N
     heldout.metadata["boundary_conditions"] = {"x": "dirichlet"}
     generator = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     with pytest.raises(ScopeValidationError, match="periodic boundary conditions in x"):
         verify_translation_generator(heldout, generator, HeatResidualEvaluator())
@@ -108,9 +127,10 @@ def test_translation_verification_fails_for_wrong_burgers_generator() -> None:
     heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=33)
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     report = verify_translation_generator(heldout, wrong, BurgersResidualEvaluator())
     assert report.classification == "failed"

--- a/tests/test_invariant_applier.py
+++ b/tests/test_invariant_applier.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from pdelie import FieldBatch, GeneratorFamily, InvariantMapSpec, SchemaValidationError, ScopeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.derivatives import compute_spectral_fd_derivatives
 from pdelie.invariants import InvariantApplier
@@ -12,27 +13,11 @@ from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import verify_translation_generator
 
 
-def translation_basis_spec() -> dict[str, object]:
-    return {
-        "variables": ["t", "x", "u"],
-        "component_names": ["xi"],
-        "basis_terms": [
-            {"label": "1", "powers": [0, 0, 0]},
-            {"label": "t", "powers": [1, 0, 0]},
-            {"label": "x", "powers": [0, 1, 0]},
-            {"label": "u", "powers": [0, 0, 1]},
-        ],
-        "component_ordering": ["xi"],
-        "term_ordering": ["1", "t", "x", "u"],
-        "layout": "component_major",
-    }
-
-
 def make_translation_generator() -> GeneratorFamily:
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )

--- a/tests/test_invariant_applier.py
+++ b/tests/test_invariant_applier.py
@@ -12,12 +12,29 @@ from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import verify_translation_generator
 
 
+def translation_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
 def make_translation_generator() -> GeneratorFamily:
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
 
 

--- a/tests/test_invariant_map_spec.py
+++ b/tests/test_invariant_map_spec.py
@@ -6,29 +6,14 @@ import numpy as np
 import pytest
 
 from pdelie import GeneratorFamily, InvariantMapSpec, SchemaValidationError
-
-
-def translation_basis_spec() -> dict[str, object]:
-    return {
-        "variables": ["t", "x", "u"],
-        "component_names": ["xi"],
-        "basis_terms": [
-            {"label": "1", "powers": [0, 0, 0]},
-            {"label": "t", "powers": [1, 0, 0]},
-            {"label": "x", "powers": [0, 1, 0]},
-            {"label": "u", "powers": [0, 0, 1]},
-        ],
-        "component_ordering": ["xi"],
-        "term_ordering": ["1", "t", "x", "u"],
-        "layout": "component_major",
-    }
+from pdelie.contracts import _translation_generator_basis_spec
 
 
 def make_translation_generator() -> GeneratorFamily:
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )

--- a/tests/test_invariant_map_spec.py
+++ b/tests/test_invariant_map_spec.py
@@ -8,12 +8,29 @@ import pytest
 from pdelie import GeneratorFamily, InvariantMapSpec, SchemaValidationError
 
 
+def translation_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
 def make_translation_generator() -> GeneratorFamily:
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([1.0, 0.0, 0.0, 0.0]),
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
 
 

--- a/tests/test_polynomial_translation.py
+++ b/tests/test_polynomial_translation.py
@@ -4,26 +4,11 @@ import numpy as np
 import pytest
 
 from pdelie import GeneratorFamily, ScopeValidationError, ShapeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import normalize_translation_coefficients, translation_span_distance
-
-
-def translation_basis_spec() -> dict[str, object]:
-    return {
-        "variables": ["t", "x", "u"],
-        "component_names": ["xi"],
-        "basis_terms": [
-            {"label": "1", "powers": [0, 0, 0]},
-            {"label": "t", "powers": [1, 0, 0]},
-            {"label": "x", "powers": [0, 1, 0]},
-            {"label": "u", "powers": [0, 0, 1]},
-        ],
-        "component_ordering": ["xi"],
-        "term_ordering": ["1", "t", "x", "u"],
-        "layout": "component_major",
-    }
 
 
 def test_translation_baseline_recovers_spatial_translation_span() -> None:
@@ -32,7 +17,7 @@ def test_translation_baseline_recovers_spatial_translation_span() -> None:
     assert generator.parameterization == "polynomial_translation_affine"
     assert generator.normalization == "l2_unit"
     assert generator.coefficients.shape == (1, 4)
-    assert generator.basis_spec == translation_basis_spec()
+    assert generator.basis_spec == _translation_generator_basis_spec()
     assert translation_span_distance(generator.coefficients) < 5e-2
     assert generator.diagnostics["fit_mode"] == "svd"
     assert generator.diagnostics["reference_fallback_used"] is False
@@ -63,7 +48,7 @@ def test_wrong_control_does_not_match_translation_span() -> None:
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
         coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
-        basis_spec=translation_basis_spec(),
+        basis_spec=_translation_generator_basis_spec(),
         normalization="l2_unit",
         diagnostics={},
     )

--- a/tests/test_polynomial_translation.py
+++ b/tests/test_polynomial_translation.py
@@ -10,21 +10,39 @@ from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import normalize_translation_coefficients, translation_span_distance
 
 
+def translation_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
 def test_translation_baseline_recovers_spatial_translation_span() -> None:
     field = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=10)
     generator = fit_translation_generator(field, HeatResidualEvaluator(), epsilon=1e-4)
     assert generator.parameterization == "polynomial_translation_affine"
     assert generator.normalization == "l2_unit"
+    assert generator.coefficients.shape == (1, 4)
+    assert generator.basis_spec == translation_basis_spec()
     assert translation_span_distance(generator.coefficients) < 5e-2
     assert generator.diagnostics["fit_mode"] == "svd"
     assert generator.diagnostics["reference_fallback_used"] is False
-    np.testing.assert_allclose(generator.coefficients, np.asarray(generator.diagnostics["svd_coefficients"], dtype=float))
+    np.testing.assert_allclose(generator.coefficients[0], np.asarray(generator.diagnostics["svd_coefficients"], dtype=float))
 
 
 def test_translation_baseline_outputs_normalized_coefficients() -> None:
     field = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=12)
     generator = fit_translation_generator(field, HeatResidualEvaluator(), epsilon=1e-4)
-    np.testing.assert_allclose(np.linalg.norm(generator.coefficients), 1.0, atol=1e-8)
+    np.testing.assert_allclose(np.linalg.norm(generator.coefficients, axis=1), np.array([1.0]), atol=1e-8)
 
 
 def test_translation_baseline_recovers_spatial_translation_span_on_burgers() -> None:
@@ -38,15 +56,16 @@ def test_translation_baseline_recovers_spatial_translation_span_on_burgers() -> 
     assert generator.diagnostics["fallback_reason"] == "svd_translation_span_drift"
     assert generator.diagnostics["min_delta_basis"] == "1"
     assert generator.diagnostics["svd_span_distance"] > 5e-2
-    np.testing.assert_allclose(generator.coefficients, np.array([1.0, 0.0, 0.0, 0.0], dtype=float))
+    np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
 
 
 def test_wrong_control_does_not_match_translation_span() -> None:
     wrong = GeneratorFamily(
         parameterization="polynomial_translation_affine",
-        coefficients=np.array([0.0, 0.0, 1.0, 0.0]),
+        coefficients=np.array([[0.0, 0.0, 1.0, 0.0]]),
+        basis_spec=translation_basis_spec(),
         normalization="l2_unit",
-        diagnostics={"basis": ["1", "t", "x", "u"]},
+        diagnostics={},
     )
     assert translation_span_distance(wrong.coefficients) > 1.0
 


### PR DESCRIPTION
## Summary

This PR implements **V0.4 Milestone 1**: freezing `GeneratorFamily` family semantics and migration policy.

The milestone is intentionally **representation-only**. It does not add symbolic rendering, span diagnostics, closure diagnostics, visualization, or fitting changes.

## What changed

### GeneratorFamily canonical form
`GeneratorFamily` now uses the canonical `v0.4` family representation:

- `schema_version = "0.2"`
- `coefficients` serialized in 2D family shape
- required `basis_spec`
- canonical meaning depends only on:
  - `schema_version`
  - `parameterization`
  - `coefficients`
  - `basis_spec`
  - `normalization`
  - optional `generator_names`

`diagnostics` remains optional and non-authoritative.

### Narrow legacy migration
Legacy compatibility is intentionally narrow.

`from_dict()` accepts only:
- canonical `0.2` family payloads
- the explicit legacy `0.1` translation payload:
  - `parameterization == "polynomial_translation_affine"`
  - 1D length-4 coefficients
  - no `basis_spec`

That legacy translation payload is upgraded in memory to canonical family form.

Direct construction without `basis_spec` is no longer broadly tolerated.

### basis_spec validation
This PR freezes the required `basis_spec` structure and validates:
- required fields
- ordering consistency
- coefficient width vs basis specification
- nonnegative integer monomial powers
- legacy translation upgrade behavior

### Translation compatibility
The current translation-only runtime path remains intact through a narrow private compatibility path:
- accepts raw 1D translation coefficients
- accepts canonical single-row `(1, 4)` family coefficients
- rejects multi-row families in the current translation-only path

### Hardening cleanup
This PR also includes a small hardening pass:
- single-sources the canonical translation `basis_spec`
- removes duplicated translation basis fixtures in tests/helpers
- adds missing contract tests