### PR TITLE
Feat/v0 4 minimal viz

### DIFF
--- a/API_STABILITY.md
+++ b/API_STABILITY.md
@@ -44,6 +44,14 @@ Runtime public API for the frozen `v0.4` Milestone 4 slice:
 
 - `pdelie.symmetry.diagnose_generator_family_closure` for runtime-only closure, structure-constant, and algebra-diagnostic reports on canonical polynomial `GeneratorFamily` objects
 
+Runtime public API for the frozen `v0.4` Milestone 5 slice:
+
+- `pdelie.viz.plot_generator_coefficients` for optional Matplotlib coefficient-bar figures over canonical `GeneratorFamily` objects
+- `pdelie.viz.plot_generator_symbolic_summary` for optional Matplotlib text-summary figures over runtime symbolic rendering output
+- `pdelie.viz.plot_verification_curve` for optional Matplotlib verification-curve figures over `VerificationReport`
+- `pdelie.viz.plot_span_diagnostics` for optional Matplotlib figures over frozen M3 span-diagnostic reports
+- `pdelie.viz.plot_closure_diagnostics` for optional Matplotlib figures over frozen M4 closure-diagnostic reports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.4 Milestone 4 — Runtime closure diagnostics**
+**V0.4 Milestone 5 — Minimal visualization suite**
 
 This file is the active execution plan for the current `v0.4` release series.
 
@@ -38,62 +38,55 @@ Completed outcome:
 
 ---
 
-## Milestone 4 — Runtime Closure Diagnostics
+## Milestone 5 — Minimal Visualization Suite
 
 ### Goal
 
-Add deterministic runtime-only closure diagnostics for canonical polynomial `GeneratorFamily` objects without changing canonical storage, fitting behavior, or the Heat/Burgers stable paths.
+Add a minimal report-first optional visualization layer over existing canonical objects and frozen runtime reports without changing scientific semantics or the Heat/Burgers stable paths.
 
 ### Frozen Decisions
 
-- `GeneratorFamily` canonical core from Milestone 1 remains unchanged
-- closure diagnostics are runtime-only and must not mutate stored coefficients or normalization
-- closure remains secondary to dynamical validity and supplied verification evidence
-- `normalized_polynomial_l2` is the only supported M4 inner-product mode
-- exact polynomial closure is frozen only for the current monomial algebraic/runtime polynomial scope
-- exact brackets may use an internal expanded polynomial representation, but that representation is not canonical
-- structure constants are estimated from projected brackets onto the stored family span
-- antisymmetry and Jacobi diagnostics are structure-constant diagnostics, not raw vector-field Jacobi claims
-- sampled fallback is minimal and deterministic, and only a compatibility path
-- no fitting changes in M4
-- no visualization in M4
+- visualization is runtime-only and must not mutate stored coefficients, normalization, or diagnostics
+- `pdelie.viz` is an optional package and must not be exported from root `pdelie`
+- Matplotlib is the only M5 visualization dependency
+- renderers must consume existing canonical objects or frozen runtime report dicts only
+- no new visualization-specific contracts or canonical objects are introduced
+- no field rollout heatmaps, transformed-field plots, animation, or interactive backends are part of M5
+- no fitting, verification, span, or closure semantics change in M5
 
 ### Deliverables
 
-- runtime-only closure diagnostic helper under `pdelie.symmetry`
-- exact polynomial Lie-bracket diagnostics for canonical monomial polynomial generator families
-- projected structure-constant diagnostics and closure residuals
-- structure-constant antisymmetry and Jacobi diagnostics
-- family-aware interpretation labels based on supplied verification evidence
-- minimal deterministic sampled fallback coverage on one controlled fixture
+- optional `pdelie.viz` runtime package
+- coefficient-bar renderer for `GeneratorFamily`
+- symbolic summary renderer using M2 symbolic display
+- verification-curve renderer for `VerificationReport`
+- span-diagnostics renderer over the frozen M3 report schema
+- closure-diagnostics renderer over the frozen M4 report schema
 
 ### Acceptance Criteria
 
-Milestone 4 is complete only if:
+Milestone 5 is complete only if:
 
 - existing Heat/Burgers stable paths still pass unchanged
-- canonical `GeneratorFamily` contracts remain unchanged
-- commuting closed families report zero closure, antisymmetry, and Jacobi summaries
-- closed nontrivial affine families report the expected structure constants
-- unresolved component-target semantics fail with typed validation errors
-- rank-deficient families fail with typed validation errors under the runtime metric policy
+- canonical objects and runtime scientific report semantics remain unchanged
+- `pdelie.viz` is importable only through the optional visualization package path
+- each M5 renderer returns a Matplotlib `Figure`
+- malformed runtime report dicts fail with typed validation errors
 - no new canonical object is introduced
-- no public fitting, invariant, visualization, or canonical semantics are broadened
+- no public fitting, invariant, span, closure, or canonical semantics are broadened
 
 ### Test Plan
 
 Run at minimum:
 
-- runtime closure diagnostic tests
+- runtime visualization tests
 - runtime public API import tests
-- commuting-family closure tests
-- affine structure-constant tests
-- structure-constant Jacobi tests on a closed three-generator family
-- exact-bracket projection tests when brackets leave the stored basis
-- explicit component-target override and unresolved-target failure tests
-- minimal sampled fallback determinism tests
-- family-aware interpretation-label tests
-- rank-deficient family tests
+- coefficient-bar structural tests
+- symbolic-summary text tests
+- verification-curve log-scale tests
+- span-plot report-shape tests
+- closure-plot report-shape tests
+- malformed-report validation tests
 - existing Heat/Burgers regression tests
 - full `pytest`
 
@@ -103,7 +96,6 @@ Run at minimum:
 
 Strict sequencing for `v0.4`:
 
-- Milestone 5: minimal visualization as renderers only and deferrable
 - Milestone 6: algebra-span release gate
 
 Hard sequencing rules:
@@ -133,6 +125,6 @@ Hard sequencing rules:
 - Milestone 1: **COMPLETE**
 - Milestone 2: **COMPLETE**
 - Milestone 3: **COMPLETE**
-- Milestone 4: **ACTIVE**
-- Milestone 5: **PLANNED**
+- Milestone 4: **COMPLETE**
+- Milestone 5: **ACTIVE**
 - Milestone 6: **PLANNED**

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -338,7 +338,7 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - controlled algebraic fixtures
 
 ### Milestone 4 — Closure diagnostics
-**Status:** Active
+**Status:** Complete
 
 - exact polynomial Lie brackets where supported
 - deterministic fallback where needed and kept minimal
@@ -347,11 +347,17 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - verification-aware interpretation labels
 
 ### Milestone 5 — Minimal visualization
-**Status:** Planned
+**Status:** Active
 
 - optional `[viz]` extra only
-- visualization consumes existing runtime reports only
+- visualization consumes existing canonical objects and runtime reports only
 - no visualization-specific contracts
+- coefficient-bar renderer for `GeneratorFamily`
+- symbolic summary renderer using the frozen M2 symbolic display
+- verification-curve renderer for `VerificationReport`
+- span-diagnostics renderer for the frozen M3 report shape
+- closure-diagnostics renderer for the frozen M4 report shape
+- no transformed-field plots, rollout heatmaps, animation, or interactive backends
 - explicitly deferrable first if M1–M4 take longer than expected
 
 ### Milestone 6 — Algebra-span release gate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,12 @@ downstream = [
   "pysindy>=1.7.5,<2; python_version < '3.12'",
   "scikit-learn>=1.2.2,<1.3; python_version < '3.12'",
 ]
+viz = [
+  "matplotlib>=3.7,<4",
+]
 test = [
   "build>=1.2",
+  "matplotlib>=3.7,<4",
   "pysindy>=1.7.5,<2; python_version < '3.12'",
   "scikit-learn>=1.2.2,<1.3; python_version < '3.12'",
   "pytest>=7.4",

--- a/src/pdelie/viz/__init__.py
+++ b/src/pdelie/viz/__init__.py
@@ -1,0 +1,15 @@
+from pdelie.viz.closure import plot_closure_diagnostics
+from pdelie.viz.generators import (
+    plot_generator_coefficients,
+    plot_generator_symbolic_summary,
+)
+from pdelie.viz.span import plot_span_diagnostics
+from pdelie.viz.verification import plot_verification_curve
+
+__all__ = [
+    "plot_closure_diagnostics",
+    "plot_generator_coefficients",
+    "plot_generator_symbolic_summary",
+    "plot_span_diagnostics",
+    "plot_verification_curve",
+]

--- a/src/pdelie/viz/_matplotlib.py
+++ b/src/pdelie/viz/_matplotlib.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+_MATPLOTLIB_IMPORT_ERROR = "Matplotlib is required for pdelie.viz. Install pdelie[viz] or pdelie[test]."
+
+
+def require_pyplot() -> ModuleType:
+    try:
+        return importlib.import_module("matplotlib.pyplot")
+    except ModuleNotFoundError as exc:
+        missing_name = exc.name or ""
+        if missing_name == "matplotlib" or missing_name.startswith("matplotlib."):
+            raise ImportError(_MATPLOTLIB_IMPORT_ERROR) from exc
+        raise
+
+
+__all__ = ["require_pyplot"]

--- a/src/pdelie/viz/closure.py
+++ b/src/pdelie/viz/closure.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.figure import Figure
 
 from pdelie.errors import SchemaValidationError
+from pdelie.viz._matplotlib import require_pyplot
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
 
 _ZERO_RESIDUAL_TOL = 1e-12
 _NEAR_ZERO_RESIDUAL_TOL = 1e-6
@@ -31,7 +35,7 @@ def _matrix_status(matrix: np.ndarray) -> str:
     return f"Nonzero residuals present (max {_format_residual(max_value)})"
 
 
-def _annotate_residual_matrix(axis: plt.Axes, matrix: np.ndarray) -> None:
+def _annotate_residual_matrix(axis: Axes, matrix: np.ndarray) -> None:
     if matrix.size > _ANNOTATION_CELL_LIMIT:
         return
     threshold = 0.5
@@ -125,8 +129,12 @@ def _validate_closure_report(
             raise SchemaValidationError(
                 f"Closure diagnostics section '{section_name}' must include 'summary' and 'pairwise_residuals'."
             )
-    if "summary" not in jacobi or "triple_residuals" not in jacobi:
-        raise SchemaValidationError("Closure diagnostics section 'jacobi' must include 'summary' and 'triple_residuals'.")
+    if "summary" not in jacobi or "triple_residuals" not in jacobi or "mode" not in jacobi:
+        raise SchemaValidationError(
+            "Closure diagnostics section 'jacobi' must include 'summary', 'triple_residuals', and 'mode'."
+        )
+    if not isinstance(jacobi["mode"], str) or not jacobi["mode"]:
+        raise SchemaValidationError("Closure diagnostics section 'jacobi' field 'mode' must be a non-empty string.")
 
     structure_constants = _require_structure_constants(report)
     return closure, antisymmetry, jacobi, structure_constants
@@ -135,6 +143,7 @@ def _validate_closure_report(
 def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
     """Plot summary heatmaps for an existing closure-diagnostics report."""
 
+    plt = require_pyplot()
     if not isinstance(report, Mapping):
         raise SchemaValidationError("Closure diagnostics input must be a mapping.")
 

--- a/src/pdelie/viz/closure.py
+++ b/src/pdelie/viz/closure.py
@@ -67,18 +67,21 @@ def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
     if closure_matrix.shape != antisymmetry_matrix.shape:
         raise SchemaValidationError("Closure and antisymmetry pairwise_residuals must have matching shapes.")
 
-    figure, axes = plt.subplots(1, 3, figsize=(12.0, 3.8))
+    figure, axes = plt.subplots(1, 3, figsize=(12.0, 3.8), constrained_layout=True)
 
     closure_axis, antisymmetry_axis, jacobi_axis = axes
-    closure_axis.imshow(closure_matrix, cmap="viridis", aspect="auto")
+    closure_image = closure_axis.imshow(closure_matrix, cmap="viridis", aspect="auto", vmin=0.0, vmax=1.0)
     closure_axis.set_title("Closure")
     closure_axis.set_xlabel("j")
     closure_axis.set_ylabel("i")
 
-    antisymmetry_axis.imshow(antisymmetry_matrix, cmap="viridis", aspect="auto")
+    antisymmetry_axis.imshow(antisymmetry_matrix, cmap="viridis", aspect="auto", vmin=0.0, vmax=1.0)
     antisymmetry_axis.set_title("Antisymmetry")
     antisymmetry_axis.set_xlabel("j")
     antisymmetry_axis.set_ylabel("i")
+
+    shared_colorbar = figure.colorbar(closure_image, ax=[closure_axis, antisymmetry_axis], fraction=0.046, pad=0.04)
+    shared_colorbar.set_label("Residual")
 
     jacobi_axis.set_axis_off()
     jacobi_axis.set_title("Jacobi")
@@ -101,7 +104,6 @@ def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
     else:
         jacobi_axis.text(0.02, 0.62, "No triple residuals", transform=jacobi_axis.transAxes, va="top")
 
-    figure.tight_layout()
     return figure
 
 

--- a/src/pdelie/viz/closure.py
+++ b/src/pdelie/viz/closure.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+
+from pdelie.errors import SchemaValidationError
+
+
+def _require_mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _validate_closure_report(report: Mapping[str, object]) -> tuple[Mapping[str, object], Mapping[str, object], Mapping[str, object]]:
+    required_keys = {
+        "interpretation_label",
+        "verification_classifications",
+        "inner_product",
+        "computation_mode",
+        "domain",
+        "component_weights",
+        "component_targets",
+        "family_rank",
+        "structure_constants",
+        "closure",
+        "antisymmetry",
+        "jacobi",
+        "conditioning",
+    }
+    missing = sorted(required_keys.difference(report))
+    if missing:
+        raise SchemaValidationError(f"Closure diagnostics report is missing required keys: {missing}.")
+
+    closure = _require_mapping(report["closure"], "closure")
+    antisymmetry = _require_mapping(report["antisymmetry"], "antisymmetry")
+    jacobi = _require_mapping(report["jacobi"], "jacobi")
+
+    for section_name, section in (("closure", closure), ("antisymmetry", antisymmetry)):
+        if "summary" not in section or "pairwise_residuals" not in section:
+            raise SchemaValidationError(
+                f"Closure diagnostics section '{section_name}' must include 'summary' and 'pairwise_residuals'."
+            )
+    if "summary" not in jacobi or "triple_residuals" not in jacobi:
+        raise SchemaValidationError("Closure diagnostics section 'jacobi' must include 'summary' and 'triple_residuals'.")
+
+    return closure, antisymmetry, jacobi
+
+
+def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
+    """Plot summary heatmaps for an existing closure-diagnostics report."""
+
+    if not isinstance(report, Mapping):
+        raise SchemaValidationError("Closure diagnostics input must be a mapping.")
+
+    closure, antisymmetry, jacobi = _validate_closure_report(report)
+    closure_matrix = np.asarray(closure["pairwise_residuals"], dtype=float)
+    antisymmetry_matrix = np.asarray(antisymmetry["pairwise_residuals"], dtype=float)
+    jacobi_summary = float(jacobi["summary"])
+    triple_residuals = np.asarray(jacobi["triple_residuals"], dtype=float)
+
+    if closure_matrix.ndim != 2 or antisymmetry_matrix.ndim != 2:
+        raise SchemaValidationError("Closure and antisymmetry pairwise_residuals must be two-dimensional.")
+    if closure_matrix.shape != antisymmetry_matrix.shape:
+        raise SchemaValidationError("Closure and antisymmetry pairwise_residuals must have matching shapes.")
+
+    figure, axes = plt.subplots(1, 3, figsize=(12.0, 3.8))
+
+    closure_axis, antisymmetry_axis, jacobi_axis = axes
+    closure_axis.imshow(closure_matrix, cmap="viridis", aspect="auto")
+    closure_axis.set_title("Closure")
+    closure_axis.set_xlabel("j")
+    closure_axis.set_ylabel("i")
+
+    antisymmetry_axis.imshow(antisymmetry_matrix, cmap="viridis", aspect="auto")
+    antisymmetry_axis.set_title("Antisymmetry")
+    antisymmetry_axis.set_xlabel("j")
+    antisymmetry_axis.set_ylabel("i")
+
+    jacobi_axis.set_axis_off()
+    jacobi_axis.set_title("Jacobi")
+    jacobi_axis.text(0.02, 0.82, f"Summary: {jacobi_summary:.3g}", transform=jacobi_axis.transAxes, va="top")
+    if triple_residuals.size > 0:
+        jacobi_axis.text(
+            0.02,
+            0.62,
+            f"Max triple residual: {float(np.max(triple_residuals)):.3g}",
+            transform=jacobi_axis.transAxes,
+            va="top",
+        )
+        jacobi_axis.text(
+            0.02,
+            0.42,
+            f"Triple tensor shape: {tuple(int(dim) for dim in triple_residuals.shape)}",
+            transform=jacobi_axis.transAxes,
+            va="top",
+        )
+    else:
+        jacobi_axis.text(0.02, 0.62, "No triple residuals", transform=jacobi_axis.transAxes, va="top")
+
+    figure.tight_layout()
+    return figure
+
+
+__all__ = ["plot_closure_diagnostics"]

--- a/src/pdelie/viz/closure.py
+++ b/src/pdelie/viz/closure.py
@@ -8,6 +8,85 @@ from matplotlib.figure import Figure
 
 from pdelie.errors import SchemaValidationError
 
+_ZERO_RESIDUAL_TOL = 1e-12
+_NEAR_ZERO_RESIDUAL_TOL = 1e-6
+_ANNOTATION_CELL_LIMIT = 25
+
+
+def _format_residual(value: float) -> str:
+    absolute = abs(float(value))
+    if absolute <= _ZERO_RESIDUAL_TOL:
+        return "0"
+    if absolute < 1e-3:
+        return f"{float(value):.1e}"
+    return f"{float(value):.3f}"
+
+
+def _matrix_status(matrix: np.ndarray) -> str:
+    max_value = float(np.max(matrix)) if matrix.size else 0.0
+    if max_value <= _ZERO_RESIDUAL_TOL:
+        return "All entries = 0"
+    if max_value <= _NEAR_ZERO_RESIDUAL_TOL:
+        return f"Near-zero residuals (max {_format_residual(max_value)})"
+    return f"Nonzero residuals present (max {_format_residual(max_value)})"
+
+
+def _annotate_residual_matrix(axis: plt.Axes, matrix: np.ndarray) -> None:
+    if matrix.size > _ANNOTATION_CELL_LIMIT:
+        return
+    threshold = 0.5
+    for row_index in range(matrix.shape[0]):
+        for col_index in range(matrix.shape[1]):
+            value = float(matrix[row_index, col_index])
+            axis.text(
+                col_index,
+                row_index,
+                _format_residual(value),
+                ha="center",
+                va="center",
+                fontsize=8,
+                color="white" if value >= threshold else "black",
+            )
+
+
+def _require_structure_constants(report: Mapping[str, object]) -> Mapping[str, object]:
+    structure_constants = _require_mapping(report["structure_constants"], "structure_constants")
+    if "tensor" not in structure_constants:
+        raise SchemaValidationError("Closure diagnostics field 'structure_constants' must include 'tensor'.")
+    return structure_constants
+
+
+def _jacobi_summary_lines(
+    *,
+    jacobi_summary: float,
+    triple_residuals: np.ndarray,
+    jacobi_mode: str,
+    structure_tensor: np.ndarray,
+) -> list[str]:
+    lines = [f"Mode: {jacobi_mode}", f"Summary: {_format_residual(jacobi_summary)}"]
+    if triple_residuals.size == 0:
+        lines.append("No triple residuals reported")
+    else:
+        max_triple = float(np.max(triple_residuals))
+        near_zero_count = int(np.count_nonzero(triple_residuals <= _NEAR_ZERO_RESIDUAL_TOL))
+        total_count = int(triple_residuals.size)
+        lines.extend(
+            [
+                f"Max triple residual: {_format_residual(max_triple)}",
+                f"Triple tensor shape: {tuple(int(dim) for dim in triple_residuals.shape)}",
+                f"Near-zero triples: {near_zero_count}/{total_count}",
+            ]
+        )
+    nonzero_structure_constants = int(np.count_nonzero(np.abs(structure_tensor) > _ZERO_RESIDUAL_TOL))
+    max_structure_constant = float(np.max(np.abs(structure_tensor))) if structure_tensor.size else 0.0
+    lines.extend(
+        [
+            f"Nonzero structure constants: {nonzero_structure_constants}",
+            f"Max |c_ijk|: {_format_residual(max_structure_constant)}",
+        ]
+    )
+    return lines
+
 
 def _require_mapping(value: object, name: str) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
@@ -15,7 +94,9 @@ def _require_mapping(value: object, name: str) -> Mapping[str, object]:
     return value
 
 
-def _validate_closure_report(report: Mapping[str, object]) -> tuple[Mapping[str, object], Mapping[str, object], Mapping[str, object]]:
+def _validate_closure_report(
+    report: Mapping[str, object],
+) -> tuple[Mapping[str, object], Mapping[str, object], Mapping[str, object], Mapping[str, object]]:
     required_keys = {
         "interpretation_label",
         "verification_classifications",
@@ -47,7 +128,8 @@ def _validate_closure_report(report: Mapping[str, object]) -> tuple[Mapping[str,
     if "summary" not in jacobi or "triple_residuals" not in jacobi:
         raise SchemaValidationError("Closure diagnostics section 'jacobi' must include 'summary' and 'triple_residuals'.")
 
-    return closure, antisymmetry, jacobi
+    structure_constants = _require_structure_constants(report)
+    return closure, antisymmetry, jacobi, structure_constants
 
 
 def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
@@ -56,11 +138,13 @@ def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
     if not isinstance(report, Mapping):
         raise SchemaValidationError("Closure diagnostics input must be a mapping.")
 
-    closure, antisymmetry, jacobi = _validate_closure_report(report)
+    closure, antisymmetry, jacobi, structure_constants = _validate_closure_report(report)
     closure_matrix = np.asarray(closure["pairwise_residuals"], dtype=float)
     antisymmetry_matrix = np.asarray(antisymmetry["pairwise_residuals"], dtype=float)
     jacobi_summary = float(jacobi["summary"])
     triple_residuals = np.asarray(jacobi["triple_residuals"], dtype=float)
+    jacobi_mode = str(jacobi["mode"])
+    structure_tensor = np.asarray(structure_constants["tensor"], dtype=float)
 
     if closure_matrix.ndim != 2 or antisymmetry_matrix.ndim != 2:
         raise SchemaValidationError("Closure and antisymmetry pairwise_residuals must be two-dimensional.")
@@ -74,35 +158,49 @@ def plot_closure_diagnostics(report: Mapping[str, object]) -> Figure:
     closure_axis.set_title("Closure")
     closure_axis.set_xlabel("j")
     closure_axis.set_ylabel("i")
+    closure_axis.set_xticks(np.arange(closure_matrix.shape[1], dtype=float))
+    closure_axis.set_yticks(np.arange(closure_matrix.shape[0], dtype=float))
+    closure_axis.text(0.02, 0.98, _matrix_status(closure_matrix), transform=closure_axis.transAxes, va="top", fontsize=9)
+    _annotate_residual_matrix(closure_axis, closure_matrix)
 
     antisymmetry_axis.imshow(antisymmetry_matrix, cmap="viridis", aspect="auto", vmin=0.0, vmax=1.0)
     antisymmetry_axis.set_title("Antisymmetry")
     antisymmetry_axis.set_xlabel("j")
     antisymmetry_axis.set_ylabel("i")
+    antisymmetry_axis.set_xticks(np.arange(antisymmetry_matrix.shape[1], dtype=float))
+    antisymmetry_axis.set_yticks(np.arange(antisymmetry_matrix.shape[0], dtype=float))
+    antisymmetry_axis.text(
+        0.02,
+        0.98,
+        _matrix_status(antisymmetry_matrix),
+        transform=antisymmetry_axis.transAxes,
+        va="top",
+        fontsize=9,
+    )
+    _annotate_residual_matrix(antisymmetry_axis, antisymmetry_matrix)
 
     shared_colorbar = figure.colorbar(closure_image, ax=[closure_axis, antisymmetry_axis], fraction=0.046, pad=0.04)
     shared_colorbar.set_label("Residual")
+    shared_colorbar.set_ticks([0.0, 0.25, 0.5, 0.75, 1.0])
 
     jacobi_axis.set_axis_off()
     jacobi_axis.set_title("Jacobi")
-    jacobi_axis.text(0.02, 0.82, f"Summary: {jacobi_summary:.3g}", transform=jacobi_axis.transAxes, va="top")
-    if triple_residuals.size > 0:
-        jacobi_axis.text(
-            0.02,
-            0.62,
-            f"Max triple residual: {float(np.max(triple_residuals)):.3g}",
-            transform=jacobi_axis.transAxes,
-            va="top",
-        )
-        jacobi_axis.text(
-            0.02,
-            0.42,
-            f"Triple tensor shape: {tuple(int(dim) for dim in triple_residuals.shape)}",
-            transform=jacobi_axis.transAxes,
-            va="top",
-        )
-    else:
-        jacobi_axis.text(0.02, 0.62, "No triple residuals", transform=jacobi_axis.transAxes, va="top")
+    jacobi_axis.text(
+        0.02,
+        0.92,
+        "\n".join(
+            _jacobi_summary_lines(
+                jacobi_summary=jacobi_summary,
+                triple_residuals=triple_residuals,
+                jacobi_mode=jacobi_mode,
+                structure_tensor=structure_tensor,
+            )
+        ),
+        transform=jacobi_axis.transAxes,
+        va="top",
+        fontsize=9.5,
+        linespacing=1.35,
+    )
 
     return figure
 

--- a/src/pdelie/viz/generators.py
+++ b/src/pdelie/viz/generators.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.figure import Figure
 
 from pdelie.contracts import GeneratorFamily
 from pdelie.symmetry import render_generator_family
+from pdelie.viz._matplotlib import require_pyplot
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
 
 _ZERO_DISPLAY_TOL = 1e-12
 
@@ -79,6 +81,7 @@ def plot_generator_coefficients(
 ) -> Figure:
     """Plot stored generator coefficients as deterministic horizontal bar charts."""
 
+    plt = require_pyplot()
     generator.validate()
     labels = _flattened_basis_labels(generator)
     rows = _display_rows(np.asarray(generator.coefficients, dtype=float), normalize_for_display=normalize_for_display)
@@ -139,6 +142,7 @@ def plot_generator_symbolic_summary(
 ) -> Figure:
     """Render stored generators as symbolic text inside a simple figure."""
 
+    plt = require_pyplot()
     generator.validate()
     lines: Sequence[str] = render_generator_family(generator, display_normalization=display_normalization)
     figure, axis = plt.subplots(figsize=_symbolic_summary_figure_size(lines))

--- a/src/pdelie/viz/generators.py
+++ b/src/pdelie/viz/generators.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Sequence
 
 import matplotlib.pyplot as plt
@@ -8,6 +9,8 @@ from matplotlib.figure import Figure
 
 from pdelie.contracts import GeneratorFamily
 from pdelie.symmetry import render_generator_family
+
+_ZERO_DISPLAY_TOL = 1e-12
 
 
 def _flattened_basis_labels(generator: GeneratorFamily) -> list[str]:
@@ -34,6 +37,41 @@ def _subplot_titles(generator: GeneratorFamily) -> list[str]:
     return [f"X_{index}" for index in range(1, generator.coefficients.shape[0] + 1)]
 
 
+def _coefficient_tick_step(num_labels: int) -> int:
+    return max(1, math.ceil(num_labels / 24))
+
+
+def _ordinal(value: int) -> str:
+    if 10 <= value % 100 <= 20:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(value % 10, "th")
+    return f"{value}{suffix}"
+
+
+def _coefficient_tick_fontsize(num_labels: int) -> float:
+    return max(7.0, 10.0 - 0.06 * max(num_labels - 12, 0))
+
+
+def _coefficient_row_height(num_labels: int) -> float:
+    return min(5.5, max(2.5, 1.7 + 0.09 * num_labels))
+
+
+def _symbolic_summary_fontsize(lines: Sequence[str]) -> float:
+    max_line_length = max((len(line) for line in lines), default=0)
+    line_count = len(lines)
+    size = 11.0 - 0.22 * max(line_count - 4, 0) - 0.03 * max(max_line_length - 36, 0)
+    return max(8.0, min(11.0, size))
+
+
+def _symbolic_summary_figure_size(lines: Sequence[str]) -> tuple[float, float]:
+    max_line_length = max((len(line) for line in lines), default=0)
+    line_count = max(len(lines), 1)
+    width = min(14.0, max(8.0, 7.5 + 0.045 * max_line_length))
+    height = min(7.0, max(2.2, 1.15 + 0.42 * line_count))
+    return width, height
+
+
 def plot_generator_coefficients(
     generator: GeneratorFamily,
     *,
@@ -45,23 +83,50 @@ def plot_generator_coefficients(
     labels = _flattened_basis_labels(generator)
     rows = _display_rows(np.asarray(generator.coefficients, dtype=float), normalize_for_display=normalize_for_display)
     titles = _subplot_titles(generator)
+    num_labels = len(labels)
+    tick_step = _coefficient_tick_step(num_labels)
+    tick_fontsize = _coefficient_tick_fontsize(num_labels)
+    displayed_labels = [label if index % tick_step == 0 else "" for index, label in enumerate(labels)]
 
     figure, axes = plt.subplots(
         nrows=rows.shape[0],
         ncols=1,
         squeeze=False,
-        figsize=(8.0, max(2.5, 2.5 * rows.shape[0])),
+        figsize=(8.0, _coefficient_row_height(num_labels) * rows.shape[0]),
     )
     y_positions = np.arange(len(labels), dtype=float)
 
     for row_index, axis in enumerate(axes[:, 0]):
         axis.barh(y_positions, rows[row_index], color="tab:blue")
         axis.axvline(0.0, color="black", linewidth=0.8)
+        zero_mask = np.isclose(rows[row_index], 0.0, atol=_ZERO_DISPLAY_TOL)
+        if np.any(zero_mask):
+            axis.scatter(
+                np.zeros(int(np.sum(zero_mask)), dtype=float),
+                y_positions[zero_mask],
+                marker="o",
+                s=20.0,
+                facecolors="white",
+                edgecolors="tab:blue",
+                linewidths=1.0,
+                zorder=3,
+            )
         axis.set_yticks(y_positions)
-        axis.set_yticklabels(labels)
+        axis.set_yticklabels(displayed_labels)
+        axis.tick_params(axis="y", labelsize=tick_fontsize)
         axis.set_title(titles[row_index])
         axis.set_xlabel("Display-normalized coefficient" if normalize_for_display else "Coefficient")
         axis.set_ylabel("Basis term")
+        if tick_step > 1:
+            axis.text(
+                0.99,
+                0.02,
+                f"Showing every {_ordinal(tick_step)} basis label",
+                transform=axis.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=8,
+            )
 
     figure.tight_layout()
     return figure
@@ -76,25 +141,22 @@ def plot_generator_symbolic_summary(
 
     generator.validate()
     lines: Sequence[str] = render_generator_family(generator, display_normalization=display_normalization)
-
-    figure, axis = plt.subplots(figsize=(9.0, max(2.5, 0.9 * len(lines) + 1.0)))
+    figure, axis = plt.subplots(figsize=_symbolic_summary_figure_size(lines))
     axis.set_axis_off()
     axis.set_title("Generator Summary")
+    axis.text(
+        0.02,
+        0.90,
+        "\n".join(lines),
+        transform=axis.transAxes,
+        fontsize=_symbolic_summary_fontsize(lines),
+        fontfamily="monospace",
+        linespacing=1.2,
+        va="top",
+        ha="left",
+    )
 
-    top = 0.92
-    step = 0.75 / max(len(lines), 1)
-    for index, line in enumerate(lines):
-        axis.text(
-            0.02,
-            top - index * step,
-            line,
-            transform=axis.transAxes,
-            fontsize=11,
-            va="top",
-            ha="left",
-        )
-
-    figure.tight_layout()
+    figure.subplots_adjust(top=0.86, bottom=0.06, left=0.04, right=0.98)
     return figure
 
 

--- a/src/pdelie/viz/generators.py
+++ b/src/pdelie/viz/generators.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+
+from pdelie.contracts import GeneratorFamily
+from pdelie.symmetry import render_generator_family
+
+
+def _flattened_basis_labels(generator: GeneratorFamily) -> list[str]:
+    component_names = [str(name) for name in generator.basis_spec["component_ordering"]]
+    term_names = [str(name) for name in generator.basis_spec["term_ordering"]]
+    return [f"{component_name}:{term_name}" for component_name in component_names for term_name in term_names]
+
+
+def _display_rows(coefficients: np.ndarray, *, normalize_for_display: bool) -> np.ndarray:
+    rows = np.asarray(coefficients, dtype=float).copy()
+    if not normalize_for_display:
+        return rows
+
+    for index, row in enumerate(rows):
+        scale = float(np.max(np.abs(row))) if row.size else 0.0
+        if scale > 0.0:
+            rows[index] = row / scale
+    return rows
+
+
+def _subplot_titles(generator: GeneratorFamily) -> list[str]:
+    if generator.generator_names is not None:
+        return list(generator.generator_names)
+    return [f"X_{index}" for index in range(1, generator.coefficients.shape[0] + 1)]
+
+
+def plot_generator_coefficients(
+    generator: GeneratorFamily,
+    *,
+    normalize_for_display: bool = False,
+) -> Figure:
+    """Plot stored generator coefficients as deterministic horizontal bar charts."""
+
+    generator.validate()
+    labels = _flattened_basis_labels(generator)
+    rows = _display_rows(np.asarray(generator.coefficients, dtype=float), normalize_for_display=normalize_for_display)
+    titles = _subplot_titles(generator)
+
+    figure, axes = plt.subplots(
+        nrows=rows.shape[0],
+        ncols=1,
+        squeeze=False,
+        figsize=(8.0, max(2.5, 2.5 * rows.shape[0])),
+    )
+    y_positions = np.arange(len(labels), dtype=float)
+
+    for row_index, axis in enumerate(axes[:, 0]):
+        axis.barh(y_positions, rows[row_index], color="tab:blue")
+        axis.axvline(0.0, color="black", linewidth=0.8)
+        axis.set_yticks(y_positions)
+        axis.set_yticklabels(labels)
+        axis.set_title(titles[row_index])
+        axis.set_xlabel("Display-normalized coefficient" if normalize_for_display else "Coefficient")
+        axis.set_ylabel("Basis term")
+
+    figure.tight_layout()
+    return figure
+
+
+def plot_generator_symbolic_summary(
+    generator: GeneratorFamily,
+    *,
+    display_normalization: str = "anchor",
+) -> Figure:
+    """Render stored generators as symbolic text inside a simple figure."""
+
+    generator.validate()
+    lines: Sequence[str] = render_generator_family(generator, display_normalization=display_normalization)
+
+    figure, axis = plt.subplots(figsize=(9.0, max(2.5, 0.9 * len(lines) + 1.0)))
+    axis.set_axis_off()
+    axis.set_title("Generator Summary")
+
+    top = 0.92
+    step = 0.75 / max(len(lines), 1)
+    for index, line in enumerate(lines):
+        axis.text(
+            0.02,
+            top - index * step,
+            line,
+            transform=axis.transAxes,
+            fontsize=11,
+            va="top",
+            ha="left",
+        )
+
+    figure.tight_layout()
+    return figure
+
+
+__all__ = [
+    "plot_generator_coefficients",
+    "plot_generator_symbolic_summary",
+]

--- a/src/pdelie/viz/span.py
+++ b/src/pdelie/viz/span.py
@@ -10,6 +10,68 @@ from matplotlib.figure import Figure
 from pdelie.errors import SchemaValidationError
 
 _ZERO_ANGLE_TOL = 1e-12
+_ANGLE_LABEL_MAX_COUNT = 10
+
+
+def _format_float(value: float) -> str:
+    return f"{float(value):.3g}"
+
+
+def _angle_label_fontsize(count: int) -> float:
+    return max(7.0, 9.0 - 0.15 * max(count - 4, 0))
+
+
+def _summary_lines(
+    *,
+    principal_angles_degrees: np.ndarray,
+    residual_summary: float,
+    reference_to_candidate: float | None,
+    candidate_to_reference: float | None,
+    comparison_rank: int,
+    reference_rank: int,
+    candidate_rank: int,
+    conditioning: Mapping[str, object] | None,
+) -> list[str]:
+    if principal_angles_degrees.size == 0:
+        min_angle = median_angle = max_angle = 0.0
+        zero_count = 0
+    else:
+        min_angle = float(np.min(principal_angles_degrees))
+        median_angle = float(np.median(principal_angles_degrees))
+        max_angle = float(np.max(principal_angles_degrees))
+        zero_count = int(np.count_nonzero(np.isclose(principal_angles_degrees, 0.0, atol=_ZERO_ANGLE_TOL)))
+
+    lines = [
+        f"Projection residual: {_format_float(residual_summary)}",
+    ]
+    if reference_to_candidate is not None and candidate_to_reference is not None:
+        lines.extend(
+            [
+                f"Ref -> Cand: {_format_float(reference_to_candidate)}",
+                f"Cand -> Ref: {_format_float(candidate_to_reference)}",
+            ]
+        )
+    lines.extend(
+        [
+            f"Ranks: {reference_rank} ref / {candidate_rank} cand / {comparison_rank} cmp",
+            f"Angles (deg): min {min_angle:.2f}, median {median_angle:.2f}, max {max_angle:.2f}",
+            f"Zero angles: {zero_count}",
+        ]
+    )
+    if conditioning is not None:
+        ambient_metric = conditioning.get("ambient_metric")
+        reference_span = conditioning.get("reference_span")
+        candidate_span = conditioning.get("candidate_span")
+        lines.append(
+            "Conditioning: "
+            f"{_format_float(float(ambient_metric))} ambient, "
+            f"{_format_float(float(reference_span))} ref, "
+            f"{_format_float(float(candidate_span))} cand"
+        )
+    if 0 < principal_angles_degrees.size <= _ANGLE_LABEL_MAX_COUNT:
+        angle_list = ", ".join(f"{angle:.2f}" for angle in principal_angles_degrees)
+        lines.append(f"Angle list: [{angle_list}]")
+    return lines
 
 
 def _validate_span_report(report: Mapping[str, object]) -> None:
@@ -46,19 +108,21 @@ def plot_span_diagnostics(report: Mapping[str, object]) -> Figure:
     principal_angles_degrees = np.degrees(np.asarray(report["principal_angles_radians"], dtype=float))
     positions = np.arange(1, principal_angles_degrees.size + 1, dtype=float)
     residual_summary = float(report["projection_residual"]["summary"])  # type: ignore[index]
+    reference_to_candidate = report["projection_residual"].get("reference_to_candidate")  # type: ignore[index]
+    candidate_to_reference = report["projection_residual"].get("candidate_to_reference")  # type: ignore[index]
     reference_rank = int(report["reference_rank"])
     candidate_rank = int(report["candidate_rank"])
     comparison_rank = int(report["comparison_rank"])
-    max_angle_degrees = float(np.max(principal_angles_degrees)) if principal_angles_degrees.size else 0.0
+    conditioning = report["conditioning"] if isinstance(report["conditioning"], Mapping) else None
 
     figure, (bars_axis, summary_axis) = plt.subplots(
-        1,
         2,
-        figsize=(8.5, 4.0),
-        gridspec_kw={"width_ratios": [3.0, 1.5]},
+        1,
+        figsize=(max(7.5, min(12.0, 6.5 + 0.45 * max(comparison_rank - 1, 0))), 5.4),
+        gridspec_kw={"height_ratios": [3.4, 1.5]},
     )
     if principal_angles_degrees.size > 0:
-        bars_axis.bar(positions, principal_angles_degrees, color="tab:orange")
+        bars_axis.bar(positions, principal_angles_degrees, color="tab:orange", edgecolor="tab:orange", width=0.72)
         bars_axis.set_xticks(positions)
         zero_mask = np.isclose(principal_angles_degrees, 0.0, atol=_ZERO_ANGLE_TOL)
         if np.any(zero_mask):
@@ -72,27 +136,50 @@ def plot_span_diagnostics(report: Mapping[str, object]) -> Figure:
                 linewidths=1.2,
                 zorder=3,
             )
+        label_fontsize = _angle_label_fontsize(principal_angles_degrees.size)
+        for position, angle in zip(positions, principal_angles_degrees):
+            y_value = max(float(angle), 0.0) + (2.0 if angle > _ZERO_ANGLE_TOL else 1.5)
+            bars_axis.text(
+                float(position),
+                y_value,
+                f"{float(angle):.1f}",
+                ha="center",
+                va="bottom",
+                fontsize=label_fontsize,
+            )
     bars_axis.set_xlabel("Principal angle index")
     bars_axis.set_ylabel("Angle (degrees)")
     bars_axis.set_title("Span Diagnostics")
+    bars_axis.set_ylim(0.0, 95.0)
+    bars_axis.set_yticks([0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0])
+    bars_axis.grid(axis="y", linestyle="--", linewidth=0.6, alpha=0.5)
+    bars_axis.set_axisbelow(True)
 
     summary_axis.set_axis_off()
     summary_axis.set_title("Summary")
     summary_axis.text(
         0.02,
-        0.95,
+        0.98,
         "\n".join(
-            [
-                f"Projection residual: {residual_summary:.3g}",
-                f"Comparison rank: {comparison_rank}",
-                f"Reference rank: {reference_rank}",
-                f"Candidate rank: {candidate_rank}",
-                f"Max angle (deg): {max_angle_degrees:.2f}",
-            ]
+            _summary_lines(
+                principal_angles_degrees=principal_angles_degrees,
+                residual_summary=residual_summary,
+                reference_to_candidate=(
+                    float(reference_to_candidate) if reference_to_candidate is not None else None
+                ),
+                candidate_to_reference=(
+                    float(candidate_to_reference) if candidate_to_reference is not None else None
+                ),
+                comparison_rank=comparison_rank,
+                reference_rank=reference_rank,
+                candidate_rank=candidate_rank,
+                conditioning=conditioning,
+            )
         ),
         transform=summary_axis.transAxes,
         ha="left",
         va="top",
+        fontsize=9,
     )
 
     figure.tight_layout()

--- a/src/pdelie/viz/span.py
+++ b/src/pdelie/viz/span.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.figure import Figure
 
 from pdelie.errors import SchemaValidationError
+from pdelie.viz._matplotlib import require_pyplot
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
 
 _ZERO_ANGLE_TOL = 1e-12
 _ANGLE_LABEL_MAX_COUNT = 10
@@ -19,6 +21,13 @@ def _format_float(value: float) -> str:
 
 def _angle_label_fontsize(count: int) -> float:
     return max(7.0, 9.0 - 0.15 * max(count - 4, 0))
+
+
+def _require_float(value: object, name: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"Span diagnostics report field '{name}' must be numeric.") from exc
 
 
 def _summary_lines(
@@ -97,10 +106,24 @@ def _validate_span_report(report: Mapping[str, object]) -> None:
     if "summary" not in projection_residual:
         raise SchemaValidationError("Span diagnostics report field 'projection_residual' must include 'summary'.")
 
+    conditioning = report["conditioning"]
+    if not isinstance(conditioning, Mapping):
+        raise SchemaValidationError("Span diagnostics report field 'conditioning' must be a mapping.")
+    required_conditioning_keys = ("ambient_metric", "reference_span", "candidate_span")
+    missing_conditioning = [key for key in required_conditioning_keys if key not in conditioning]
+    if missing_conditioning:
+        raise SchemaValidationError(
+            "Span diagnostics report field 'conditioning' is missing required keys: "
+            f"{missing_conditioning}."
+        )
+    for key in required_conditioning_keys:
+        _require_float(conditioning[key], f"conditioning.{key}")
+
 
 def plot_span_diagnostics(report: Mapping[str, object]) -> Figure:
     """Plot principal angles and projection-residual summary from an existing span report."""
 
+    plt = require_pyplot()
     if not isinstance(report, Mapping):
         raise SchemaValidationError("Span diagnostics input must be a mapping.")
     _validate_span_report(report)

--- a/src/pdelie/viz/span.py
+++ b/src/pdelie/viz/span.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.figure import Figure
+
+from pdelie.errors import SchemaValidationError
+
+
+def _validate_span_report(report: Mapping[str, object]) -> None:
+    required_keys = {
+        "inner_product",
+        "evaluation_mode",
+        "domain",
+        "component_weights",
+        "reference_rank",
+        "candidate_rank",
+        "comparison_rank",
+        "principal_angles_radians",
+        "projection_residual",
+        "conditioning",
+    }
+    missing = sorted(required_keys.difference(report))
+    if missing:
+        raise SchemaValidationError(f"Span diagnostics report is missing required keys: {missing}.")
+
+    projection_residual = report["projection_residual"]
+    if not isinstance(projection_residual, Mapping):
+        raise SchemaValidationError("Span diagnostics report field 'projection_residual' must be a mapping.")
+    if "summary" not in projection_residual:
+        raise SchemaValidationError("Span diagnostics report field 'projection_residual' must include 'summary'.")
+
+
+def plot_span_diagnostics(report: Mapping[str, object]) -> Figure:
+    """Plot principal angles and projection-residual summary from an existing span report."""
+
+    if not isinstance(report, Mapping):
+        raise SchemaValidationError("Span diagnostics input must be a mapping.")
+    _validate_span_report(report)
+
+    principal_angles = np.asarray(report["principal_angles_radians"], dtype=float)
+    positions = np.arange(1, principal_angles.size + 1, dtype=float)
+    residual_summary = float(report["projection_residual"]["summary"])  # type: ignore[index]
+
+    figure, axis = plt.subplots(figsize=(6.5, 4.0))
+    if principal_angles.size > 0:
+        axis.bar(positions, principal_angles, color="tab:orange")
+        axis.set_xticks(positions)
+    axis.set_xlabel("Principal angle index")
+    axis.set_ylabel("Angle (radians)")
+    axis.set_title("Span Diagnostics")
+    axis.text(
+        0.98,
+        0.98,
+        f"Projection residual: {residual_summary:.3g}",
+        transform=axis.transAxes,
+        ha="right",
+        va="top",
+    )
+
+    figure.tight_layout()
+    return figure
+
+
+__all__ = ["plot_span_diagnostics"]

--- a/src/pdelie/viz/span.py
+++ b/src/pdelie/viz/span.py
@@ -9,6 +9,8 @@ from matplotlib.figure import Figure
 
 from pdelie.errors import SchemaValidationError
 
+_ZERO_ANGLE_TOL = 1e-12
+
 
 def _validate_span_report(report: Mapping[str, object]) -> None:
     required_keys = {
@@ -41,23 +43,55 @@ def plot_span_diagnostics(report: Mapping[str, object]) -> Figure:
         raise SchemaValidationError("Span diagnostics input must be a mapping.")
     _validate_span_report(report)
 
-    principal_angles = np.asarray(report["principal_angles_radians"], dtype=float)
-    positions = np.arange(1, principal_angles.size + 1, dtype=float)
+    principal_angles_degrees = np.degrees(np.asarray(report["principal_angles_radians"], dtype=float))
+    positions = np.arange(1, principal_angles_degrees.size + 1, dtype=float)
     residual_summary = float(report["projection_residual"]["summary"])  # type: ignore[index]
+    reference_rank = int(report["reference_rank"])
+    candidate_rank = int(report["candidate_rank"])
+    comparison_rank = int(report["comparison_rank"])
+    max_angle_degrees = float(np.max(principal_angles_degrees)) if principal_angles_degrees.size else 0.0
 
-    figure, axis = plt.subplots(figsize=(6.5, 4.0))
-    if principal_angles.size > 0:
-        axis.bar(positions, principal_angles, color="tab:orange")
-        axis.set_xticks(positions)
-    axis.set_xlabel("Principal angle index")
-    axis.set_ylabel("Angle (radians)")
-    axis.set_title("Span Diagnostics")
-    axis.text(
-        0.98,
-        0.98,
-        f"Projection residual: {residual_summary:.3g}",
-        transform=axis.transAxes,
-        ha="right",
+    figure, (bars_axis, summary_axis) = plt.subplots(
+        1,
+        2,
+        figsize=(8.5, 4.0),
+        gridspec_kw={"width_ratios": [3.0, 1.5]},
+    )
+    if principal_angles_degrees.size > 0:
+        bars_axis.bar(positions, principal_angles_degrees, color="tab:orange")
+        bars_axis.set_xticks(positions)
+        zero_mask = np.isclose(principal_angles_degrees, 0.0, atol=_ZERO_ANGLE_TOL)
+        if np.any(zero_mask):
+            bars_axis.scatter(
+                positions[zero_mask],
+                np.zeros(int(np.sum(zero_mask)), dtype=float),
+                marker="o",
+                s=26.0,
+                facecolors="white",
+                edgecolors="tab:orange",
+                linewidths=1.2,
+                zorder=3,
+            )
+    bars_axis.set_xlabel("Principal angle index")
+    bars_axis.set_ylabel("Angle (degrees)")
+    bars_axis.set_title("Span Diagnostics")
+
+    summary_axis.set_axis_off()
+    summary_axis.set_title("Summary")
+    summary_axis.text(
+        0.02,
+        0.95,
+        "\n".join(
+            [
+                f"Projection residual: {residual_summary:.3g}",
+                f"Comparison rank: {comparison_rank}",
+                f"Reference rank: {reference_rank}",
+                f"Candidate rank: {candidate_rank}",
+                f"Max angle (deg): {max_angle_degrees:.2f}",
+            ]
+        ),
+        transform=summary_axis.transAxes,
+        ha="left",
         va="top",
     )
 

--- a/src/pdelie/viz/verification.py
+++ b/src/pdelie/viz/verification.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
+from typing import TYPE_CHECKING
 
 from pdelie.contracts import VerificationReport
+from pdelie.viz._matplotlib import require_pyplot
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
 
 
 def plot_verification_curve(report: VerificationReport) -> Figure:
     """Plot the held-out verification curve for an existing VerificationReport."""
 
+    plt = require_pyplot()
     report.validate()
 
     figure, axis = plt.subplots(figsize=(6.5, 4.0))

--- a/src/pdelie/viz/verification.py
+++ b/src/pdelie/viz/verification.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from pdelie.contracts import VerificationReport
+
+
+def plot_verification_curve(report: VerificationReport) -> Figure:
+    """Plot the held-out verification curve for an existing VerificationReport."""
+
+    report.validate()
+
+    figure, axis = plt.subplots(figsize=(6.5, 4.0))
+    axis.plot(report.epsilon_values, report.error_curve, marker="o", color="tab:blue")
+    axis.set_xscale("log")
+    axis.set_xlabel("epsilon")
+    axis.set_ylabel(report.norm)
+    axis.set_title(f"Verification Curve ({report.classification})")
+    axis.grid(True, alpha=0.3)
+
+    figure.tight_layout()
+    return figure
+
+
+__all__ = ["plot_verification_curve"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -33,6 +33,13 @@ def test_runtime_package_api_is_importable() -> None:
         render_generator_family,
         to_sympy_component_expressions,
     )
+    from pdelie.viz import (
+        plot_closure_diagnostics,
+        plot_generator_coefficients,
+        plot_generator_symbolic_summary,
+        plot_span_diagnostics,
+        plot_verification_curve,
+    )
 
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
@@ -40,6 +47,11 @@ def test_runtime_package_api_is_importable() -> None:
     assert diagnose_generator_family_closure is not None
     assert render_generator_family is not None
     assert to_sympy_component_expressions is not None
+    assert plot_generator_coefficients is not None
+    assert plot_generator_symbolic_summary is not None
+    assert plot_verification_curve is not None
+    assert plot_span_diagnostics is not None
+    assert plot_closure_diagnostics is not None
 
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
@@ -49,6 +61,11 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "diagnose_generator_family_closure")
     assert not hasattr(pdelie, "render_generator_family")
     assert not hasattr(pdelie, "to_sympy_component_expressions")
+    assert not hasattr(pdelie, "plot_generator_coefficients")
+    assert not hasattr(pdelie, "plot_generator_symbolic_summary")
+    assert not hasattr(pdelie, "plot_verification_curve")
+    assert not hasattr(pdelie, "plot_span_diagnostics")
+    assert not hasattr(pdelie, "plot_closure_diagnostics")
 
 
 def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> None:
@@ -73,3 +90,13 @@ def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     assert hasattr(symmetry_module, "compare_generator_spans")
     assert hasattr(symmetry_module, "render_generator_family")
     assert hasattr(symmetry_module, "to_sympy_component_expressions")
+
+
+def test_viz_package_runtime_api_matches_frozen_m5_surface() -> None:
+    viz_module = importlib.import_module("pdelie.viz")
+
+    assert hasattr(viz_module, "plot_generator_coefficients")
+    assert hasattr(viz_module, "plot_generator_symbolic_summary")
+    assert hasattr(viz_module, "plot_verification_curve")
+    assert hasattr(viz_module, "plot_span_diagnostics")
+    assert hasattr(viz_module, "plot_closure_diagnostics")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import importlib
+import sys
+
+import numpy as np
+import pytest
 
 import pdelie
 from pdelie import (
@@ -100,3 +104,31 @@ def test_viz_package_runtime_api_matches_frozen_m5_surface() -> None:
     assert hasattr(viz_module, "plot_verification_curve")
     assert hasattr(viz_module, "plot_span_diagnostics")
     assert hasattr(viz_module, "plot_closure_diagnostics")
+
+
+def test_viz_package_import_succeeds_without_matplotlib_until_renderer_use(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import_module = importlib.import_module
+
+    def _fake_import_module(name: str, package: str | None = None):
+        if name == "matplotlib" or name.startswith("matplotlib."):
+            raise ModuleNotFoundError("No module named 'matplotlib'", name="matplotlib")
+        return original_import_module(name, package)
+
+    for module_name in list(sys.modules):
+        if module_name == "pdelie.viz" or module_name.startswith("pdelie.viz."):
+            sys.modules.pop(module_name)
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    viz_module = importlib.import_module("pdelie.viz")
+    report = VerificationReport(
+        norm="relative_l2",
+        epsilon_values=np.logspace(-4, -1, 7),
+        error_curve=np.logspace(-7, -4, 7),
+        classification="exact",
+        diagnostics={},
+    )
+
+    assert hasattr(viz_module, "plot_verification_curve")
+    with pytest.raises(ImportError, match="Matplotlib is required for pdelie\\.viz"):
+        viz_module.plot_verification_curve(report)

--- a/tests/test_viz_runtime.py
+++ b/tests/test_viz_runtime.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from pdelie import GeneratorFamily, SchemaValidationError, VerificationReport
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.symmetry import compare_generator_spans, diagnose_generator_family_closure
+from pdelie.viz import (
+    plot_closure_diagnostics,
+    plot_generator_coefficients,
+    plot_generator_symbolic_summary,
+    plot_span_diagnostics,
+    plot_verification_curve,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures() -> None:
+    yield
+    plt.close("all")
+
+
+def _x_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0]},
+            {"label": "x", "powers": [1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "x"],
+        "layout": "component_major",
+    }
+
+
+def _make_generator(
+    coefficients: np.ndarray,
+    *,
+    basis_spec: dict[str, object],
+    normalization: str = "runtime_fixture",
+    parameterization: str = "algebraic_fixture",
+) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization=parameterization,
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization=normalization,
+        diagnostics={},
+    )
+
+
+def _make_verification_report() -> VerificationReport:
+    return VerificationReport(
+        norm="relative_l2",
+        epsilon_values=np.logspace(-4, -1, 7),
+        error_curve=np.logspace(-7, -4, 7),
+        classification="exact",
+        diagnostics={},
+    )
+
+
+def test_plot_generator_coefficients_returns_figure_with_deterministic_bar_count() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+
+    figure = plot_generator_coefficients(generator)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes) == 2
+    assert sum(len(axis.patches) for axis in figure.axes) == 8
+
+
+def test_plot_generator_symbolic_summary_contains_rendered_generator_strings() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        parameterization="polynomial_translation_affine",
+    )
+
+    figure = plot_generator_symbolic_summary(generator)
+
+    assert isinstance(figure, Figure)
+    texts = [text.get_text() for text in figure.axes[0].texts]
+    assert "X_1 = ∂x" in texts
+    assert "X_2 = t∂x" in texts
+
+
+def test_plot_verification_curve_returns_log_scaled_figure() -> None:
+    report = _make_verification_report()
+
+    figure = plot_verification_curve(report)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes) == 1
+    assert figure.axes[0].get_xscale() == "log"
+    assert "exact" in figure.axes[0].get_title().lower()
+
+
+def test_plot_span_diagnostics_accepts_frozen_m3_report_shape() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    report = compare_generator_spans(reference, candidate)
+
+    figure = plot_span_diagnostics(report)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes) == 1
+    assert len(figure.axes[0].patches) == report["comparison_rank"]
+    assert any("Projection residual" in text.get_text() for text in figure.axes[0].texts)
+
+
+def test_plot_closure_diagnostics_accepts_frozen_m4_report_shape() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+    report = diagnose_generator_family_closure(generator)
+
+    figure = plot_closure_diagnostics(report)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes) == 3
+    assert [axis.get_title() for axis in figure.axes] == ["Closure", "Antisymmetry", "Jacobi"]
+
+
+def test_plot_span_diagnostics_rejects_malformed_report() -> None:
+    with pytest.raises(SchemaValidationError, match="missing required keys"):
+        plot_span_diagnostics({})
+
+
+def test_plot_closure_diagnostics_rejects_malformed_report() -> None:
+    with pytest.raises(SchemaValidationError, match="missing required keys"):
+        plot_closure_diagnostics({})

--- a/tests/test_viz_runtime.py
+++ b/tests/test_viz_runtime.py
@@ -41,6 +41,24 @@ def _x_basis_spec() -> dict[str, object]:
     }
 
 
+def _wide_x_basis_spec(num_terms: int = 32) -> dict[str, object]:
+    basis_terms: list[dict[str, object]] = []
+    term_ordering: list[str] = []
+    for power in range(num_terms):
+        label = "1" if power == 0 else "x" if power == 1 else f"x^{power}"
+        basis_terms.append({"label": label, "powers": [power]})
+        term_ordering.append(label)
+
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": basis_terms,
+        "component_ordering": ["xi"],
+        "term_ordering": term_ordering,
+        "layout": "component_major",
+    }
+
+
 def _make_generator(
     coefficients: np.ndarray,
     *,
@@ -93,9 +111,37 @@ def test_plot_generator_symbolic_summary_contains_rendered_generator_strings() -
     figure = plot_generator_symbolic_summary(generator)
 
     assert isinstance(figure, Figure)
-    texts = [text.get_text() for text in figure.axes[0].texts]
-    assert "X_1 = ∂x" in texts
-    assert "X_2 = t∂x" in texts
+    assert len(figure.axes[0].texts) == 1
+    summary_text = figure.axes[0].texts[0].get_text()
+    assert "X_1 = ∂x" in summary_text
+    assert "X_2 = t∂x" in summary_text
+    assert "monospace" in [family.lower() for family in figure.axes[0].texts[0].get_fontfamily()]
+
+
+def test_plot_generator_symbolic_summary_scales_for_denser_families() -> None:
+    dense_generator = _make_generator(
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [1.0, 1.0, 0.0, 0.0],
+                [1.0, 0.0, 1.0, 1.0],
+            ],
+            dtype=float,
+        ),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="runtime_fixture",
+        parameterization="polynomial_translation_affine",
+    )
+
+    figure = plot_generator_symbolic_summary(dense_generator)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes[0].texts) == 1
+    assert figure.axes[0].texts[0].get_fontsize() < 11.0
+    assert figure.get_size_inches()[1] < 4.0
 
 
 def test_plot_verification_curve_returns_log_scaled_figure() -> None:
@@ -125,9 +171,27 @@ def test_plot_span_diagnostics_accepts_frozen_m3_report_shape() -> None:
     figure = plot_span_diagnostics(report)
 
     assert isinstance(figure, Figure)
-    assert len(figure.axes) == 1
+    assert len(figure.axes) == 2
     assert len(figure.axes[0].patches) == report["comparison_rank"]
-    assert any("Projection residual" in text.get_text() for text in figure.axes[0].texts)
+    assert "degrees" in figure.axes[0].get_ylabel().lower()
+    assert any("Projection residual" in text.get_text() for text in figure.axes[1].texts)
+
+
+def test_plot_span_diagnostics_marks_zero_angle_bars_intentionally() -> None:
+    basis_spec = _x_basis_spec()
+    reference = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=basis_spec,
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0], [1.0, 1.0]], dtype=float),
+        basis_spec=basis_spec,
+    )
+
+    figure = plot_span_diagnostics(compare_generator_spans(reference, candidate))
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes[0].collections) == 1
 
 
 def test_plot_closure_diagnostics_accepts_frozen_m4_report_shape() -> None:
@@ -140,8 +204,30 @@ def test_plot_closure_diagnostics_accepts_frozen_m4_report_shape() -> None:
     figure = plot_closure_diagnostics(report)
 
     assert isinstance(figure, Figure)
-    assert len(figure.axes) == 3
-    assert [axis.get_title() for axis in figure.axes] == ["Closure", "Antisymmetry", "Jacobi"]
+    assert len(figure.axes) == 4
+    assert [axis.get_title() for axis in figure.axes[:3]] == ["Closure", "Antisymmetry", "Jacobi"]
+    assert figure.axes[3].get_ylabel() == "Residual"
+    assert figure.axes[0].images[0].get_clim() == (0.0, 1.0)
+    assert figure.axes[1].images[0].get_clim() == (0.0, 1.0)
+
+
+def test_plot_generator_coefficients_decimates_labels_for_wide_bases() -> None:
+    basis_spec = _wide_x_basis_spec()
+    generator = _make_generator(
+        np.arange(len(basis_spec["term_ordering"]), dtype=float).reshape(1, -1),
+        basis_spec=basis_spec,
+    )
+
+    figure = plot_generator_coefficients(generator)
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes) == 1
+    assert len(figure.axes[0].patches) == 32
+    assert len(figure.axes[0].collections) == 1
+    visible_labels = [label.get_text() for label in figure.axes[0].get_yticklabels() if label.get_text()]
+    expected_labels = [f"xi:{label}" for index, label in enumerate(basis_spec["term_ordering"]) if index % 2 == 0]
+    assert visible_labels == expected_labels
+    assert any("Showing every 2nd basis label" in text.get_text() for text in figure.axes[0].texts)
 
 
 def test_plot_span_diagnostics_rejects_malformed_report() -> None:

--- a/tests/test_viz_runtime.py
+++ b/tests/test_viz_runtime.py
@@ -173,8 +173,29 @@ def test_plot_span_diagnostics_accepts_frozen_m3_report_shape() -> None:
     assert isinstance(figure, Figure)
     assert len(figure.axes) == 2
     assert len(figure.axes[0].patches) == report["comparison_rank"]
+    assert figure.axes[0].get_ylim()[1] >= 90.0
     assert "degrees" in figure.axes[0].get_ylabel().lower()
     assert any("Projection residual" in text.get_text() for text in figure.axes[1].texts)
+    assert any("Ref -> Cand" in text.get_text() for text in figure.axes[1].texts)
+
+
+def test_plot_span_diagnostics_summarizes_multi_rank_cases_more_densely() -> None:
+    basis_spec = _x_basis_spec()
+    reference = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=basis_spec,
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0], [1.0, 1.0]], dtype=float),
+        basis_spec=basis_spec,
+    )
+
+    figure = plot_span_diagnostics(compare_generator_spans(reference, candidate))
+
+    assert isinstance(figure, Figure)
+    assert len(figure.axes[0].patches) == 2
+    assert any("Angle list" in text.get_text() for text in figure.axes[1].texts)
+    assert any("Zero angles" in text.get_text() for text in figure.axes[1].texts)
 
 
 def test_plot_span_diagnostics_marks_zero_angle_bars_intentionally() -> None:
@@ -209,6 +230,33 @@ def test_plot_closure_diagnostics_accepts_frozen_m4_report_shape() -> None:
     assert figure.axes[3].get_ylabel() == "Residual"
     assert figure.axes[0].images[0].get_clim() == (0.0, 1.0)
     assert figure.axes[1].images[0].get_clim() == (0.0, 1.0)
+    assert any("All entries = 0" in text.get_text() for text in figure.axes[0].texts)
+    assert any("Mode: structure_constants" in text.get_text() for text in figure.axes[2].texts)
+
+
+def test_plot_closure_diagnostics_annotates_nontrivial_closed_families() -> None:
+    basis_spec = {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0]},
+            {"label": "x", "powers": [1]},
+            {"label": "x^2", "powers": [2]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "x", "x^2"],
+        "layout": "component_major",
+    }
+    generator = _make_generator(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=float),
+        basis_spec=basis_spec,
+    )
+
+    figure = plot_closure_diagnostics(diagnose_generator_family_closure(generator))
+
+    assert isinstance(figure, Figure)
+    assert any(text.get_text() == "0" for text in figure.axes[0].texts)
+    assert any("Nonzero structure constants" in text.get_text() for text in figure.axes[2].texts)
 
 
 def test_plot_generator_coefficients_decimates_labels_for_wide_bases() -> None:

--- a/tests/test_viz_runtime.py
+++ b/tests/test_viz_runtime.py
@@ -283,6 +283,76 @@ def test_plot_span_diagnostics_rejects_malformed_report() -> None:
         plot_span_diagnostics({})
 
 
+def test_plot_span_diagnostics_rejects_missing_conditioning_fields() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    report = compare_generator_spans(reference, candidate)
+    malformed = dict(report)
+    malformed["conditioning"] = {
+        "ambient_metric": report["conditioning"]["ambient_metric"],
+        "reference_span": report["conditioning"]["reference_span"],
+    }
+
+    with pytest.raises(SchemaValidationError, match="conditioning'.*missing required keys"):
+        plot_span_diagnostics(malformed)
+
+
+def test_plot_span_diagnostics_rejects_non_numeric_conditioning_values() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    candidate = _make_generator(
+        np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        parameterization="polynomial_translation_affine",
+    )
+    report = compare_generator_spans(reference, candidate)
+    malformed = dict(report)
+    malformed["conditioning"] = dict(report["conditioning"])
+    malformed["conditioning"]["candidate_span"] = "not-a-number"
+
+    with pytest.raises(SchemaValidationError, match="conditioning\\.candidate_span"):
+        plot_span_diagnostics(malformed)
+
+
 def test_plot_closure_diagnostics_rejects_malformed_report() -> None:
     with pytest.raises(SchemaValidationError, match="missing required keys"):
         plot_closure_diagnostics({})
+
+
+def test_plot_closure_diagnostics_rejects_missing_jacobi_mode() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+    report = diagnose_generator_family_closure(generator)
+    malformed = dict(report)
+    malformed["jacobi"] = dict(report["jacobi"])
+    malformed["jacobi"].pop("mode")
+
+    with pytest.raises(SchemaValidationError, match="'summary', 'triple_residuals', and 'mode'"):
+        plot_closure_diagnostics(malformed)
+
+
+def test_plot_closure_diagnostics_rejects_invalid_jacobi_mode_type() -> None:
+    generator = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+    )
+    report = diagnose_generator_family_closure(generator)
+    malformed = dict(report)
+    malformed["jacobi"] = dict(report["jacobi"])
+    malformed["jacobi"]["mode"] = 1
+
+    with pytest.raises(SchemaValidationError, match="field 'mode' must be a non-empty string"):
+        plot_closure_diagnostics(malformed)


### PR DESCRIPTION
Summary

This PR implements V0.4 Milestone 5 as a minimal, optional visualization layer for PDELie.

The goal is not a broad plotting framework or dashboarding system. The goal is a thin set of renderer-only helpers for inspecting the outputs of the current v0.4 generator-family, verification, span, and closure workflows by eye. This stays aligned with the frozen v0.4 scope, where visualization is optional, runtime-level only, and explicitly secondary to the core algebra/reporting milestones.    

What changed

This PR adds a small visualization surface under pdelie.viz, kept out of root pdelie exports and out of the canonical object layer.

Included renderers:

* generator coefficient plots
* symbolic generator summary rendering
* verification curve plotting
* span diagnostics plotting
* closure diagnostics plotting

The renderers consume existing canonical objects and runtime reports only. They do not define new report schemas, do not mutate inputs, and do not introduce visualization-specific data contracts. That is consistent with the v0.4 design, where visualization helpers are runtime-only and must remain optional.  

Scope discipline

This PR does not:

* change canonical objects
* change fitting behavior
* change verification, span, or closure semantics
* add weak-form methods
* add operator methods
* add broad adapters
* add interactive/dashboard features
* add visualization-specific runtime report classes

The visualization layer is intentionally thin and renderer-only. It improves inspection, not the underlying mathematical pipeline.    

Design intent

The current renderers are meant to support:

* quick generator inspection
* human-readable symbolic summaries
* verification curve inspection
* span-angle inspection
* closure / antisymmetry / Jacobi inspection

This PR is not claiming a mature visualization system. It provides a practical baseline for visual debugging and interpretation while keeping the optional visualization layer outside the core install path and outside canonical semantics. That matches the milestone sequencing in the active v0.4 plan, where visualization is explicitly optional, renderer-only, and deferrable relative to the representation/diagnostic core.    

Validation

* focused visualization tests pass
* full test suite passes
* no regressions were introduced into the Heat/Burgers stable paths
* no public root-package exports were broadened

Result

This PR completes the minimal visualization foundation for v0.4 by adding optional renderers for the current runtime outputs, while preserving the strict stable/runtime boundary of the library. The next work after this remains the v0.4 release-gate layer, not broader numerics or operators.