### PR TITLE
Closure diagnostics added

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -40,6 +40,10 @@ Runtime public API for the frozen `v0.4` Milestone 3 slice:
 
 - `pdelie.symmetry.compare_generator_spans` for runtime-only algebraic span comparison of canonical polynomial `GeneratorFamily` objects under the frozen normalized polynomial inner product
 
+Runtime public API for the frozen `v0.4` Milestone 4 slice:
+
+- `pdelie.symmetry.diagnose_generator_family_closure` for runtime-only closure, structure-constant, and algebra-diagnostic reports on canonical polynomial `GeneratorFamily` objects
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.4 Milestone 3 — Runtime span diagnostics**
+**V0.4 Milestone 4 — Runtime closure diagnostics**
 
 This file is the active execution plan for the current `v0.4` release series.
 
@@ -38,58 +38,62 @@ Completed outcome:
 
 ---
 
-## Milestone 3 — Runtime Span Diagnostics
+## Milestone 4 — Runtime Closure Diagnostics
 
 ### Goal
 
-Add deterministic runtime-only algebraic span comparison for canonical `GeneratorFamily` objects without changing canonical storage, fitting behavior, or the Heat/Burgers stable paths.
+Add deterministic runtime-only closure diagnostics for canonical polynomial `GeneratorFamily` objects without changing canonical storage, fitting behavior, or the Heat/Burgers stable paths.
 
 ### Frozen Decisions
 
 - `GeneratorFamily` canonical core from Milestone 1 remains unchanged
-- span diagnostics are runtime-only and must not mutate stored coefficients or normalization
-- principal angles are the primary span metric
-- projection residual is the paired derived diagnostic
-- `normalized_polynomial_l2` is the only supported M3 inner-product mode
-- exact polynomial comparison is frozen only for the current algebraic/runtime polynomial scope
-- structurally equivalent `basis_spec` semantics are required; raw dictionary identity is not
-- no fitting changes in M3
-- no closure diagnostics in M3
-- no visualization in M3
+- closure diagnostics are runtime-only and must not mutate stored coefficients or normalization
+- closure remains secondary to dynamical validity and supplied verification evidence
+- `normalized_polynomial_l2` is the only supported M4 inner-product mode
+- exact polynomial closure is frozen only for the current monomial algebraic/runtime polynomial scope
+- exact brackets may use an internal expanded polynomial representation, but that representation is not canonical
+- structure constants are estimated from projected brackets onto the stored family span
+- antisymmetry and Jacobi diagnostics are structure-constant diagnostics, not raw vector-field Jacobi claims
+- sampled fallback is minimal and deterministic, and only a compatibility path
+- no fitting changes in M4
+- no visualization in M4
 
 ### Deliverables
 
-- runtime-only span comparison helper under `pdelie.symmetry`
-- deterministic principal-angle diagnostics for canonical polynomial generator families
-- deterministic projection residual diagnostics under the frozen normalized polynomial inner product
-- basis-spec structural-equivalence checks for span comparison
-- regression protection for canonical translation families, legacy-upgraded translation payloads, and controlled algebraic fixtures
+- runtime-only closure diagnostic helper under `pdelie.symmetry`
+- exact polynomial Lie-bracket diagnostics for canonical monomial polynomial generator families
+- projected structure-constant diagnostics and closure residuals
+- structure-constant antisymmetry and Jacobi diagnostics
+- family-aware interpretation labels based on supplied verification evidence
+- minimal deterministic sampled fallback coverage on one controlled fixture
 
 ### Acceptance Criteria
 
-Milestone 3 is complete only if:
+Milestone 4 is complete only if:
 
 - existing Heat/Burgers stable paths still pass unchanged
 - canonical `GeneratorFamily` contracts remain unchanged
-- identical spans compare with zero principal angles and zero projection residual summary
-- same spans under basis change compare as equivalent
-- structurally non-equivalent basis semantics fail with typed validation errors
-- zero-rank effective spans fail with typed validation errors
+- commuting closed families report zero closure, antisymmetry, and Jacobi summaries
+- closed nontrivial affine families report the expected structure constants
+- unresolved component-target semantics fail with typed validation errors
+- rank-deficient families fail with typed validation errors under the runtime metric policy
 - no new canonical object is introduced
-- no public fitting, invariant, closure, or visualization semantics are broadened
+- no public fitting, invariant, visualization, or canonical semantics are broadened
 
 ### Test Plan
 
 Run at minimum:
 
-- runtime span comparison tests
+- runtime closure diagnostic tests
 - runtime public API import tests
-- canonical single-row translation span tests
-- legacy-upgraded translation span tests
-- basis-change equivalence tests
-- strict-containment residual tests
-- basis-spec structural-equivalence and mismatch tests
-- zero-rank span tests
+- commuting-family closure tests
+- affine structure-constant tests
+- structure-constant Jacobi tests on a closed three-generator family
+- exact-bracket projection tests when brackets leave the stored basis
+- explicit component-target override and unresolved-target failure tests
+- minimal sampled fallback determinism tests
+- family-aware interpretation-label tests
+- rank-deficient family tests
 - existing Heat/Burgers regression tests
 - full `pytest`
 
@@ -99,7 +103,6 @@ Run at minimum:
 
 Strict sequencing for `v0.4`:
 
-- Milestone 4: closure diagnostics with exact bracket preferred
 - Milestone 5: minimal visualization as renderers only and deferrable
 - Milestone 6: algebra-span release gate
 
@@ -129,7 +132,7 @@ Hard sequencing rules:
 - `v0.3`: **COMPLETE**
 - Milestone 1: **COMPLETE**
 - Milestone 2: **COMPLETE**
-- Milestone 3: **ACTIVE**
-- Milestone 4: **PLANNED**
+- Milestone 3: **COMPLETE**
+- Milestone 4: **ACTIVE**
 - Milestone 5: **PLANNED**
 - Milestone 6: **PLANNED**

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -250,29 +250,44 @@ Additional runtime diagnostic fields may be included, but are not frozen in `v0.
 
 Preferred mode:
 
-- exact polynomial coefficient-space Lie bracket when supported
+- exact polynomial Lie brackets for the current monomial algebraic/runtime polynomial scope
 
 Fallback mode:
 
-- sampled/projection closure only when exact mode is unavailable
+- deterministic sampled/projection closure only when exact mode is unavailable or explicitly forced
 
-Every closure report must store:
+Exact-mode policy:
 
-- computation mode
-- domain or sample grid
-- variable scaling
-- component weights
-- projection method
-- residual normalization
-- conditioning
-- warning flags for ill-conditioned structure-constant estimation
+- closure diagnostics use raw vector-field brackets
+- exact brackets may use an internal expanded polynomial representation when bracket monomials leave the stored family basis
+- that expanded bracket representation is runtime-only and not a canonical object or stable basis contract
+- projected brackets determine reported structure constants and closure diagnostics
+- exact mode is available only for the current monomial basis-term encoding; richer or noncanonical term encodings must reject exact mode or downgrade to fallback
 
 Interpretation rule:
 
-- closure diagnostics on verified symmetry generators may be called **symmetry-algebra diagnostics**
-- closure diagnostics on unverified generators are only **vector-field algebra diagnostics**
+- `symmetry_algebra_diagnostics` means closure diagnostics on a family with supplied symmetry-validity evidence
+- it does not claim a full family symmetry proof or full per-generator coverage in `v0.4`
+- `symmetry_algebra_diagnostics` requires non-empty supplied verification evidence whose classifications are all `exact` or `approximate`
+- otherwise the label is `vector_field_algebra_diagnostics`
 - closure is interpretive support, never primary evidence
 - finite-flow validity, residual validity, and held-out verification remain primary
+
+Required core closure report fields:
+
+- interpretation_label
+- verification_classifications
+- inner_product
+- computation_mode
+- domain
+- component_weights
+- component_targets
+- family_rank
+- structure_constants
+- closure
+- antisymmetry
+- jacobi
+- conditioning
 
 ---
 
@@ -315,7 +330,7 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - no heuristic basis simplification helper in the completed M2 slice
 
 ### Milestone 3 — Span diagnostics
-**Status:** Active
+**Status:** Complete
 
 - principal angles
 - projection residual
@@ -323,10 +338,10 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - controlled algebraic fixtures
 
 ### Milestone 4 — Closure diagnostics
-**Status:** Planned
+**Status:** Active
 
 - exact polynomial Lie brackets where supported
-- deterministic fallback where needed
+- deterministic fallback where needed and kept minimal
 - structure constants
 - closure / antisymmetry / Jacobi diagnostics
 - verification-aware interpretation labels

--- a/src/pdelie/symmetry/__init__.py
+++ b/src/pdelie/symmetry/__init__.py
@@ -1,9 +1,11 @@
 from pdelie.symmetry.fitting.translation_baseline import fit_translation_generator
+from pdelie.symmetry.closure import diagnose_generator_family_closure
 from pdelie.symmetry.span import compare_generator_spans
 from pdelie.symmetry.symbolic import render_generator_family, to_sympy_component_expressions
 
 __all__ = [
     "fit_translation_generator",
+    "diagnose_generator_family_closure",
     "compare_generator_spans",
     "render_generator_family",
     "to_sympy_component_expressions",

--- a/src/pdelie/symmetry/_polynomial_metric.py
+++ b/src/pdelie/symmetry/_polynomial_metric.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Private polynomial metric helpers shared by runtime symmetry diagnostics."""
+
+
+def _monomial_average_inner_product(powers_a: tuple[int, ...], powers_b: tuple[int, ...]) -> float:
+    value = 1.0
+    for power_a, power_b in zip(powers_a, powers_b):
+        total_power = int(power_a) + int(power_b)
+        if total_power % 2 == 1:
+            return 0.0
+        value *= 1.0 / float(total_power + 1)
+    return value
+
+
+__all__ = ["_monomial_average_inner_product"]

--- a/src/pdelie/symmetry/closure.py
+++ b/src/pdelie/symmetry/closure.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+"""Runtime-only closure diagnostics for canonical GeneratorFamily objects."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from pdelie.contracts import GeneratorFamily, VerificationReport
+from pdelie.errors import SchemaValidationError, ScopeValidationError, ShapeValidationError
+
+
+_SUPPORTED_INNER_PRODUCTS = frozenset({"normalized_polynomial_l2"})
+_SUPPORTED_COMPUTATION_MODES = frozenset({"auto", "exact_polynomial", "sampled_projection"})
+_RANK_TOL = 1e-10
+_METRIC_EIGEN_TOL = 1e-12
+_RESIDUAL_EPS = 1e-12
+_SAMPLED_GRID_POINTS_PER_AXIS = 5
+_FALLBACK_DOMAIN_BOUND = 1.0
+_SYMMETRY_ALGEBRA_CLASSIFICATIONS = frozenset({"exact", "approximate"})
+
+_Polynomial = dict[tuple[int, ...], float]
+_VectorField = dict[str, _Polynomial]
+
+
+def _validate_component_targets(
+    generator: GeneratorFamily,
+    component_targets: Mapping[str, str] | None,
+) -> dict[str, str]:
+    component_names = [str(name) for name in generator.basis_spec["component_ordering"]]
+    variables = [str(name) for name in generator.basis_spec["variables"]]
+    resolved: dict[str, str] = {}
+
+    if component_targets is not None:
+        if not isinstance(component_targets, Mapping):
+            raise SchemaValidationError("component_targets must be a mapping when provided.")
+        for component_name, target_name in component_targets.items():
+            normalized_component = str(component_name)
+            normalized_target = str(target_name)
+            if normalized_component not in component_names:
+                raise SchemaValidationError(
+                    f"component_targets includes unknown component '{normalized_component}'."
+                )
+            if normalized_target not in variables:
+                raise SchemaValidationError(
+                    f"component_targets maps component '{normalized_component}' to unknown variable '{normalized_target}'."
+                )
+            resolved[normalized_component] = normalized_target
+
+    if component_names == variables:
+        for component_name in component_names:
+            resolved.setdefault(component_name, component_name)
+
+    if variables == ["t", "x", "u"]:
+        special_defaults = {"tau": "t", "xi": "x", "phi": "u"}
+        for component_name, target_name in special_defaults.items():
+            if component_name in component_names:
+                resolved.setdefault(component_name, target_name)
+
+    if "x" in variables and "xi" in component_names:
+        resolved.setdefault("xi", "x")
+
+    for component_name in component_names:
+        if component_name in resolved:
+            continue
+        if "_" in component_name:
+            suffix = component_name.rsplit("_", 1)[1]
+            if suffix in variables:
+                resolved[component_name] = suffix
+
+    missing = [component_name for component_name in component_names if component_name not in resolved]
+    if missing:
+        raise ScopeValidationError(
+            "diagnose_generator_family_closure requires resolved component targets for all components."
+        )
+
+    return {component_name: resolved[component_name] for component_name in component_names}
+
+
+def _canonical_monomial_label(variables: Sequence[str], powers: Sequence[int]) -> str:
+    parts: list[str] = []
+    for variable_name, power in zip(variables, powers):
+        if power == 0:
+            continue
+        if power == 1:
+            parts.append(str(variable_name))
+        else:
+            parts.append(f"{variable_name}^{int(power)}")
+    return "1" if not parts else "*".join(parts)
+
+
+def _supports_exact_polynomial_terms(generator: GeneratorFamily) -> bool:
+    variables = [str(name) for name in generator.basis_spec["variables"]]
+    for term in generator.basis_spec["basis_terms"]:
+        powers = [int(power) for power in term["powers"]]
+        if str(term["label"]) != _canonical_monomial_label(variables, powers):
+            return False
+    return True
+
+
+def _resolve_computation_mode(
+    generator: GeneratorFamily,
+    *,
+    component_targets_resolved: bool,
+    inner_product: str,
+    computation_mode: str,
+) -> str:
+    if inner_product not in _SUPPORTED_INNER_PRODUCTS:
+        raise SchemaValidationError(
+            "diagnose_generator_family_closure only supports inner_product='normalized_polynomial_l2' in V0.4 Milestone 4."
+        )
+    if computation_mode not in _SUPPORTED_COMPUTATION_MODES:
+        raise SchemaValidationError(
+            "computation_mode must be one of {'auto', 'exact_polynomial', 'sampled_projection'}."
+        )
+    if not component_targets_resolved:
+        raise ScopeValidationError(
+            "diagnose_generator_family_closure requires resolved component targets for both exact and sampled modes."
+        )
+
+    exact_supported = _supports_exact_polynomial_terms(generator)
+    if computation_mode == "sampled_projection":
+        return "sampled_projection"
+    if computation_mode == "exact_polynomial":
+        if not exact_supported:
+            raise ScopeValidationError(
+                "exact_polynomial closure diagnostics only support the current canonical monomial polynomial basis_terms in V0.4 Milestone 4."
+            )
+        return "exact_polynomial"
+    if exact_supported:
+        return "exact_polynomial"
+    return "sampled_projection"
+
+
+def _ordered_basis_terms(generator: GeneratorFamily) -> list[dict[str, Any]]:
+    return [
+        {"label": str(term["label"]), "powers": [int(power) for power in term["powers"]]}
+        for term in generator.basis_spec["basis_terms"]
+    ]
+
+
+def _row_to_vector_field(generator: GeneratorFamily, row: np.ndarray) -> _VectorField:
+    component_names = [str(name) for name in generator.basis_spec["component_ordering"]]
+    basis_terms = _ordered_basis_terms(generator)
+    vector_field: _VectorField = {component_name: {} for component_name in component_names}
+    offset = 0
+    for component_name in component_names:
+        component_polynomial = vector_field[component_name]
+        for term in basis_terms:
+            coefficient = float(row[offset])
+            offset += 1
+            if abs(coefficient) <= _RESIDUAL_EPS:
+                continue
+            component_polynomial[tuple(int(power) for power in term["powers"])] = coefficient
+    return vector_field
+
+
+def _clean_polynomial(polynomial: _Polynomial) -> _Polynomial:
+    return {
+        tuple(int(power) for power in powers): float(value)
+        for powers, value in polynomial.items()
+        if abs(float(value)) > _RESIDUAL_EPS
+    }
+
+
+def _poly_add_scaled(target: _Polynomial, source: _Polynomial, scale: float) -> None:
+    for powers, coefficient in source.items():
+        updated = float(target.get(powers, 0.0)) + float(scale) * float(coefficient)
+        if abs(updated) <= _RESIDUAL_EPS:
+            target.pop(powers, None)
+        else:
+            target[powers] = updated
+
+
+def _differentiate_polynomial(polynomial: _Polynomial, variable_index: int) -> _Polynomial:
+    derivative: _Polynomial = {}
+    for powers, coefficient in polynomial.items():
+        power = int(powers[variable_index])
+        if power == 0:
+            continue
+        new_powers = list(powers)
+        new_powers[variable_index] -= 1
+        derivative[tuple(new_powers)] = float(derivative.get(tuple(new_powers), 0.0)) + float(coefficient) * power
+    return _clean_polynomial(derivative)
+
+
+def _multiply_polynomials(left: _Polynomial, right: _Polynomial) -> _Polynomial:
+    product: _Polynomial = {}
+    for left_powers, left_coefficient in left.items():
+        for right_powers, right_coefficient in right.items():
+            powers = tuple(int(a) + int(b) for a, b in zip(left_powers, right_powers))
+            product[powers] = float(product.get(powers, 0.0)) + float(left_coefficient) * float(right_coefficient)
+    return _clean_polynomial(product)
+
+
+def _lie_bracket(
+    left: _VectorField,
+    right: _VectorField,
+    *,
+    component_names: Sequence[str],
+    component_targets: Mapping[str, str],
+    variable_indices: Mapping[str, int],
+) -> _VectorField:
+    bracket: _VectorField = {component_name: {} for component_name in component_names}
+    for output_component in component_names:
+        component_bracket: _Polynomial = {}
+        for derivative_component in component_names:
+            variable_index = int(variable_indices[component_targets[derivative_component]])
+            _poly_add_scaled(
+                component_bracket,
+                _multiply_polynomials(
+                    left[derivative_component],
+                    _differentiate_polynomial(right[output_component], variable_index),
+                ),
+                1.0,
+            )
+            _poly_add_scaled(
+                component_bracket,
+                _multiply_polynomials(
+                    right[derivative_component],
+                    _differentiate_polynomial(left[output_component], variable_index),
+                ),
+                -1.0,
+            )
+        bracket[output_component] = _clean_polynomial(component_bracket)
+    return bracket
+
+
+def _monomial_average_inner_product(powers_a: tuple[int, ...], powers_b: tuple[int, ...]) -> float:
+    value = 1.0
+    for power_a, power_b in zip(powers_a, powers_b):
+        total_power = int(power_a) + int(power_b)
+        if total_power % 2 == 1:
+            return 0.0
+        value *= 1.0 / float(total_power + 1)
+    return value
+
+
+def _polynomial_inner_product(left: _Polynomial, right: _Polynomial) -> float:
+    total = 0.0
+    for left_powers, left_coefficient in left.items():
+        for right_powers, right_coefficient in right.items():
+            total += (
+                float(left_coefficient)
+                * float(right_coefficient)
+                * _monomial_average_inner_product(tuple(left_powers), tuple(right_powers))
+            )
+    return float(total)
+
+
+def _vector_field_inner_product(
+    left: _VectorField,
+    right: _VectorField,
+    *,
+    component_names: Sequence[str],
+    component_weights: Mapping[str, float],
+) -> float:
+    total = 0.0
+    for component_name in component_names:
+        total += float(component_weights[component_name]) * _polynomial_inner_product(
+            left[component_name],
+            right[component_name],
+        )
+    return float(total)
+
+
+def _condition_number(values: np.ndarray) -> float:
+    positive = np.asarray(values, dtype=float)
+    positive = positive[positive > 0.0]
+    if positive.size == 0:
+        return float("inf")
+    minimum = float(np.min(positive))
+    maximum = float(np.max(positive))
+    if minimum == 0.0:
+        return float("inf")
+    return maximum / minimum
+
+
+def _family_metric_summary(metric_matrix: np.ndarray) -> tuple[int, float]:
+    symmetric = 0.5 * (np.asarray(metric_matrix, dtype=float) + np.asarray(metric_matrix, dtype=float).T)
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    max_abs = float(np.max(np.abs(eigenvalues))) if eigenvalues.size else 0.0
+    threshold = max(_RANK_TOL * max_abs, _METRIC_EIGEN_TOL)
+    if np.any(eigenvalues < -threshold):
+        raise ShapeValidationError("Closure diagnostics require a positive semidefinite family metric.")
+    positive = eigenvalues[eigenvalues > threshold]
+    return int(positive.size), _condition_number(positive)
+
+
+def _solve_projection_coefficients(metric_matrix: np.ndarray, rhs: np.ndarray) -> tuple[np.ndarray, float]:
+    coefficients, _, _, singular_values = np.linalg.lstsq(metric_matrix, rhs, rcond=None)
+    return np.asarray(coefficients, dtype=float), _condition_number(np.asarray(singular_values, dtype=float))
+
+
+def _normalized_domain(variables: Sequence[str]) -> dict[str, object]:
+    return {
+        "kind": "normalized_hypercube",
+        "variables": [str(name) for name in variables],
+        "bounds": [[-_FALLBACK_DOMAIN_BOUND, _FALLBACK_DOMAIN_BOUND] for _ in variables],
+    }
+
+
+def _tensor_grid(variables: Sequence[str]) -> np.ndarray:
+    axes = [
+        np.linspace(-_FALLBACK_DOMAIN_BOUND, _FALLBACK_DOMAIN_BOUND, _SAMPLED_GRID_POINTS_PER_AXIS, dtype=float)
+        for _ in variables
+    ]
+    mesh = np.meshgrid(*axes, indexing="ij")
+    return np.stack([axis.reshape(-1) for axis in mesh], axis=1)
+
+
+def _evaluate_polynomial(polynomial: _Polynomial, points: np.ndarray) -> np.ndarray:
+    values = np.zeros(points.shape[0], dtype=float)
+    for powers, coefficient in polynomial.items():
+        term = np.full(points.shape[0], float(coefficient), dtype=float)
+        for variable_index, power in enumerate(powers):
+            if int(power) == 0:
+                continue
+            term *= points[:, variable_index] ** int(power)
+        values += term
+    return values
+
+
+def _evaluate_vector_field(
+    vector_field: _VectorField,
+    *,
+    component_names: Sequence[str],
+    points: np.ndarray,
+) -> np.ndarray:
+    return np.vstack([
+        _evaluate_polynomial(vector_field[component_name], points)
+        for component_name in component_names
+    ])
+
+
+def _sampled_inner_product(
+    left: np.ndarray,
+    right: np.ndarray,
+    *,
+    component_names: Sequence[str],
+    component_weights: Mapping[str, float],
+) -> float:
+    total = 0.0
+    for component_index, component_name in enumerate(component_names):
+        total += float(component_weights[component_name]) * float(
+            np.mean(left[component_index] * right[component_index])
+        )
+    return float(total)
+
+
+def _normalize_verification_reports(
+    verification_reports: Sequence[VerificationReport] | None,
+) -> list[VerificationReport] | None:
+    if verification_reports is None:
+        return None
+    if isinstance(verification_reports, (str, bytes)) or not isinstance(verification_reports, Sequence):
+        raise SchemaValidationError("verification_reports must be a sequence of VerificationReport objects.")
+    normalized: list[VerificationReport] = []
+    for index, report in enumerate(verification_reports):
+        if not isinstance(report, VerificationReport):
+            raise SchemaValidationError(
+                f"verification_reports[{index}] must be a VerificationReport instance."
+            )
+        report.validate()
+        normalized.append(report)
+    return normalized
+
+
+def _interpretation_label(verification_reports: list[VerificationReport] | None) -> tuple[str, list[str] | None]:
+    if verification_reports is None:
+        return "vector_field_algebra_diagnostics", None
+    classifications = [report.classification for report in verification_reports]
+    if classifications and all(
+        classification in _SYMMETRY_ALGEBRA_CLASSIFICATIONS for classification in classifications
+    ):
+        return "symmetry_algebra_diagnostics", classifications
+    return "vector_field_algebra_diagnostics", classifications
+
+
+def diagnose_generator_family_closure(
+    generator: GeneratorFamily,
+    *,
+    verification_reports: Sequence[VerificationReport] | None = None,
+    component_targets: Mapping[str, str] | None = None,
+    inner_product: str = "normalized_polynomial_l2",
+    computation_mode: str = "auto",
+) -> dict[str, object]:
+    """Diagnose runtime closure properties for a canonical polynomial GeneratorFamily."""
+
+    generator.validate()
+
+    normalized_reports = _normalize_verification_reports(verification_reports)
+    interpretation_label, verification_classifications = _interpretation_label(normalized_reports)
+
+    resolved_component_targets = _validate_component_targets(generator, component_targets)
+    resolved_mode = _resolve_computation_mode(
+        generator,
+        component_targets_resolved=True,
+        inner_product=inner_product,
+        computation_mode=computation_mode,
+    )
+
+    component_names = [str(name) for name in generator.basis_spec["component_ordering"]]
+    variables = [str(name) for name in generator.basis_spec["variables"]]
+    variable_indices = {variable_name: index for index, variable_name in enumerate(variables)}
+    component_weights = {component_name: 1.0 for component_name in component_names}
+    family_fields = [
+        _row_to_vector_field(generator, row)
+        for row in np.asarray(generator.coefficients, dtype=float)
+    ]
+    family_size = len(family_fields)
+
+    if resolved_mode == "exact_polynomial":
+        metric_matrix = np.empty((family_size, family_size), dtype=float)
+        for row_index, left in enumerate(family_fields):
+            for col_index, right in enumerate(family_fields):
+                metric_matrix[row_index, col_index] = _vector_field_inner_product(
+                    left,
+                    right,
+                    component_names=component_names,
+                    component_weights=component_weights,
+                )
+        sampled_points = None
+        family_evaluations = None
+        domain: dict[str, object] = _normalized_domain(variables)
+    else:
+        sampled_points = _tensor_grid(variables)
+        family_evaluations = [
+            _evaluate_vector_field(field, component_names=component_names, points=sampled_points)
+            for field in family_fields
+        ]
+        metric_matrix = np.empty((family_size, family_size), dtype=float)
+        for row_index, left in enumerate(family_evaluations):
+            for col_index, right in enumerate(family_evaluations):
+                metric_matrix[row_index, col_index] = _sampled_inner_product(
+                    left,
+                    right,
+                    component_names=component_names,
+                    component_weights=component_weights,
+                )
+        domain = _normalized_domain(variables)
+        domain["grid_points_per_axis"] = _SAMPLED_GRID_POINTS_PER_AXIS
+
+    family_rank, family_condition = _family_metric_summary(metric_matrix)
+    if family_rank != family_size:
+        raise ShapeValidationError(
+            "diagnose_generator_family_closure requires full effective family rank under the runtime metric policy; structure constants are not uniquely defined for a rank-deficient family."
+        )
+
+    structure_tensor = np.zeros((family_size, family_size, family_size), dtype=float)
+    closure_residuals = np.zeros((family_size, family_size), dtype=float)
+    antisymmetry_residuals = np.zeros((family_size, family_size), dtype=float)
+    solve_condition = family_condition
+
+    for left_index, left in enumerate(family_fields):
+        for right_index, right in enumerate(family_fields):
+            raw_bracket = _lie_bracket(
+                left,
+                right,
+                component_names=component_names,
+                component_targets=resolved_component_targets,
+                variable_indices=variable_indices,
+            )
+            if resolved_mode == "exact_polynomial":
+                rhs = np.asarray(
+                    [
+                        _vector_field_inner_product(
+                            raw_bracket,
+                            family_field,
+                            component_names=component_names,
+                            component_weights=component_weights,
+                        )
+                        for family_field in family_fields
+                    ],
+                    dtype=float,
+                )
+                raw_norm_sq = _vector_field_inner_product(
+                    raw_bracket,
+                    raw_bracket,
+                    component_names=component_names,
+                    component_weights=component_weights,
+                )
+            else:
+                assert sampled_points is not None
+                assert family_evaluations is not None
+                raw_evaluation = _evaluate_vector_field(
+                    raw_bracket,
+                    component_names=component_names,
+                    points=sampled_points,
+                )
+                rhs = np.asarray(
+                    [
+                        _sampled_inner_product(
+                            raw_evaluation,
+                            family_evaluation,
+                            component_names=component_names,
+                            component_weights=component_weights,
+                        )
+                        for family_evaluation in family_evaluations
+                    ],
+                    dtype=float,
+                )
+                raw_norm_sq = _sampled_inner_product(
+                    raw_evaluation,
+                    raw_evaluation,
+                    component_names=component_names,
+                    component_weights=component_weights,
+                )
+
+            structure_coefficients, current_solve_condition = _solve_projection_coefficients(metric_matrix, rhs)
+            solve_condition = max(solve_condition, current_solve_condition)
+            structure_tensor[left_index, right_index, :] = structure_coefficients
+
+            projected_norm_sq = float(structure_coefficients @ metric_matrix @ structure_coefficients)
+            residual_sq = max(
+                float(raw_norm_sq) - 2.0 * float(structure_coefficients @ rhs) + projected_norm_sq,
+                0.0,
+            )
+            closure_residuals[left_index, right_index] = float(
+                np.sqrt(residual_sq) / (np.sqrt(max(float(raw_norm_sq), 0.0)) + _RESIDUAL_EPS)
+            )
+
+    for left_index in range(family_size):
+        for right_index in range(left_index, family_size):
+            antisymmetry_numerator = np.linalg.norm(
+                structure_tensor[left_index, right_index, :] + structure_tensor[right_index, left_index, :]
+            )
+            antisymmetry_denominator = (
+                np.linalg.norm(structure_tensor[left_index, right_index, :])
+                + np.linalg.norm(structure_tensor[right_index, left_index, :])
+                + _RESIDUAL_EPS
+            )
+            antisymmetry_value = float(antisymmetry_numerator / antisymmetry_denominator)
+            antisymmetry_residuals[left_index, right_index] = antisymmetry_value
+            antisymmetry_residuals[right_index, left_index] = antisymmetry_value
+
+    jacobi_residuals: list[list[list[float]]] | list[object]
+    if family_size < 3:
+        jacobi_residuals = []
+        jacobi_summary = 0.0
+    else:
+        jacobi_array = np.zeros((family_size, family_size, family_size), dtype=float)
+        for i in range(family_size):
+            for j in range(family_size):
+                for k in range(family_size):
+                    first = np.zeros(family_size, dtype=float)
+                    second = np.zeros(family_size, dtype=float)
+                    third = np.zeros(family_size, dtype=float)
+                    for ell in range(family_size):
+                        first += structure_tensor[i, j, ell] * structure_tensor[ell, k, :]
+                        second += structure_tensor[j, k, ell] * structure_tensor[ell, i, :]
+                        third += structure_tensor[k, i, ell] * structure_tensor[ell, j, :]
+                    numerator = np.linalg.norm(first + second + third)
+                    denominator = np.linalg.norm(first) + np.linalg.norm(second) + np.linalg.norm(third) + _RESIDUAL_EPS
+                    jacobi_array[i, j, k] = float(numerator / denominator)
+        jacobi_residuals = jacobi_array.tolist()
+        jacobi_summary = float(np.max(jacobi_array))
+
+    conditioning = {
+        "family_gram": family_condition,
+        "structure_constant_solve": solve_condition,
+    }
+
+    return {
+        "interpretation_label": interpretation_label,
+        "verification_classifications": verification_classifications,
+        "inner_product": inner_product,
+        "computation_mode": resolved_mode,
+        "domain": domain,
+        "component_weights": component_weights,
+        "component_targets": resolved_component_targets,
+        "family_rank": family_rank,
+        "structure_constants": {
+            "tensor": structure_tensor.tolist(),
+            "estimation_mode": resolved_mode,
+            "conditioning": {
+                "family_gram": family_condition,
+                "structure_constant_solve": solve_condition,
+            },
+        },
+        "closure": {
+            "summary": float(np.max(closure_residuals)),
+            "pairwise_residuals": closure_residuals.tolist(),
+        },
+        "antisymmetry": {
+            "summary": float(np.max(antisymmetry_residuals)),
+            "pairwise_residuals": antisymmetry_residuals.tolist(),
+        },
+        "jacobi": {
+            "summary": jacobi_summary,
+            "triple_residuals": jacobi_residuals,
+            "mode": "structure_constants",
+        },
+        "conditioning": conditioning,
+    }
+
+
+__all__ = ["diagnose_generator_family_closure"]

--- a/src/pdelie/symmetry/closure.py
+++ b/src/pdelie/symmetry/closure.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from pdelie.contracts import GeneratorFamily, VerificationReport
 from pdelie.errors import SchemaValidationError, ScopeValidationError, ShapeValidationError
+from pdelie.symmetry._polynomial_metric import _monomial_average_inner_product
 
 
 _SUPPORTED_INNER_PRODUCTS = frozenset({"normalized_polynomial_l2"})
@@ -17,6 +18,7 @@ _RANK_TOL = 1e-10
 _METRIC_EIGEN_TOL = 1e-12
 _RESIDUAL_EPS = 1e-12
 _SAMPLED_GRID_POINTS_PER_AXIS = 5
+_MAX_SAMPLED_GRID_POINTS = 15625
 _FALLBACK_DOMAIN_BOUND = 1.0
 _SYMMETRY_ALGEBRA_CLASSIFICATIONS = frozenset({"exact", "approximate"})
 
@@ -226,17 +228,6 @@ def _lie_bracket(
         bracket[output_component] = _clean_polynomial(component_bracket)
     return bracket
 
-
-def _monomial_average_inner_product(powers_a: tuple[int, ...], powers_b: tuple[int, ...]) -> float:
-    value = 1.0
-    for power_a, power_b in zip(powers_a, powers_b):
-        total_power = int(power_a) + int(power_b)
-        if total_power % 2 == 1:
-            return 0.0
-        value *= 1.0 / float(total_power + 1)
-    return value
-
-
 def _polynomial_inner_product(left: _Polynomial, right: _Polynomial) -> float:
     total = 0.0
     for left_powers, left_coefficient in left.items():
@@ -302,6 +293,15 @@ def _normalized_domain(variables: Sequence[str]) -> dict[str, object]:
 
 
 def _tensor_grid(variables: Sequence[str]) -> np.ndarray:
+    num_variables = len(variables)
+    total_points = _SAMPLED_GRID_POINTS_PER_AXIS ** num_variables
+    if total_points > _MAX_SAMPLED_GRID_POINTS:
+        raise ScopeValidationError(
+            "sampled_projection fallback is only supported up to "
+            f"{_MAX_SAMPLED_GRID_POINTS} total tensor-grid points in V0.4 Milestone 4; "
+            f"got {total_points} points for {num_variables} variables with "
+            f"{_SAMPLED_GRID_POINTS_PER_AXIS} points per axis."
+        )
     axes = [
         np.linspace(-_FALLBACK_DOMAIN_BOUND, _FALLBACK_DOMAIN_BOUND, _SAMPLED_GRID_POINTS_PER_AXIS, dtype=float)
         for _ in variables

--- a/src/pdelie/symmetry/span.py
+++ b/src/pdelie/symmetry/span.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from pdelie.contracts import GeneratorFamily
 from pdelie.errors import SchemaValidationError, ShapeValidationError
+from pdelie.symmetry._polynomial_metric import _monomial_average_inner_product
 
 
 _SUPPORTED_INNER_PRODUCTS = frozenset({"normalized_polynomial_l2"})
@@ -38,17 +39,6 @@ def _require_structurally_equivalent_basis_spec(
         raise SchemaValidationError(
             "compare_generator_spans requires structurally equivalent basis_spec semantics."
         )
-
-
-def _monomial_average_inner_product(powers_a: tuple[int, ...], powers_b: tuple[int, ...]) -> float:
-    value = 1.0
-    for power_a, power_b in zip(powers_a, powers_b):
-        total_power = int(power_a) + int(power_b)
-        if total_power % 2 == 1:
-            return 0.0
-        value *= 1.0 / float(total_power + 1)
-    return value
-
 
 def _basis_term_gram_matrix(generator: GeneratorFamily) -> np.ndarray:
     basis_terms = [

--- a/tests/test_closure_runtime.py
+++ b/tests/test_closure_runtime.py
@@ -56,6 +56,21 @@ def _velocity_basis_spec(labels: list[str] | None = None) -> dict[str, object]:
     }
 
 
+def _high_dim_velocity_basis_spec(*, labels: list[str], num_variables: int = 7) -> dict[str, object]:
+    variables = [f"x{index}" for index in range(num_variables)]
+    return {
+        "variables": variables,
+        "component_names": ["velocity"],
+        "basis_terms": [
+            {"label": labels[0], "powers": [0] * num_variables},
+            {"label": labels[1], "powers": [1] + [0] * (num_variables - 1)},
+        ],
+        "component_ordering": ["velocity"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
 def _make_generator(
     coefficients: np.ndarray,
     *,
@@ -212,6 +227,34 @@ def test_diagnose_generator_family_closure_sampled_projection_is_deterministic()
     np.testing.assert_allclose(first["structure_constants"]["tensor"], second["structure_constants"]["tensor"], atol=1e-12)
     np.testing.assert_allclose(first["closure"]["pairwise_residuals"], second["closure"]["pairwise_residuals"], atol=1e-12)
     np.testing.assert_allclose(first["antisymmetry"]["pairwise_residuals"], second["antisymmetry"]["pairwise_residuals"], atol=1e-12)
+
+
+def test_diagnose_generator_family_closure_rejects_forced_sampled_projection_when_tensor_grid_exceeds_cap() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0]], dtype=float),
+        basis_spec=_high_dim_velocity_basis_spec(labels=["1", "x0"]),
+    )
+
+    with pytest.raises(ScopeValidationError, match=r"15625.*78125.*7 variables.*5 points per axis"):
+        diagnose_generator_family_closure(
+            generator,
+            component_targets={"velocity": "x0"},
+            computation_mode="sampled_projection",
+        )
+
+
+def test_diagnose_generator_family_closure_auto_mode_raises_same_error_when_fallback_grid_exceeds_cap() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0]], dtype=float),
+        basis_spec=_high_dim_velocity_basis_spec(labels=["offset", "linear"]),
+    )
+
+    with pytest.raises(ScopeValidationError, match=r"15625.*78125.*7 variables.*5 points per axis"):
+        diagnose_generator_family_closure(
+            generator,
+            component_targets={"velocity": "x0"},
+            computation_mode="auto",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_closure_runtime.py
+++ b/tests/test_closure_runtime.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdelie import GeneratorFamily, ScopeValidationError, ShapeValidationError, VerificationReport
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.symmetry import diagnose_generator_family_closure
+
+
+def _txu_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["t", "x", "u"],
+        "component_names": ["tau", "xi", "phi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0, 0, 0]},
+            {"label": "t", "powers": [1, 0, 0]},
+            {"label": "x", "powers": [0, 1, 0]},
+            {"label": "u", "powers": [0, 0, 1]},
+        ],
+        "component_ordering": ["tau", "xi", "phi"],
+        "term_ordering": ["1", "t", "x", "u"],
+        "layout": "component_major",
+    }
+
+
+def _x_basis_spec(labels: list[str] | None = None, powers: list[list[int]] | None = None) -> dict[str, object]:
+    powers = [[0], [1]] if powers is None else powers
+    if labels is None:
+        labels = ["1", "x"] if powers == [[0], [1]] else [("1" if item == [0] else f"x^{item[0]}") for item in powers]
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": label, "powers": power}
+            for label, power in zip(labels, powers)
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _velocity_basis_spec(labels: list[str] | None = None) -> dict[str, object]:
+    labels = ["1", "x"] if labels is None else labels
+    return {
+        "variables": ["x"],
+        "component_names": ["velocity"],
+        "basis_terms": [
+            {"label": labels[0], "powers": [0]},
+            {"label": labels[1], "powers": [1]},
+        ],
+        "component_ordering": ["velocity"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _make_generator(
+    coefficients: np.ndarray,
+    *,
+    basis_spec: dict[str, object],
+    normalization: str = "runtime_fixture",
+    parameterization: str = "algebraic_fixture",
+) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization=parameterization,
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization=normalization,
+        diagnostics={},
+    )
+
+
+def _make_verification_report(classification: str) -> VerificationReport:
+    return VerificationReport(
+        norm="relative_l2",
+        epsilon_values=np.logspace(-4, -1, 7),
+        error_curve=np.full(7, 1e-8 if classification != "failed" else 1.0, dtype=float),
+        classification=classification,
+        diagnostics={},
+    )
+
+
+def test_diagnose_generator_family_closure_commuting_family_is_closed() -> None:
+    generator = _make_generator(
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ],
+            dtype=float,
+        ),
+        basis_spec=_txu_basis_spec(),
+    )
+
+    report = diagnose_generator_family_closure(generator)
+
+    assert report["computation_mode"] == "exact_polynomial"
+    assert report["interpretation_label"] == "vector_field_algebra_diagnostics"
+    assert report["family_rank"] == 2
+    assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert report["antisymmetry"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert report["jacobi"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    np.testing.assert_allclose(report["structure_constants"]["tensor"], np.zeros((2, 2, 2)), atol=1e-12)
+
+
+def test_diagnose_generator_family_closure_reports_expected_affine_structure_constants() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+
+    report = diagnose_generator_family_closure(generator)
+    tensor = np.asarray(report["structure_constants"]["tensor"], dtype=float)
+
+    assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    np.testing.assert_allclose(tensor[0, 1], [1.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(tensor[1, 0], [-1.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(tensor[0, 0], [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(tensor[1, 1], [0.0, 0.0], atol=1e-12)
+
+
+def test_diagnose_generator_family_closure_reports_zero_structure_constant_jacobi_for_closed_three_generator_family() -> None:
+    generator = _make_generator(
+        np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=float,
+        ),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+
+    report = diagnose_generator_family_closure(generator)
+
+    assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert report["jacobi"]["mode"] == "structure_constants"
+    assert report["jacobi"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_diagnose_generator_family_closure_handles_exact_brackets_outside_stored_basis_via_projection() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["x^2", "x^3"], powers=[[2], [3]]),
+    )
+
+    report = diagnose_generator_family_closure(generator)
+
+    assert report["computation_mode"] == "exact_polynomial"
+    assert report["closure"]["summary"] > 1e-6
+    assert report["structure_constants"]["estimation_mode"] == "exact_polynomial"
+
+
+def test_diagnose_generator_family_closure_component_targets_override_inference() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(),
+    )
+
+    report = diagnose_generator_family_closure(generator, component_targets={"velocity": "x"})
+
+    assert report["component_targets"] == {"velocity": "x"}
+    assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_diagnose_generator_family_closure_rejects_unresolved_component_targets() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(),
+    )
+
+    with pytest.raises(ScopeValidationError, match="resolved component targets"):
+        diagnose_generator_family_closure(generator)
+
+
+def test_diagnose_generator_family_closure_rejects_noncanonical_basis_labels_in_exact_mode_and_downgrades_in_auto() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(labels=["offset", "linear"]),
+    )
+
+    with pytest.raises(ScopeValidationError, match="exact_polynomial"):
+        diagnose_generator_family_closure(
+            generator,
+            component_targets={"velocity": "x"},
+            computation_mode="exact_polynomial",
+        )
+
+    report = diagnose_generator_family_closure(
+        generator,
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+
+    assert report["computation_mode"] == "sampled_projection"
+    assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_diagnose_generator_family_closure_sampled_projection_is_deterministic() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+
+    first = diagnose_generator_family_closure(generator, computation_mode="sampled_projection")
+    second = diagnose_generator_family_closure(generator, computation_mode="sampled_projection")
+
+    assert first["computation_mode"] == "sampled_projection"
+    np.testing.assert_allclose(first["structure_constants"]["tensor"], second["structure_constants"]["tensor"], atol=1e-12)
+    np.testing.assert_allclose(first["closure"]["pairwise_residuals"], second["closure"]["pairwise_residuals"], atol=1e-12)
+    np.testing.assert_allclose(first["antisymmetry"]["pairwise_residuals"], second["antisymmetry"]["pairwise_residuals"], atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("verification_reports", "expected_label", "expected_classifications"),
+    [
+        (None, "vector_field_algebra_diagnostics", None),
+        ([], "vector_field_algebra_diagnostics", []),
+        ([("failed")], "vector_field_algebra_diagnostics", ["failed"]),
+        ([("exact"), ("approximate")], "symmetry_algebra_diagnostics", ["exact", "approximate"]),
+        ([("exact"), ("failed")], "vector_field_algebra_diagnostics", ["exact", "failed"]),
+    ],
+)
+def test_diagnose_generator_family_closure_uses_family_aware_interpretation_labels(
+    verification_reports: list[str] | None,
+    expected_label: str,
+    expected_classifications: list[str] | None,
+) -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+    reports = (
+        None
+        if verification_reports is None
+        else [_make_verification_report(classification) for classification in verification_reports]
+    )
+
+    report = diagnose_generator_family_closure(generator, verification_reports=reports)
+
+    assert report["interpretation_label"] == expected_label
+    assert report["verification_classifications"] == expected_classifications
+
+
+def test_diagnose_generator_family_closure_rejects_rank_deficient_family_with_degeneracy_message() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [2.0, 0.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+
+    with pytest.raises(ShapeValidationError, match="rank-deficient family"):
+        diagnose_generator_family_closure(generator)
+
+
+def test_diagnose_generator_family_closure_returns_required_core_report_schema() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+
+    report = diagnose_generator_family_closure(generator)
+
+    assert set(report) == {
+        "interpretation_label",
+        "verification_classifications",
+        "inner_product",
+        "computation_mode",
+        "domain",
+        "component_weights",
+        "component_targets",
+        "family_rank",
+        "structure_constants",
+        "closure",
+        "antisymmetry",
+        "jacobi",
+        "conditioning",
+    }
+    assert set(report["structure_constants"]) == {"tensor", "estimation_mode", "conditioning"}
+    assert set(report["closure"]) == {"summary", "pairwise_residuals"}
+    assert set(report["antisymmetry"]) == {"summary", "pairwise_residuals"}
+    assert set(report["jacobi"]) == {"summary", "triple_residuals", "mode"}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,6 +29,7 @@ def test_runtime_package_api_is_importable() -> None:
     from pdelie.invariants import InvariantApplier
     from pdelie.symmetry import (
         compare_generator_spans,
+        diagnose_generator_family_closure,
         render_generator_family,
         to_sympy_component_expressions,
     )
@@ -36,6 +37,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
     assert compare_generator_spans is not None
+    assert diagnose_generator_family_closure is not None
     assert render_generator_family is not None
     assert to_sympy_component_expressions is not None
 
@@ -44,6 +46,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
     assert not hasattr(pdelie, "compare_generator_spans")
+    assert not hasattr(pdelie, "diagnose_generator_family_closure")
     assert not hasattr(pdelie, "render_generator_family")
     assert not hasattr(pdelie, "to_sympy_component_expressions")
 
@@ -62,10 +65,11 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 
 
-def test_symmetry_package_runtime_api_matches_frozen_m3_surface() -> None:
+def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     symmetry_module = importlib.import_module("pdelie.symmetry")
 
     assert hasattr(symmetry_module, "fit_translation_generator")
+    assert hasattr(symmetry_module, "diagnose_generator_family_closure")
     assert hasattr(symmetry_module, "compare_generator_spans")
     assert hasattr(symmetry_module, "render_generator_family")
     assert hasattr(symmetry_module, "to_sympy_component_expressions")


### PR DESCRIPTION
This PR implements V0.4 Milestone 4: Runtime closure diagnostics.

It adds a runtime-only helper for diagnosing algebraic closure properties of GeneratorFamily objects, without modifying canonical objects, fitting behavior, or existing PDE workflows.

The goal of this milestone is to extend the v0.4 inspection layer from:
	•	symbolic display (M2)
	•	span diagnostics (M3)

to:
	•	closure and Lie-algebra diagnostics (M4)

under a strictly algebraic, runtime-only scope.