### PR TITLE
Add V0.4 algebra-span release gate test and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,35 @@ on:
   pull_request:
 
 jobs:
+  v0_4-release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package and test dependencies
+        shell: bash
+        run: |
+          retry() {
+            local attempts="$1"
+            shift
+            local count=1
+            until "$@"; do
+              if [ "${count}" -ge "${attempts}" ]; then
+                return 1
+              fi
+              count=$((count + 1))
+              echo "Retrying (${count}/${attempts}): $*"
+              sleep 5
+            done
+          }
+          retry 3 python -m pip install --upgrade pip
+          retry 3 python -m pip install -e .[test]
+      - name: Check dependencies
+        run: python -m pip check
+      - name: Run V0.4 release gate
+        run: python -m pytest tests/test_v0_4_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.4 Milestone 5 — Minimal visualization suite**
+**V0.4 Milestone 6 — Algebra-span release gate**
 
 This file is the active execution plan for the current `v0.4` release series.
 
@@ -92,11 +92,51 @@ Run at minimum:
 
 ---
 
+## Milestone 6 — Algebra-Span Release Gate
+
+### Goal
+
+Turn the already-implemented V0.4 M1–M5 behavior into one explicit pytest+CI release gate without adding any new capabilities or changing any runtime semantics.
+
+### Frozen Decisions
+
+- M6 is a release-gate milestone only; it does not add new public APIs, canonical objects, or runtime behavior
+- M6 excludes downstream and SymPy behavior from the gate itself
+- the dedicated CI job may still install the standard `.[test]` extra; M6 does not claim total optional-dependency isolation
+- floating outputs in the release gate must use tolerant numeric checks; exact assertions are reserved for strings and small clearly algebraic fixtures
+- the dedicated M6 CI job is an explicit release-gate visibility job and does not replace the full editable/full-suite job
+- visualization smoke in M6 must use a non-interactive backend and must close figures cleanly
+
+### Deliverables
+
+- one focused `tests/test_v0_4_release_gate.py` module over frozen M1–M5 behavior
+- one dedicated `v0_4-release-gate` CI job that runs only the release-gate module
+
+### Acceptance Criteria
+
+Milestone 6 is complete only if:
+
+- legacy translation payloads still upgrade cleanly to canonical `GeneratorFamily`
+- canonical translation family serialization remains explicit and stable
+- symbolic rendering remains deterministic for the frozen translation slice
+- span diagnostics are reproducible on representative exact multi-rank fixtures
+- closure diagnostics are reproducible on representative nontrivial closed fixtures
+- Heat and Burgers stable translation paths still verify as `exact`
+- all current M5 renderers smoke-test cleanly under a non-interactive backend
+- the dedicated M6 CI job is added without replacing the existing full-suite or package-smoke jobs
+
+### Test Plan
+
+Run at minimum:
+
+- `pytest tests/test_v0_4_release_gate.py`
+- full `pytest`
+
+---
+
 ## Later Milestones
 
 Strict sequencing for `v0.4`:
-
-- Milestone 6: algebra-span release gate
 
 Hard sequencing rules:
 
@@ -126,5 +166,5 @@ Hard sequencing rules:
 - Milestone 2: **COMPLETE**
 - Milestone 3: **COMPLETE**
 - Milestone 4: **COMPLETE**
-- Milestone 5: **ACTIVE**
-- Milestone 6: **PLANNED**
+- Milestone 5: **COMPLETE**
+- Milestone 6: **ACTIVE**

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -347,7 +347,7 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - verification-aware interpretation labels
 
 ### Milestone 5 — Minimal visualization
-**Status:** Active
+**Status:** Complete
 
 - optional `[viz]` extra only
 - visualization consumes existing canonical objects and runtime reports only
@@ -361,14 +361,19 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - explicitly deferrable first if M1–M4 take longer than expected
 
 ### Milestone 6 — Algebra-span release gate
-**Status:** Planned
+**Status:** Active
 
-- migration tests
-- symbolic determinism tests
-- span tests
-- closure tests
-- Heat/Burgers regression tests
-- optional-viz smoke tests
+- one focused pytest release-gate module over the already-implemented M1–M5 behavior
+- one dedicated CI visibility job running only that release-gate module
+- migration / canonical serialization checks for the translation slice
+- symbolic determinism checks for canonical and legacy-upgraded translation families
+- tolerant span reproducibility checks on representative exact multi-rank fixtures
+- tolerant closure reproducibility checks on representative nontrivial closed fixtures
+- compact Heat/Burgers stable translation regression checks
+- optional-viz smoke tests using a non-interactive backend with figure cleanup
+- no downstream or SymPy behavior in the gate itself
+- the CI job may still use the standard `.[test]` environment; this milestone does not claim total optional-dependency isolation
+- the dedicated CI job supplements, and does not replace, the full editable/full-suite job
 
 ---
 
@@ -382,7 +387,9 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - symbolic rendering is deterministic for a given basis
 - span diagnostics are reproducible under the frozen inner-product policy
 - closure diagnostics are reproducible and condition-aware
+- release-gate numeric assertions use tolerant checks for floating outputs
 - visualization remains optional and outside the core install
+- visualization smoke does not require an interactive/display backend and closes figures cleanly
 - no weak-form, operator, neural, broad-adapter, or manuscript-facing feature is required
 
 ---

--- a/tests/test_v0_4_release_gate.py
+++ b/tests/test_v0_4_release_gate.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from pdelie import GeneratorFamily, SchemaValidationError, VerificationReport
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.residuals import BurgersResidualEvaluator, HeatResidualEvaluator
+from pdelie.symmetry import (
+    compare_generator_spans,
+    diagnose_generator_family_closure,
+    render_generator_family,
+)
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+from pdelie.viz import (
+    plot_closure_diagnostics,
+    plot_generator_coefficients,
+    plot_generator_symbolic_summary,
+    plot_span_diagnostics,
+    plot_verification_curve,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures() -> None:
+    yield
+    plt.close("all")
+
+
+def _translation_generator(coefficients: np.ndarray) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={},
+    )
+
+
+def _x_basis_spec(*, labels: list[str], powers: list[list[int]]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": label, "powers": power}
+            for label, power in zip(labels, powers)
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _velocity_basis_spec(labels: list[str]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["velocity"],
+        "basis_terms": [
+            {"label": labels[0], "powers": [0]},
+            {"label": labels[1], "powers": [1]},
+        ],
+        "component_ordering": ["velocity"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _algebraic_generator(coefficients: np.ndarray, *, basis_spec: dict[str, object]) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="algebraic_fixture",
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization="runtime_fixture",
+        diagnostics={},
+    )
+
+
+def _verification_report() -> VerificationReport:
+    return VerificationReport(
+        norm="relative_l2",
+        epsilon_values=np.logspace(-4, -1, 7),
+        error_curve=np.logspace(-7, -4, 7),
+        classification="exact",
+        diagnostics={},
+    )
+
+
+def test_v0_4_release_gate_migration_and_canonical_translation_serialization() -> None:
+    legacy_payload = {
+        "schema_version": "0.1",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [1.0, 0.0, 0.0, 0.0],
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+    generator = GeneratorFamily.from_dict(legacy_payload)
+    payload = generator.to_dict()
+    basis_spec = generator.basis_spec
+
+    assert generator.schema_version == "0.2"
+    assert generator.parameterization == "polynomial_translation_affine"
+    assert generator.coefficients.shape == (1, 4)
+    np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+    assert basis_spec["variables"] == ["t", "x", "u"]
+    assert basis_spec["component_names"] == ["xi"]
+    assert basis_spec["term_ordering"] == ["1", "t", "x", "u"]
+    assert basis_spec["layout"] == "component_major"
+    assert payload["schema_version"] == "0.2"
+    assert payload["coefficients"] == [[1.0, 0.0, 0.0, 0.0]]
+    assert payload["basis_spec"]["variables"] == ["t", "x", "u"]
+    assert payload["basis_spec"]["component_names"] == ["xi"]
+    assert payload["basis_spec"]["term_ordering"] == ["1", "t", "x", "u"]
+    assert payload["basis_spec"]["layout"] == "component_major"
+
+    with pytest.raises(SchemaValidationError, match="basis_spec is required"):
+        GeneratorFamily.from_dict(
+            {
+                "schema_version": "0.2",
+                "parameterization": "algebraic_fixture",
+                "coefficients": [[1.0, 0.0]],
+                "normalization": "runtime_fixture",
+                "diagnostics": {},
+            }
+        )
+
+
+def test_v0_4_release_gate_symbolic_rendering_is_deterministic_for_translation_slice() -> None:
+    canonical = _translation_generator(np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+    legacy = GeneratorFamily.from_dict(
+        {
+            "schema_version": "0.1",
+            "parameterization": "polynomial_translation_affine",
+            "coefficients": [1.0, 0.0, 0.0, 0.0],
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        }
+    )
+
+    first = render_generator_family(canonical)
+    second = render_generator_family(canonical)
+    upgraded = render_generator_family(legacy)
+
+    assert first == ["X_1 = ∂x"]
+    assert second == first
+    assert upgraded == first
+
+
+def test_v0_4_release_gate_span_diagnostics_are_reproducible_on_multi_rank_fixture() -> None:
+    reference = _translation_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float)
+    )
+    candidate = _translation_generator(
+        np.array([[1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], dtype=float) / np.sqrt(2.0)
+    )
+
+    first = compare_generator_spans(reference, candidate)
+    second = compare_generator_spans(reference, candidate)
+
+    assert first["inner_product"] == "normalized_polynomial_l2"
+    assert first["evaluation_mode"] == "exact_polynomial"
+    assert first["reference_rank"] == 2
+    assert first["candidate_rank"] == 2
+    assert first["comparison_rank"] == 2
+    assert second["reference_rank"] == first["reference_rank"]
+    assert second["candidate_rank"] == first["candidate_rank"]
+    assert second["comparison_rank"] == first["comparison_rank"]
+    np.testing.assert_allclose(first["principal_angles_radians"], [0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(first["principal_angles_radians"], second["principal_angles_radians"], atol=1e-12)
+    assert first["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert second["projection_residual"]["summary"] == pytest.approx(
+        first["projection_residual"]["summary"],
+        abs=1e-12,
+    )
+    assert "ambient_metric" in first["conditioning"]
+    assert "reference_span" in first["conditioning"]
+    assert "candidate_span" in first["conditioning"]
+
+
+def test_v0_4_release_gate_closure_diagnostics_are_reproducible_in_exact_and_fallback_modes() -> None:
+    exact_generator = _algebraic_generator(
+        np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=float,
+        ),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+    fallback_generator = _algebraic_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(["offset", "linear"]),
+    )
+
+    exact_first = diagnose_generator_family_closure(exact_generator)
+    exact_second = diagnose_generator_family_closure(exact_generator)
+    fallback_first = diagnose_generator_family_closure(
+        fallback_generator,
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+    fallback_second = diagnose_generator_family_closure(
+        fallback_generator,
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+
+    assert exact_first["computation_mode"] == "exact_polynomial"
+    assert exact_first["family_rank"] == 3
+    assert exact_first["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert exact_first["antisymmetry"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert exact_first["jacobi"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert np.asarray(exact_first["structure_constants"]["tensor"], dtype=float).shape == (3, 3, 3)
+    np.testing.assert_allclose(
+        exact_first["structure_constants"]["tensor"],
+        exact_second["structure_constants"]["tensor"],
+        atol=1e-12,
+    )
+    assert exact_second["closure"]["summary"] == pytest.approx(exact_first["closure"]["summary"], abs=1e-12)
+    assert exact_second["antisymmetry"]["summary"] == pytest.approx(
+        exact_first["antisymmetry"]["summary"],
+        abs=1e-12,
+    )
+    assert exact_second["jacobi"]["summary"] == pytest.approx(exact_first["jacobi"]["summary"], abs=1e-12)
+
+    assert fallback_first["computation_mode"] == "sampled_projection"
+    assert fallback_first["family_rank"] == 2
+    np.testing.assert_allclose(
+        fallback_first["structure_constants"]["tensor"],
+        fallback_second["structure_constants"]["tensor"],
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        fallback_first["closure"]["pairwise_residuals"],
+        fallback_second["closure"]["pairwise_residuals"],
+        atol=1e-12,
+    )
+    assert fallback_second["closure"]["summary"] == pytest.approx(
+        fallback_first["closure"]["summary"],
+        abs=1e-12,
+    )
+    assert fallback_second["antisymmetry"]["summary"] == pytest.approx(
+        fallback_first["antisymmetry"]["summary"],
+        abs=1e-12,
+    )
+    assert fallback_second["jacobi"]["summary"] == pytest.approx(
+        fallback_first["jacobi"]["summary"],
+        abs=1e-12,
+    )
+
+
+def test_v0_4_release_gate_heat_and_burgers_translation_paths_remain_exact() -> None:
+    heat_training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=50)
+    heat_heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=51)
+    burgers_training = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=52)
+    burgers_heldout = generate_burgers_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=53)
+
+    heat_generator = fit_translation_generator(heat_training, HeatResidualEvaluator(), epsilon=1e-4)
+    burgers_generator = fit_translation_generator(burgers_training, BurgersResidualEvaluator(), epsilon=1e-4)
+    heat_report = verify_translation_generator(heat_heldout, heat_generator, HeatResidualEvaluator())
+    burgers_report = verify_translation_generator(burgers_heldout, burgers_generator, BurgersResidualEvaluator())
+
+    for generator in (heat_generator, burgers_generator):
+        assert generator.parameterization == "polynomial_translation_affine"
+        assert generator.coefficients.shape == (1, 4)
+        assert generator.basis_spec["variables"] == ["t", "x", "u"]
+        assert generator.basis_spec["component_names"] == ["xi"]
+        assert generator.basis_spec["term_ordering"] == ["1", "t", "x", "u"]
+        assert generator.basis_spec["layout"] == "component_major"
+
+    assert heat_report.classification == "exact"
+    assert burgers_report.classification == "exact"
+
+
+def test_v0_4_release_gate_viz_smoke_returns_figures_with_noninteractive_backend() -> None:
+    generator = _translation_generator(
+        np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=float)
+    )
+    span_reference = _translation_generator(np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+    span_candidate = _translation_generator(np.array([[0.0, 1.0, 0.0, 0.0]], dtype=float))
+    closure_generator = _algebraic_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["1", "x"], powers=[[0], [1]]),
+    )
+    verification_report = _verification_report()
+    span_report = compare_generator_spans(span_reference, span_candidate)
+    closure_report = diagnose_generator_family_closure(closure_generator)
+
+    figures = [
+        plot_generator_coefficients(generator),
+        plot_generator_symbolic_summary(generator),
+        plot_verification_curve(verification_report),
+        plot_span_diagnostics(span_report),
+        plot_closure_diagnostics(closure_report),
+    ]
+
+    assert matplotlib.get_backend().lower() == "agg"
+    assert all(isinstance(figure, Figure) for figure in figures)


### PR DESCRIPTION
## Summary

This PR implements **V0.4 Milestone 6** as a release-gate milestone only.

It does not add new capabilities. Instead, it turns the already-implemented `v0.4` algebra-span stack into one explicit pytest + CI release gate over the frozen M1–M5 behavior.

The gate covers:

- `GeneratorFamily` migration / canonical serialization
- symbolic determinism
- span reproducibility
- closure reproducibility
- Heat/Burgers stable translation regression
- visualization smoke over the current M5 renderer suite

This follows the current `v0.4` execution plan and scope, where M6 is defined as the algebra-span release gate rather than a new feature milestone. 

## What changed

### New release-gate test module
Added a focused release-gate module:

- `tests/test_v0_4_release_gate.py`

This module is intentionally compact and high-signal. It does not replace the existing detailed unit tests; it adds one explicit top-level gate for the frozen `v0.4` guarantees.

### New CI visibility job
Added a dedicated GitHub Actions job:

- `v0_4-release-gate`

This job:
- installs the standard test environment
- runs only the release-gate module
- supplements the existing full editable/full-suite job and package-smoke job
- does not replace them

### Planning / scope updates
Updated:

- `PLAN.md`
- `V0_4_SCOPE.md`

to mark:
- M5 complete
- M6 active

and to clarify that M6 is a release-gate milestone only.

## Scope discipline

This PR does **not**:

- add new public APIs
- add new canonical objects
- change fitting behavior
- change span or closure semantics
- change visualization semantics
- broaden downstream behavior
- introduce weak-form or operator features

It is strictly a release-gate / CI visibility milestone. 

## What the gate asserts

The release-gate module checks the top-level `v0.4` guarantees only:

### 1. Migration / canonical serialization
- legacy translation payloads still upgrade cleanly
- canonical `GeneratorFamily` output remains explicit and stable
- backward compatibility remains limited to the intended translation slice

### 2. Symbolic determinism
- symbolic rendering is deterministic for canonical families
- legacy-upgraded translation renders identically to canonical translation

### 3. Span reproducibility
- representative exact multi-rank span fixtures give reproducible reports
- checks focus on high-signal outputs:
  - ranks
  - principal angles
  - projection residual summary

### 4. Closure reproducibility
- representative nontrivial closed families give reproducible closure diagnostics
- one deterministic fallback case is included where supported
- checks focus on high-signal outputs:
  - closure summary
  - antisymmetry summary
  - Jacobi summary
  - stable structure-constant tensor shape / repeated-output consistency

### 5. Heat/Burgers regression protection
- the current stable translation slice still works unchanged
- Heat and Burgers still verify as `exact`

### 6. Viz smoke
- all current M5 renderers return Matplotlib `Figure` objects
- the gate uses a non-interactive backend
- figures are closed cleanly
- no file writing or image snapshots are involved

## Numeric assertion policy

The release gate deliberately avoids brittle exact floating-point equality except where appropriate.

- exact equality is used for:
  - strings
  - clearly algebraic small fixtures where exact values are appropriate
- tolerant checks are used for floating outputs:
  - span outputs
  - closure outputs
  - repeated report comparisons

This is now part of the documented M6 release-gate policy. 

## Dependency / CI note

M6 excludes downstream and SymPy behavior from what it *tests*, but the dedicated CI job may still install the standard `.[test]` environment. This PR does not claim total optional-dependency isolation. It only makes the `v0.4` release gate explicit and visible in CI. 

## Result

This PR completes the final planned `v0.4` milestone by promoting the already-implemented algebra-span inspection stack into an explicit release gate.

After this PR, `v0.4` is feature-complete and has:
- M1: `GeneratorFamily` family semantics
- M2: symbolic display
- M3: span diagnostics
- M4: closure diagnostics
- M5: minimal renderer suite
- M6: explicit pytest + CI release gate

The next step after merge should be **release-surface alignment / RC hardening for `v0.4`**, not new feature work. 