### PR TITLE
Add runtime span diagnostics for GeneratorFamily

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -36,6 +36,10 @@ Runtime public API for the frozen `v0.4` Milestone 2 slice:
 - `pdelie.symmetry.render_generator_family` for deterministic runtime-only symbolic display of the stored generator basis
 - `pdelie.symmetry.to_sympy_component_expressions` for optional runtime-only SymPy component expressions when `sympy` is installed
 
+Runtime public API for the frozen `v0.4` Milestone 3 slice:
+
+- `pdelie.symmetry.compare_generator_spans` for runtime-only algebraic span comparison of canonical polynomial `GeneratorFamily` objects under the frozen normalized polynomial inner product
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.4 Milestone 2 — Runtime symbolic normalization and display**
+**V0.4 Milestone 3 — Runtime span diagnostics**
 
 This file is the active execution plan for the current `v0.4` release series.
 
@@ -38,57 +38,58 @@ Completed outcome:
 
 ---
 
-## Milestone 2 — Runtime Symbolic Normalization And Display
+## Milestone 3 — Runtime Span Diagnostics
 
 ### Goal
 
-Add deterministic runtime-only symbolic rendering for canonical `GeneratorFamily` objects without changing canonical storage, fitting behavior, or the Heat/Burgers stable paths.
+Add deterministic runtime-only algebraic span comparison for canonical `GeneratorFamily` objects without changing canonical storage, fitting behavior, or the Heat/Burgers stable paths.
 
 ### Frozen Decisions
 
 - `GeneratorFamily` canonical core from Milestone 1 remains unchanged
-- symbolic display is runtime-only and must not mutate stored coefficients or normalization
-- default display normalization is `"anchor"`
-- display normalization is separate from canonical numerical normalization
-- rendering is deterministic for the given basis only
-- optional SymPy support is lazy-imported and not part of the core install contract
-- no heuristic basis simplification in this milestone
-- no fitting changes in M2
-- no span metrics in M2
-- no closure diagnostics in M2
-- no visualization in M2
+- span diagnostics are runtime-only and must not mutate stored coefficients or normalization
+- principal angles are the primary span metric
+- projection residual is the paired derived diagnostic
+- `normalized_polynomial_l2` is the only supported M3 inner-product mode
+- exact polynomial comparison is frozen only for the current algebraic/runtime polynomial scope
+- structurally equivalent `basis_spec` semantics are required; raw dictionary identity is not
+- no fitting changes in M3
+- no closure diagnostics in M3
+- no visualization in M3
 
 ### Deliverables
 
-- runtime-only symbolic rendering helpers under `pdelie.symmetry`
-- deterministic sign, component ordering, and term ordering from canonical `basis_spec`
-- runtime-only display normalization modes `"anchor"` and `"none"`
-- optional SymPy component-expression helper with clear missing-dependency error
-- regression protection for canonical single-row translation families and legacy-upgraded translation payloads
+- runtime-only span comparison helper under `pdelie.symmetry`
+- deterministic principal-angle diagnostics for canonical polynomial generator families
+- deterministic projection residual diagnostics under the frozen normalized polynomial inner product
+- basis-spec structural-equivalence checks for span comparison
+- regression protection for canonical translation families, legacy-upgraded translation payloads, and controlled algebraic fixtures
 
 ### Acceptance Criteria
 
-Milestone 2 is complete only if:
+Milestone 3 is complete only if:
 
 - existing Heat/Burgers stable paths still pass unchanged
 - canonical `GeneratorFamily` contracts remain unchanged
-- canonical single-row translation families render deterministically
-- legacy translation payloads upgraded through `from_dict()` render identically to canonical family-shaped construction
-- runtime display normalization does not mutate stored coefficients
-- missing SymPy raises a clear runtime error for the SymPy helper only
+- identical spans compare with zero principal angles and zero projection residual summary
+- same spans under basis change compare as equivalent
+- structurally non-equivalent basis semantics fail with typed validation errors
+- zero-rank effective spans fail with typed validation errors
 - no new canonical object is introduced
-- no public downstream, invariant, span, closure, or visualization semantics are broadened
+- no public fitting, invariant, closure, or visualization semantics are broadened
 
 ### Test Plan
 
 Run at minimum:
 
-- runtime symbolic rendering tests
+- runtime span comparison tests
 - runtime public API import tests
-- canonical single-row translation rendering tests
-- legacy-upgraded translation rendering tests
-- deterministic sign / ordering / zero-tolerance tests
-- optional SymPy missing-dependency and installed-path tests
+- canonical single-row translation span tests
+- legacy-upgraded translation span tests
+- basis-change equivalence tests
+- strict-containment residual tests
+- basis-spec structural-equivalence and mismatch tests
+- zero-rank span tests
 - existing Heat/Burgers regression tests
 - full `pytest`
 
@@ -98,7 +99,6 @@ Run at minimum:
 
 Strict sequencing for `v0.4`:
 
-- Milestone 3: span diagnostics under the frozen inner-product policy
 - Milestone 4: closure diagnostics with exact bracket preferred
 - Milestone 5: minimal visualization as renderers only and deferrable
 - Milestone 6: algebra-span release gate
@@ -128,8 +128,8 @@ Hard sequencing rules:
 
 - `v0.3`: **COMPLETE**
 - Milestone 1: **COMPLETE**
-- Milestone 2: **ACTIVE**
-- Milestone 3: **PLANNED**
+- Milestone 2: **COMPLETE**
+- Milestone 3: **ACTIVE**
 - Milestone 4: **PLANNED**
 - Milestone 5: **PLANNED**
 - Milestone 6: **PLANNED**

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -211,6 +211,10 @@ Paired derived metric:
 
 - projection residual
 
+Comparison precondition:
+
+- compared families must have structurally equivalent `basis_spec` semantics
+
 Freeze one default inner-product policy:
 
 - normalized variable domain
@@ -220,20 +224,27 @@ Freeze one default inner-product policy:
 
 Preferred computation mode:
 
-- exact polynomial inner product where straightforward for the supported `basis_spec`
+- exact polynomial inner product for the current algebraic/runtime polynomial scope
 
-Accepted fallback:
+Deferred later work:
 
-- deterministic sampled inner product on the normalized domain
+- field-aware scaling for PDE-associated learned spans
+- deterministic sampled fallback modes for broader comparison settings
 
-Every span report must store:
+Required core span report fields:
 
-- evaluation mode
+- inner_product
+- evaluation_mode
 - domain
-- variable scaling
-- component weights
+- component_weights
+- reference_rank
+- candidate_rank
+- comparison_rank
+- principal_angles_radians
+- projection_residual
 - conditioning
-- orthonormalization method
+
+Additional runtime diagnostic fields may be included, but are not frozen in `v0.4` Milestone 3 unless promoted later.
 
 ### Closure / structure-constant policy
 
@@ -286,7 +297,7 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 ## Frozen Milestones
 
 ### Milestone 1 — `GeneratorFamily` representation semantics
-**Status:** Planned
+**Status:** Complete
 
 - freeze family-shaped `GeneratorFamily`
 - add required `basis_spec`
@@ -296,15 +307,15 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - no visualization
 
 ### Milestone 2 — Symbolic normalization and display
-**Status:** Planned
+**Status:** Complete
 
 - deterministic symbolic rendering
 - runtime-only display normalization
 - optional SymPy output
-- optional heuristic basis simplification helper
+- no heuristic basis simplification helper in the completed M2 slice
 
 ### Milestone 3 — Span diagnostics
-**Status:** Planned
+**Status:** Active
 
 - principal angles
 - projection residual

--- a/src/pdelie/symmetry/__init__.py
+++ b/src/pdelie/symmetry/__init__.py
@@ -1,8 +1,10 @@
 from pdelie.symmetry.fitting.translation_baseline import fit_translation_generator
+from pdelie.symmetry.span import compare_generator_spans
 from pdelie.symmetry.symbolic import render_generator_family, to_sympy_component_expressions
 
 __all__ = [
     "fit_translation_generator",
+    "compare_generator_spans",
     "render_generator_family",
     "to_sympy_component_expressions",
 ]

--- a/src/pdelie/symmetry/span.py
+++ b/src/pdelie/symmetry/span.py
@@ -64,7 +64,6 @@ def _basis_term_gram_matrix(generator: GeneratorFamily) -> np.ndarray:
 
 
 def _ambient_gram_matrix(generator: GeneratorFamily) -> tuple[np.ndarray, dict[str, float]]:
-    num_components = len(generator.basis_spec["component_names"])
     term_gram = _basis_term_gram_matrix(generator)
     component_weights = {str(name): 1.0 for name in generator.basis_spec["component_names"]}
     block_weights = np.diag([component_weights[str(name)] for name in generator.basis_spec["component_names"]])

--- a/src/pdelie/symmetry/span.py
+++ b/src/pdelie/symmetry/span.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+"""Runtime-only span diagnostics for canonical GeneratorFamily objects."""
+
+from typing import Any, Mapping
+
+import numpy as np
+
+from pdelie.contracts import GeneratorFamily
+from pdelie.errors import SchemaValidationError, ShapeValidationError
+
+
+_SUPPORTED_INNER_PRODUCTS = frozenset({"normalized_polynomial_l2"})
+_RANK_TOL = 1e-10
+_GRAM_EIGEN_TOL = 1e-12
+
+
+def _basis_spec_signature(basis_spec: Mapping[str, Any]) -> tuple[Any, ...]:
+    basis_terms = tuple(
+        (str(term["label"]), tuple(int(power) for power in term["powers"]))
+        for term in basis_spec["basis_terms"]
+    )
+    return (
+        tuple(str(name) for name in basis_spec["variables"]),
+        tuple(str(name) for name in basis_spec["component_names"]),
+        tuple(str(name) for name in basis_spec["component_ordering"]),
+        tuple(str(name) for name in basis_spec["term_ordering"]),
+        str(basis_spec["layout"]),
+        basis_terms,
+    )
+
+
+def _require_structurally_equivalent_basis_spec(
+    reference: GeneratorFamily,
+    candidate: GeneratorFamily,
+) -> None:
+    if _basis_spec_signature(reference.basis_spec) != _basis_spec_signature(candidate.basis_spec):
+        raise SchemaValidationError(
+            "compare_generator_spans requires structurally equivalent basis_spec semantics."
+        )
+
+
+def _monomial_average_inner_product(powers_a: tuple[int, ...], powers_b: tuple[int, ...]) -> float:
+    value = 1.0
+    for power_a, power_b in zip(powers_a, powers_b):
+        total_power = int(power_a) + int(power_b)
+        if total_power % 2 == 1:
+            return 0.0
+        value *= 1.0 / float(total_power + 1)
+    return value
+
+
+def _basis_term_gram_matrix(generator: GeneratorFamily) -> np.ndarray:
+    basis_terms = [
+        tuple(int(power) for power in term["powers"])
+        for term in generator.basis_spec["basis_terms"]
+    ]
+    size = len(basis_terms)
+    gram = np.empty((size, size), dtype=float)
+    for row_index, powers_a in enumerate(basis_terms):
+        for col_index, powers_b in enumerate(basis_terms):
+            gram[row_index, col_index] = _monomial_average_inner_product(powers_a, powers_b)
+    return gram
+
+
+def _ambient_gram_matrix(generator: GeneratorFamily) -> tuple[np.ndarray, dict[str, float]]:
+    num_components = len(generator.basis_spec["component_names"])
+    term_gram = _basis_term_gram_matrix(generator)
+    component_weights = {str(name): 1.0 for name in generator.basis_spec["component_names"]}
+    block_weights = np.diag([component_weights[str(name)] for name in generator.basis_spec["component_names"]])
+    ambient_gram = np.kron(block_weights, term_gram)
+    return ambient_gram, component_weights
+
+
+def _condition_number_from_values(values: np.ndarray) -> float:
+    values = np.asarray(values, dtype=float)
+    if values.size == 0:
+        return float("inf")
+    positive = values[values > 0.0]
+    if positive.size == 0:
+        return float("inf")
+    minimum = float(np.min(positive))
+    maximum = float(np.max(positive))
+    if minimum == 0.0:
+        return float("inf")
+    return maximum / minimum
+
+
+def _metric_transform(ambient_gram: np.ndarray) -> tuple[np.ndarray, float]:
+    eigenvalues, eigenvectors = np.linalg.eigh(np.asarray(ambient_gram, dtype=float))
+    max_abs_eigenvalue = float(np.max(np.abs(eigenvalues))) if eigenvalues.size else 0.0
+    floor = max(_GRAM_EIGEN_TOL * max_abs_eigenvalue, _GRAM_EIGEN_TOL)
+    adjusted = np.where(np.abs(eigenvalues) <= floor, 0.0, eigenvalues)
+    if np.any(adjusted < 0.0):
+        raise ShapeValidationError("Span comparison ambient Gram matrix must be positive semidefinite.")
+    positive_mask = adjusted > 0.0
+    transform = eigenvectors[:, positive_mask] * np.sqrt(adjusted[positive_mask])[None, :]
+    condition_number = _condition_number_from_values(adjusted[positive_mask])
+    return transform, condition_number
+
+
+def _orthonormal_row_span(matrix: np.ndarray) -> tuple[np.ndarray, int, float]:
+    _, singular_values, vh = np.linalg.svd(np.asarray(matrix, dtype=float), full_matrices=False)
+    if singular_values.size == 0:
+        return np.empty((0, matrix.shape[1]), dtype=float), 0, float("inf")
+    threshold = max(float(singular_values[0]) * _RANK_TOL, _RANK_TOL)
+    rank = int(np.count_nonzero(singular_values > threshold))
+    if rank == 0:
+        return np.empty((0, matrix.shape[1]), dtype=float), 0, float("inf")
+    retained = singular_values[:rank]
+    return vh[:rank], rank, _condition_number_from_values(retained)
+
+
+def _projection_residual(source_basis: np.ndarray, target_basis: np.ndarray) -> float:
+    projector = target_basis.T @ target_basis
+    residual = source_basis - source_basis @ projector
+    return float(np.linalg.norm(residual, ord="fro") / np.sqrt(float(source_basis.shape[0])))
+
+
+def compare_generator_spans(
+    reference: GeneratorFamily,
+    candidate: GeneratorFamily,
+    *,
+    inner_product: str = "normalized_polynomial_l2",
+) -> dict[str, object]:
+    """Compare generator-family row spans under the frozen M3 polynomial inner product.
+
+    Raises:
+        SchemaValidationError: for unsupported inner products or non-equivalent basis semantics.
+        ShapeValidationError: if either effective span has zero numerical rank.
+    """
+
+    reference.validate()
+    candidate.validate()
+
+    if inner_product not in _SUPPORTED_INNER_PRODUCTS:
+        raise SchemaValidationError(
+            "compare_generator_spans only supports inner_product='normalized_polynomial_l2' in V0.4 Milestone 3."
+        )
+
+    _require_structurally_equivalent_basis_spec(reference, candidate)
+
+    ambient_gram, component_weights = _ambient_gram_matrix(reference)
+    transform, ambient_condition_number = _metric_transform(ambient_gram)
+
+    reference_transformed = np.asarray(reference.coefficients, dtype=float) @ transform
+    candidate_transformed = np.asarray(candidate.coefficients, dtype=float) @ transform
+
+    reference_basis, reference_rank, reference_condition = _orthonormal_row_span(reference_transformed)
+    candidate_basis, candidate_rank, candidate_condition = _orthonormal_row_span(candidate_transformed)
+
+    if reference_rank == 0 or candidate_rank == 0:
+        raise ShapeValidationError("compare_generator_spans requires both generator families to have nonzero rank.")
+
+    comparison_rank = min(reference_rank, candidate_rank)
+    singular_values = np.linalg.svd(reference_basis @ candidate_basis.T, compute_uv=False)
+    principal_angles = np.arccos(np.clip(singular_values[:comparison_rank], -1.0, 1.0))
+
+    reference_to_candidate = _projection_residual(reference_basis, candidate_basis)
+    candidate_to_reference = _projection_residual(candidate_basis, reference_basis)
+
+    return {
+        "inner_product": inner_product,
+        "evaluation_mode": "exact_polynomial",
+        "domain": {
+            "kind": "normalized_hypercube",
+            "variables": list(reference.basis_spec["variables"]),
+            "bounds": [[-1.0, 1.0] for _ in reference.basis_spec["variables"]],
+        },
+        "component_weights": component_weights,
+        "reference_rank": reference_rank,
+        "candidate_rank": candidate_rank,
+        "comparison_rank": comparison_rank,
+        "principal_angles_radians": principal_angles.tolist(),
+        "projection_residual": {
+            "summary": float(max(reference_to_candidate, candidate_to_reference)),
+            "reference_to_candidate": reference_to_candidate,
+            "candidate_to_reference": candidate_to_reference,
+        },
+        "conditioning": {
+            "ambient_metric": ambient_condition_number,
+            "reference_span": reference_condition,
+            "candidate_span": candidate_condition,
+        },
+    }
+
+
+__all__ = ["compare_generator_spans"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -27,10 +27,15 @@ def test_stable_public_api_is_importable() -> None:
 def test_runtime_package_api_is_importable() -> None:
     from pdelie.discovery import to_pysindy_trajectories
     from pdelie.invariants import InvariantApplier
-    from pdelie.symmetry import render_generator_family, to_sympy_component_expressions
+    from pdelie.symmetry import (
+        compare_generator_spans,
+        render_generator_family,
+        to_sympy_component_expressions,
+    )
 
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
+    assert compare_generator_spans is not None
     assert render_generator_family is not None
     assert to_sympy_component_expressions is not None
 
@@ -38,6 +43,7 @@ def test_runtime_package_api_is_importable() -> None:
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
+    assert not hasattr(pdelie, "compare_generator_spans")
     assert not hasattr(pdelie, "render_generator_family")
     assert not hasattr(pdelie, "to_sympy_component_expressions")
 
@@ -56,9 +62,10 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 
 
-def test_symmetry_package_runtime_api_matches_frozen_m2_surface() -> None:
+def test_symmetry_package_runtime_api_matches_frozen_m3_surface() -> None:
     symmetry_module = importlib.import_module("pdelie.symmetry")
 
     assert hasattr(symmetry_module, "fit_translation_generator")
+    assert hasattr(symmetry_module, "compare_generator_spans")
     assert hasattr(symmetry_module, "render_generator_family")
     assert hasattr(symmetry_module, "to_sympy_component_expressions")

--- a/tests/test_span_runtime.py
+++ b/tests/test_span_runtime.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdelie import GeneratorFamily, SchemaValidationError, ShapeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.symmetry import compare_generator_spans
+
+
+def _txu_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["tau", "xi", "phi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["tau", "xi", "phi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
+def _make_generator(
+    coefficients: np.ndarray,
+    *,
+    basis_spec: dict[str, object],
+    normalization: str = "runtime_fixture",
+    parameterization: str = "algebraic_fixture",
+) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization=parameterization,
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization=normalization,
+        diagnostics={},
+    )
+
+
+def test_compare_generator_spans_matches_identical_translation_spans() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    assert report["inner_product"] == "normalized_polynomial_l2"
+    assert report["evaluation_mode"] == "exact_polynomial"
+    assert report["reference_rank"] == 1
+    assert report["candidate_rank"] == 1
+    assert report["comparison_rank"] == 1
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0], atol=1e-12)
+    assert report["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert report["projection_residual"]["reference_to_candidate"] == pytest.approx(0.0, abs=1e-12)
+    assert report["projection_residual"]["candidate_to_reference"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_compare_generator_spans_matches_legacy_upgraded_translation_against_canonical() -> None:
+    legacy = GeneratorFamily.from_dict(
+        {
+            "schema_version": "0.1",
+            "parameterization": "polynomial_translation_affine",
+            "coefficients": [1.0, 0.0, 0.0, 0.0],
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        }
+    )
+    canonical = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(legacy, canonical)
+
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0], atol=1e-12)
+    assert report["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_compare_generator_spans_matches_same_span_under_basis_change() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], dtype=float) / np.sqrt(2.0),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0, 0.0], atol=1e-12)
+    assert report["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_compare_generator_spans_reports_nonzero_angle_for_distinct_one_dimensional_spans() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+    angle = float(report["principal_angles_radians"][0])
+
+    assert angle > 0.1
+    assert report["projection_residual"]["summary"] > 0.0
+
+
+def test_compare_generator_spans_reports_directional_residual_for_strict_containment() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0], atol=1e-12)
+    assert report["projection_residual"]["reference_to_candidate"] == pytest.approx(0.0, abs=1e-12)
+    assert report["projection_residual"]["candidate_to_reference"] > 0.0
+    assert report["projection_residual"]["summary"] == pytest.approx(
+        report["projection_residual"]["candidate_to_reference"],
+        rel=0.0,
+        abs=1e-12,
+    )
+
+
+def test_compare_generator_spans_accepts_structurally_equivalent_basis_specs() -> None:
+    reordered_basis_spec = {
+        "layout": "component_major",
+        "term_ordering": ["1", "t", "x", "u"],
+        "basis_terms": [
+            {"powers": [0, 0, 0], "label": "1"},
+            {"powers": [1, 0, 0], "label": "t"},
+            {"powers": [0, 1, 0], "label": "x"},
+            {"powers": [0, 0, 1], "label": "u"},
+        ],
+        "component_ordering": ["xi"],
+        "component_names": ["xi"],
+        "variables": ["t", "x", "u"],
+    }
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=reordered_basis_spec,
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0], atol=1e-12)
+
+
+def test_compare_generator_spans_rejects_non_equivalent_basis_semantics() -> None:
+    mismatched = {
+        "variables": ["x", "t", "u"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [0, 1, 0]},
+            {"label": "x", "powers": [1, 0, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=mismatched,
+        parameterization="polynomial_translation_affine",
+    )
+
+    with pytest.raises(SchemaValidationError, match="structurally equivalent basis_spec"):
+        compare_generator_spans(reference, candidate)
+
+
+def test_compare_generator_spans_rejects_zero_rank_spans() -> None:
+    reference = _make_generator(
+        np.zeros((1, 4), dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+
+    with pytest.raises(ShapeValidationError, match="nonzero rank"):
+        compare_generator_spans(reference, candidate)
+
+
+def test_compare_generator_spans_returns_required_core_report_schema() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    assert set(report) == {
+        "inner_product",
+        "evaluation_mode",
+        "domain",
+        "component_weights",
+        "reference_rank",
+        "candidate_rank",
+        "comparison_rank",
+        "principal_angles_radians",
+        "projection_residual",
+        "conditioning",
+    }
+    assert set(report["projection_residual"]) == {
+        "summary",
+        "reference_to_candidate",
+        "candidate_to_reference",
+    }
+    assert set(report["conditioning"]) == {
+        "ambient_metric",
+        "reference_span",
+        "candidate_span",
+    }
+
+
+def test_compare_generator_spans_supports_multi_component_polynomial_fixtures() -> None:
+    reference = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, -1.0]], dtype=float),
+        basis_spec=_txu_basis_spec(),
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, -2.0]], dtype=float),
+        basis_spec=_txu_basis_spec(),
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0], atol=1e-12)


### PR DESCRIPTION
- Added pdelie.symmetry.compare_generator_spans(...) as a runtime-only helper.
- Implemented exact polynomial span comparison under the frozen normalized_polynomial_l2 mode for the current algebraic/runtime polynomial scope.
- Enforced structural basis_spec equivalence rather than raw mapping identity.
- Reported the smaller core runtime schema only:
inner_product
evaluation_mode
domain
component_weights
reference_rank
candidate_rank
comparison_rank
principal_angles_radians
projection_residual
conditioning
- Used ShapeValidationError for zero-rank effective spans.