### PR TITLE
Freeze v0.5 planning docs around portability scope

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -38,6 +38,9 @@ Completed outcome:
 
 `v0.5` begins from that frozen release surface.
 
+This release series is portability / external compatibility first.
+It does not broaden numerics beyond the current Heat/Burgers stable regime.
+
 ---
 
 ## Milestone 1 — Generator-family Export/Import Manifest
@@ -59,6 +62,7 @@ This milestone is portability-only.
 - no KdV work in M1
 - no prediction utility in M1
 - no downstream benchmark expansion in M1
+- no broad numerics expansion in M1
 
 ### Deliverables
 
@@ -95,6 +99,14 @@ Run at minimum:
 
 ## Later Milestones
 
+Locked sequence:
+
+Milestone 1 -> manifest export/import portability  
+Milestone 2 -> external-family compatibility  
+Milestone 3 -> portability benchmark  
+Milestone 4 -> KdV feasibility  
+Milestone 5 -> V0.5 release gate
+
 - Milestone 2: external-family compatibility
 - Milestone 3: portability benchmark
 - Milestone 4: KdV feasibility
@@ -104,6 +116,7 @@ Hard sequencing rules:
 
 - do not promote KdV before the feasibility gate
 - do not add prediction utility until it has a precise task definition
+- do not broaden numerics during `v0.5` without an explicit scope reset
 - do not introduce weak-form methods inside `v0.5`
 - do not turn the manifest into a new canonical object without explicit review
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -195,7 +195,7 @@ Its purpose is:
 ### `v0.5` — Generator-family portability and external-family compatibility
 **Status:** Committed
 
-`v0.5` is the next planned release after the completed `v0.4` line.
+`v0.5` is the next committed release target after the completed `v0.4` line.
 
 Its purpose is:
 
@@ -216,6 +216,7 @@ Its purpose is:
 - no broad adapter ecosystem
 - no neural-operator workflow as stable scope
 - no weak-form expansion
+- no broad numerics expansion beyond the current stable regime
 - no broad PDE-zoo expansion
 
 ---
@@ -273,5 +274,5 @@ It should **not** be edited every time a new idea appears.
 - `v0.2` = add Burgers under the same stable pipeline
 - `v0.3` = first stable invariant/downstream utility via invariants
 - `v0.4` = Lie-algebra span, symbolic reporting, and visual diagnostics
-- `v0.5` = downstream compatibility and prediction utility
+- `v0.5` = generator-family portability and external-family compatibility, with KdV gated and prediction deferred
 - `v0.6+` = broader numerics, broader data, operator methods, and other experimental directions

--- a/docs/planning/V0_5_SCOPE.md
+++ b/docs/planning/V0_5_SCOPE.md
@@ -13,6 +13,7 @@ Instead, it asks:
 > Can learned or externally supplied polynomial Lie generator families be exported, imported, validated, inspected, and used in controlled downstream workflows without losing their semantics?
 
 `v0.5` is therefore a portability release, not a broader numerics or PDE-zoo release.
+Prediction-facing utility remains deferred unless it is narrowed later with a precise fixed task.
 
 ---
 
@@ -40,6 +41,7 @@ Deferred:
 - prediction-facing utility task unless explicitly narrowed
 - weak-form methods
 - operator methods
+- broad numerics expansion beyond the current stable regime
 - broad adapters
 - broad PDE zoo
 


### PR DESCRIPTION
- docs-only planning freeze
- no runtime changes
- freezes v0.5 as portability / external compatibility
- keeps KdV as feasibility only
- keeps prediction deferred
- prevents implementation drift before M1 starts