### PR TITLE
release: prepare v0.4.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.4.0rc1
+
+First release candidate for the frozen V0.4 generator-family and algebra-diagnostics core.
+
+- canonical `GeneratorFamily` family semantics finalized with `schema_version = "0.2"`, family-shaped coefficients, and explicit `basis_spec`
+- runtime-only symbolic generator rendering added under `pdelie.symmetry`
+- optional runtime-only SymPy component expressions added under `pdelie.symmetry`
+- runtime-only span diagnostics added under `pdelie.symmetry`
+- runtime-only closure / structure-constant diagnostics added under `pdelie.symmetry`
+- optional Matplotlib visualization layer added under `pdelie.viz`
+- explicit V0.4 release-gate pytest module and `v0_4-release-gate` CI visibility job added
+- package metadata, README, milestone docs, and release-readiness docs aligned with the implemented V0.4 state
+
+Explicitly deferred for this release candidate:
+
+- weak-form methods
+- operator methods
+- broad adapters or interoperability expansion
+- stable multi-generator PDE fitting
+- broader downstream compatibility or prediction-facing workflows
+- new canonical stable objects beyond the current V0.4 slice
+
 ## 0.3.0
 
 First final release for the frozen V0.3 stable core.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,15 +1,15 @@
 # PDELie — Execution Plan (V0.4)
 
-## Current Active Milestone
+## Current State
 
-**V0.4 Milestone 6 — Algebra-span release gate**
+**V0.4 feature milestones complete — pre-`0.4.0rc1` release preparation**
 
 This file is the active execution plan for the current `v0.4` release series.
 
 It should contain:
 
 - a short record of the completed `v0.3` release
-- the frozen plan for the current active milestone
+- the frozen record of the completed `v0.4` milestone line
 - milestone-specific rules and gates
 
 It should **not** redefine package contracts or roadmap commitments. Those belong in:
@@ -132,11 +132,13 @@ Run at minimum:
 - `pytest tests/test_v0_4_release_gate.py`
 - full `pytest`
 
+Milestone 6 is now complete. No further V0.4 feature milestones are planned before `0.4.0rc1`.
+
 ---
 
 ## Later Milestones
 
-Strict sequencing for `v0.4`:
+Feature milestone sequencing for `v0.4` is complete.
 
 Hard sequencing rules:
 
@@ -167,4 +169,4 @@ Hard sequencing rules:
 - Milestone 3: **COMPLETE**
 - Milestone 4: **COMPLETE**
 - Milestone 5: **COMPLETE**
-- Milestone 6: **ACTIVE**
+- Milestone 6: **COMPLETE**

--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the stable V0.3 core on the frozen synthetic Heat/Burgers slice:
+The current repository implements the stable V0.4 core on the frozen synthetic Heat/Burgers slice:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
 - uniform periodic grid
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
+- family-shaped `GeneratorFamily` with explicit `basis_spec`
+- runtime-only symbolic helpers under `pdelie.symmetry`
+- runtime-only span and closure diagnostics under `pdelie.symmetry`
+- optional `pdelie.viz` visualization layer
 - one stable invariant canonical object: `InvariantMapSpec`
-- one runtime-only invariant path: `pdelie.invariants.InvariantApplier`
-- one runtime-only backend-specific downstream bridge: `pdelie.discovery.to_pysindy_trajectories`
+- one runtime-only invariant path retained from V0.3: `pdelie.invariants.InvariantApplier`
+- one runtime-only backend-specific downstream bridge retained from V0.3: `pdelie.discovery.to_pysindy_trajectories`
 
 ## Setup
 
@@ -26,13 +30,20 @@ conda activate pdelie
 
 ### Editable install
 
-The environment file installs the package in editable mode with test dependencies.
-
-To install manually from the repo root:
+Core install from the repo root:
 
 ```bash
-python -m pip install -e .[test]
+python -m pip install -e .
 ```
+
+### Optional dependencies
+
+- `.[viz]` adds the optional Matplotlib visualization layer exposed under `pdelie.viz`
+- `.[downstream]` adds the optional narrow PySINDy bridge path exposed under `pdelie.discovery`
+- `.[test]` installs the test environment used in CI and includes the current viz/downstream test dependencies
+- `sympy` is an optional runtime dependency for `pdelie.symmetry.to_sympy_component_expressions`; it is not required for the core install
+
+The downstream path is still intentionally narrow: it is currently validated on the PySINDy 1.x / scikit-learn 1.2.x line under Python `<3.12`, matching the policy in `pyproject.toml`.
 
 ## Run Tests
 
@@ -60,7 +71,7 @@ The packaged example currently demonstrates the stable Heat verification path on
 4. fit the polynomial spatial-translation baseline
 5. verify the generator on held-out heat batches
 
-V0.3 adds a stable invariant canonical object and narrow runtime-level invariant/downstream utilities, but it does not yet add a broad public discovery workflow.
+The packaged example remains Heat-only even though the frozen stable slice also covers Burgers.
 
 You can also call the example programmatically:
 
@@ -77,17 +88,24 @@ Included in the current stable core:
 
 - stable canonical objects and typed validation errors, including `InvariantMapSpec`
 - synthetic heat and Burgers data
-- polynomial translation baseline only
-- finite-transform verification only
+- polynomial translation baseline for the stable PDE slice
+- finite-transform verification for the stable PDE slice
+- family-shaped `GeneratorFamily` serialization and narrow translation compatibility migration
 - single-generator invariant map support
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
 
-Runtime-level public APIs in the frozen V0.3 slice:
+Runtime-level public APIs in the frozen V0.4 slice:
 
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
+- `pdelie.symmetry.render_generator_family` for deterministic symbolic display
+- `pdelie.symmetry.to_sympy_component_expressions` when `sympy` is installed at runtime
+- `pdelie.symmetry.compare_generator_spans` for runtime span diagnostics
+- `pdelie.symmetry.diagnose_generator_family_closure` for runtime closure diagnostics
+- `pdelie.viz.plot_generator_coefficients`, `plot_generator_symbolic_summary`, `plot_verification_curve`, `plot_span_diagnostics`, and `plot_closure_diagnostics` when `matplotlib` is installed
 
 Explicitly deferred:
+- stable multi-generator PDE fitting
 - multi-generator invariant machinery
 - broad downstream discovery contracts
 - operator symmetry

--- a/V0_4_RELEASE_READINESS.md
+++ b/V0_4_RELEASE_READINESS.md
@@ -1,0 +1,67 @@
+# V0.4 Release Readiness
+
+## Release Target
+
+- package version: `0.4.0rc1`
+- git tag: `v0.4.0rc1`
+
+## Done
+
+- canonical `GeneratorFamily` family semantics are implemented with `schema_version = "0.2"`, family-shaped coefficients, and explicit `basis_spec`
+- the narrow legacy single-generator translation compatibility path remains in place via `GeneratorFamily.from_dict()`
+- Heat remains supported under the existing stable path
+- Burgers remains supported under the existing stable path
+- the stable derivative backend remains `spectral_fd`
+- analytic Heat and Burgers residual evaluators remain in place
+- the polynomial spatial-translation fitting path remains the stable PDE fitting slice
+- the finite-transform verification path remains the stable verification slice
+- runtime-only symbolic generator rendering is implemented under `pdelie.symmetry`
+- optional runtime-only SymPy component expressions are implemented under `pdelie.symmetry`
+- runtime-only span diagnostics are implemented under `pdelie.symmetry`
+- runtime-only closure / structure-constant diagnostics are implemented under `pdelie.symmetry`
+- optional Matplotlib visualization is implemented under `pdelie.viz`
+- the V0.4 release-gate module and `v0_4-release-gate` CI visibility job are implemented
+- the full test suite passes from the repo root
+- package metadata, README, changelog, milestone docs, and release-readiness docs are aligned with the implemented V0.4 surface
+
+## Explicitly Deferred
+
+- weak-form methods beyond the reserved interface surface
+- operator methods
+- neural generators as stable API
+- broad dataset adapters or interoperability expansion
+- stable multi-generator PDE fitting
+- broader downstream compatibility or prediction-facing workflows
+- new canonical stable objects beyond the current V0.4 slice
+- paper-specific experiment logic
+
+## Release Candidate View
+
+The current repository is ready for the first `0.4.0rc1` release candidate for the frozen V0.4 stable core, subject to the release-path checks passing on the release branch and CI passing on the release PR.
+
+There are no known scientific-scope blockers inside the current V0.4 slice.
+
+`0.4.0rc1` is the first release candidate for the completed V0.4 milestone line. Any post-rc changes should be minimal blocker fixes only.
+
+## Packaging And Public API Notes
+
+- canonical `GeneratorFamily` output now uses `schema_version = "0.2"` and explicit `basis_spec`
+- the legacy translation compatibility path remains narrow and runtime-gated through `GeneratorFamily.from_dict()` only
+- `InvariantMapSpec` remains the only stable canonical object added in the V0.3 era; V0.4 adds runtime-level symbolic/span/closure/viz APIs without adding a new canonical object
+- `pdelie.viz` is optional via `pdelie[viz]`
+- the runtime downstream bridge remains optional via `pdelie[downstream]`
+- the downstream path is still intentionally narrow and currently validated on the PySINDy 1.x / scikit-learn 1.2.x line under Python `<3.12`
+- SymPy support is optional at runtime and is not part of the core install
+- the `v0_4-release-gate` CI job is an explicit visibility check; if it should block merges, repository branch-protection settings must be updated separately
+
+## Final Tag Checklist
+
+Before tagging `v0.4.0rc1`:
+
+- run `python -m pytest` from the repo root
+- run `python -m build --sdist --wheel`
+- install the built wheel into a clean environment and verify stable imports
+- run `python -m pdelie.examples.heat_vertical_slice`
+- confirm GitHub Actions jobs `v0_4-release-gate`, `editable-tests`, and `package-smoke` pass on the release PR commit
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.4.0rc1`

--- a/V0_4_SCOPE.md
+++ b/V0_4_SCOPE.md
@@ -361,7 +361,7 @@ Rotation-style fixtures must be coefficient-level algebra fixtures, not PDE/data
 - explicitly deferrable first if M1–M4 take longer than expected
 
 ### Milestone 6 — Algebra-span release gate
-**Status:** Active
+**Status:** Complete
 
 - one focused pytest release-gate module over the already-implemented M1–M5 behavior
 - one dedicated CI visibility job running only that release-gate module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.3.0"
-description = "Stable V0.3 invariant/downstream utility core for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
+version = "0.4.0rc1"
+description = "Stable V0.4 polynomial generator-family core with algebra diagnostics and optional visualization for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",


### PR DESCRIPTION
## Summary

This PR prepares **`v0.4.0rc1`** by aligning release metadata, top-level docs, and milestone status with the already-implemented `v0.4` surface.

It does **not** add any new scientific or runtime capability.  
It is a release-surface / RC-hardening pass only.

## Why this PR is needed

The runtime/code surface already contains the completed `v0.4` milestones:

- M1: `GeneratorFamily` family semantics and migration policy
- M2: runtime symbolic display
- M3: runtime span diagnostics
- M4: runtime closure diagnostics
- M5: minimal visualization suite
- M6: explicit algebra-span release gate

But the release-facing layer was still partly presenting the repo in `v0.3` terms and still marking milestone state as active rather than complete. This PR fixes that mismatch.

## What changed

### Release metadata
- bumps package metadata to `0.4.0rc1`
- updates package description to the actual `v0.4` surface

### Top-level docs
- updates `README.md` from `v0.3` framing to the current `v0.4` stable surface
- clarifies optional dependency boundaries:
  - `pdelie.viz` is optional
  - downstream remains optional
  - SymPy support is runtime-optional

### Changelog / release notes
- adds a `0.4.0rc1` changelog entry
- adds `V0_4_RELEASE_READINESS.md`

### Milestone state
- updates `PLAN.md` and `V0_4_SCOPE.md` so:
  - M1–M6 are no longer presented as active in-progress work
  - `v0.4` is represented as feature-complete and in RC-hardening / release-ready state

## Scope discipline

This PR does **not**:
- add new public APIs
- add new canonical objects
- change fitting behavior
- change symbolic/span/closure/viz semantics
- add weak-form or operator work
- broaden adapters or downstream capability

It is strictly a release-surface alignment pass for the frozen `v0.4` implementation.

## Current `v0.4` surface being released

The release candidate now accurately reflects the implemented `v0.4` stack:

- stable `GeneratorFamily` with family semantics and explicit `basis_spec`
- runtime symbolic rendering under `pdelie.symmetry`
- runtime span diagnostics under `pdelie.symmetry`
- runtime closure diagnostics under `pdelie.symmetry`
- optional `pdelie.viz` renderer suite
- Heat/Burgers stable paths preserved
- explicit M6 release-gate test + CI visibility job

## Validation

This PR is intended to be validated with the usual release path:

- `python -m pytest`
- `python -m build --sdist --wheel`
- wheel install/import smoke in a fresh environment
- packaged example smoke
- CI confirmation on:
  - editable/full suite
  - package smoke
  - `v0_4-release-gate`

## Result

After this PR, the repository should be ready for tagging and publishing **`v0.4.0rc1`** as a pre-release, with the release-facing layer finally matching the actual implemented `v0.4` feature set.