### PR TITLE
Add V0.5 M1 generator-family manifest export/import helpers

### DIFF
--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -52,6 +52,11 @@ Runtime public API for the frozen `v0.4` Milestone 5 slice:
 - `pdelie.viz.plot_span_diagnostics` for optional Matplotlib figures over frozen M3 span-diagnostic reports
 - `pdelie.viz.plot_closure_diagnostics` for optional Matplotlib figures over frozen M4 closure-diagnostic reports
 
+Runtime public API for the frozen `v0.5` Milestone 1 slice:
+
+- `pdelie.portability.export_generator_family_manifest` for dict-level export of a stable manifest artifact schema around canonical `GeneratorFamily` payloads
+- `pdelie.portability.import_generator_family_manifest` for dict-level validation/import of the frozen manifest schema back into canonical `GeneratorFamily`
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -109,6 +109,12 @@ Canonical meaning depends only on:
 `v0.4` direct construction is canonical-only.
 Legacy single-generator translation payloads are a narrow `from_dict()` compatibility path only.
 
+Stable `v0.5` runtime artifact note:
+
+- `pdelie.portability` may wrap a canonical `GeneratorFamily` payload in a stable export/import manifest artifact
+- the manifest is not a canonical object
+- canonical meaning remains only the nested `GeneratorFamily`
+
 ---
 
 ## InvariantMapSpec

--- a/src/pdelie/portability/__init__.py
+++ b/src/pdelie/portability/__init__.py
@@ -1,0 +1,9 @@
+from pdelie.portability.manifest import (
+    export_generator_family_manifest,
+    import_generator_family_manifest,
+)
+
+__all__ = [
+    "export_generator_family_manifest",
+    "import_generator_family_manifest",
+]

--- a/src/pdelie/portability/manifest.py
+++ b/src/pdelie/portability/manifest.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from pdelie.contracts import GeneratorFamily
+from pdelie.errors import SchemaValidationError
+
+
+MANIFEST_SCHEMA_VERSION = "0.1"
+MANIFEST_TYPE = "pdelie.generator_family_export"
+
+
+def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _validate_json_compatible(value: Any, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise SchemaValidationError(f"{path} keys must be strings.")
+            _validate_json_compatible(item, f"{path}[{key!r}]")
+        return
+
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _validate_json_compatible(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, bool) or value is None or isinstance(value, (str, int)):
+        return
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise SchemaValidationError(f"{path} must not contain non-finite floats.")
+        return
+
+    raise SchemaValidationError(f"{path} is not strict JSON-compatible.")
+
+
+def _validate_json_dump(payload: dict[str, Any]) -> None:
+    try:
+        json.dumps(payload, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError("Manifest payload must be strict JSON-compatible.") from exc
+
+
+def _validate_manifest_generator_family_payload(payload: Any) -> Mapping[str, Any]:
+    generator_family_payload = _require_mapping(payload, "generator_family")
+
+    if "schema_version" not in generator_family_payload:
+        raise SchemaValidationError(
+            "generator_family is missing required canonical GeneratorFamily fields: ['schema_version']."
+        )
+    if str(generator_family_payload["schema_version"]) != GeneratorFamily.SCHEMA_VERSION:
+        raise SchemaValidationError(
+            "generator_family must be a canonical GeneratorFamily payload with "
+            f"schema_version '{GeneratorFamily.SCHEMA_VERSION}'."
+        )
+
+    missing_fields = [
+        field
+        for field in ("schema_version", "parameterization", "coefficients", "basis_spec", "normalization")
+        if field not in generator_family_payload
+    ]
+    if missing_fields:
+        raise SchemaValidationError(
+            "generator_family is missing required canonical GeneratorFamily fields: "
+            f"{missing_fields}."
+        )
+    return generator_family_payload
+
+
+def export_generator_family_manifest(
+    generator: GeneratorFamily,
+    *,
+    pdelie_version: str | None = None,
+    symbolic: Any | None = None,
+    diagnostics: Mapping[str, Any] | None = None,
+    provenance: Mapping[str, Any] | None = None,
+    compatibility_hints: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(generator, GeneratorFamily):
+        raise SchemaValidationError("generator must be an in-memory GeneratorFamily.")
+    generator.validate()
+
+    manifest: dict[str, Any] = {
+        "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+        "manifest_type": MANIFEST_TYPE,
+        "generator_family": generator.to_dict(),
+    }
+
+    if pdelie_version is not None:
+        if not isinstance(pdelie_version, str) or not pdelie_version:
+            raise SchemaValidationError("pdelie_version must be a non-empty string when provided.")
+        manifest["pdelie_version"] = pdelie_version
+
+    if symbolic is not None:
+        manifest["symbolic"] = symbolic
+
+    for name, value in (
+        ("diagnostics", diagnostics),
+        ("provenance", provenance),
+        ("compatibility_hints", compatibility_hints),
+    ):
+        if value is None:
+            continue
+        if not isinstance(value, Mapping):
+            raise SchemaValidationError(f"{name} must be a mapping when provided.")
+        manifest[name] = value
+
+    _validate_json_compatible(manifest, "manifest")
+    _validate_json_dump(manifest)
+    return manifest
+
+
+def import_generator_family_manifest(payload: Mapping[str, Any]) -> GeneratorFamily:
+    manifest = _require_mapping(payload, "payload")
+
+    missing_fields = [
+        field
+        for field in ("manifest_schema_version", "manifest_type", "generator_family")
+        if field not in manifest
+    ]
+    if missing_fields:
+        raise SchemaValidationError(f"Manifest payload is missing required fields: {missing_fields}.")
+
+    manifest_schema_version = str(manifest["manifest_schema_version"])
+    manifest_type = str(manifest["manifest_type"])
+
+    if manifest_schema_version != MANIFEST_SCHEMA_VERSION:
+        raise SchemaValidationError(
+            f"Unsupported manifest_schema_version: {manifest_schema_version}."
+        )
+    if manifest_type != MANIFEST_TYPE:
+        raise SchemaValidationError(f"Unsupported manifest_type: {manifest_type}.")
+
+    generator_family_payload = _validate_manifest_generator_family_payload(manifest["generator_family"])
+    return GeneratorFamily.from_dict(generator_family_payload)

--- a/tests/test_portability_manifest.py
+++ b/tests/test_portability_manifest.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from pdelie import GeneratorFamily, SchemaValidationError
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.portability import (
+    export_generator_family_manifest,
+    import_generator_family_manifest,
+)
+
+
+def _make_translation_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={"source": "translation"},
+    )
+
+
+def _make_algebraic_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_point_family",
+        coefficients=np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 1.0],
+            ],
+            dtype=float,
+        ),
+        basis_spec={
+            "variables": ["x"],
+            "component_names": ["xi"],
+            "basis_terms": [
+                {"label": "1", "powers": [0]},
+                {"label": "x", "powers": [1]},
+                {"label": "x^2", "powers": [2]},
+            ],
+            "component_ordering": ["xi"],
+            "term_ordering": ["1", "x", "x^2"],
+            "layout": "component_major",
+        },
+        normalization="none",
+        generator_names=["const", "affine_plus_quadratic"],
+        diagnostics={"family": "algebraic"},
+    )
+
+
+def test_manifest_export_import_round_trip_for_translation_family() -> None:
+    generator = _make_translation_family()
+
+    manifest = export_generator_family_manifest(generator)
+    imported = import_generator_family_manifest(manifest)
+
+    assert manifest["manifest_schema_version"] == "0.1"
+    assert manifest["manifest_type"] == "pdelie.generator_family_export"
+    assert manifest["generator_family"] == generator.to_dict()
+    assert imported.to_dict() == generator.to_dict()
+
+
+def test_manifest_export_import_round_trip_for_non_translation_family() -> None:
+    generator = _make_algebraic_family()
+
+    manifest = export_generator_family_manifest(generator)
+    imported = import_generator_family_manifest(manifest)
+
+    assert manifest["generator_family"] == generator.to_dict()
+    assert imported.to_dict() == generator.to_dict()
+
+
+def test_manifest_supports_literal_json_round_trip() -> None:
+    generator = _make_translation_family()
+
+    manifest = export_generator_family_manifest(
+        generator,
+        pdelie_version="0.5.0",
+        symbolic=["xi = 1"],
+        diagnostics={"stage": "m1"},
+        provenance={"source": "unit-test"},
+        compatibility_hints={"downstream": "narrow-translation"},
+    )
+
+    loaded_manifest = json.loads(json.dumps(manifest, allow_nan=False))
+    imported = import_generator_family_manifest(loaded_manifest)
+
+    assert loaded_manifest == manifest
+    assert imported.to_dict() == generator.to_dict()
+
+
+def test_manifest_optional_metadata_is_non_authoritative() -> None:
+    generator = _make_translation_family()
+
+    manifest_a = export_generator_family_manifest(
+        generator,
+        pdelie_version="0.5.0a1",
+        symbolic=["xi = 1"],
+        diagnostics={"tag": "a"},
+        provenance={"source": "first"},
+        compatibility_hints={"backend": "alpha"},
+    )
+    manifest_b = export_generator_family_manifest(
+        generator,
+        pdelie_version="0.5.0",
+        symbolic=["translation"],
+        diagnostics={"tag": "b"},
+        provenance={"source": "second"},
+        compatibility_hints={"backend": "beta"},
+    )
+
+    imported_a = import_generator_family_manifest(manifest_a)
+    imported_b = import_generator_family_manifest(manifest_b)
+
+    assert imported_a.to_dict() == generator.to_dict()
+    assert imported_b.to_dict() == generator.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({}, "missing required fields"),
+        (
+            {
+                "manifest_type": "pdelie.generator_family_export",
+                "generator_family": _make_translation_family().to_dict(),
+            },
+            "missing required fields",
+        ),
+        (
+            {
+                "manifest_schema_version": "0.1",
+                "generator_family": _make_translation_family().to_dict(),
+            },
+            "missing required fields",
+        ),
+        (
+            {
+                "manifest_schema_version": "0.1",
+                "manifest_type": "pdelie.generator_family_export",
+            },
+            "missing required fields",
+        ),
+        ("not-a-mapping", "payload must be a mapping"),
+        (
+            {
+                "manifest_schema_version": "0.1",
+                "manifest_type": "wrong.type",
+                "generator_family": _make_translation_family().to_dict(),
+            },
+            "Unsupported manifest_type",
+        ),
+        (
+            {
+                "manifest_schema_version": "0.2",
+                "manifest_type": "pdelie.generator_family_export",
+                "generator_family": _make_translation_family().to_dict(),
+            },
+            "Unsupported manifest_schema_version",
+        ),
+    ],
+)
+def test_manifest_import_rejects_malformed_manifest_shapes(payload: object, match: str) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        import_generator_family_manifest(payload)  # type: ignore[arg-type]
+
+
+def test_manifest_import_rejects_legacy_nested_generator_family_payload() -> None:
+    manifest = {
+        "manifest_schema_version": "0.1",
+        "manifest_type": "pdelie.generator_family_export",
+        "generator_family": {
+            "schema_version": "0.1",
+            "parameterization": "polynomial_translation_affine",
+            "coefficients": [1.0, 0.0, 0.0, 0.0],
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        },
+    }
+
+    with pytest.raises(SchemaValidationError, match="canonical GeneratorFamily payload"):
+        import_generator_family_manifest(manifest)
+
+
+def test_manifest_import_propagates_typed_canonical_nested_payload_errors() -> None:
+    manifest = export_generator_family_manifest(_make_translation_family())
+    manifest["generator_family"] = {
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+        "basis_spec": _translation_generator_basis_spec(),
+        "normalization": "l2_unit",
+        "diagnostics": "not-a-mapping",
+    }
+
+    with pytest.raises(SchemaValidationError, match="diagnostics must be a mapping"):
+        import_generator_family_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"diagnostics": {"bad": float("nan")}},
+        {"diagnostics": {"bad": float("inf")}},
+    ],
+)
+def test_manifest_export_rejects_non_finite_optional_metadata(kwargs: dict[str, object]) -> None:
+    with pytest.raises(SchemaValidationError, match="non-finite"):
+        export_generator_family_manifest(_make_translation_family(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"diagnostics": {1: "value"}},
+        {"provenance": {"ok": object()}},
+        {"compatibility_hints": ["not", "a", "mapping"]},
+    ],
+)
+def test_manifest_export_rejects_non_strict_json_optional_metadata(kwargs: dict[str, object]) -> None:
+    with pytest.raises(SchemaValidationError):
+        export_generator_family_manifest(_make_translation_family(), **kwargs)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -31,6 +31,10 @@ def test_stable_public_api_is_importable() -> None:
 def test_runtime_package_api_is_importable() -> None:
     from pdelie.discovery import to_pysindy_trajectories
     from pdelie.invariants import InvariantApplier
+    from pdelie.portability import (
+        export_generator_family_manifest,
+        import_generator_family_manifest,
+    )
     from pdelie.symmetry import (
         compare_generator_spans,
         diagnose_generator_family_closure,
@@ -47,6 +51,8 @@ def test_runtime_package_api_is_importable() -> None:
 
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
+    assert export_generator_family_manifest is not None
+    assert import_generator_family_manifest is not None
     assert compare_generator_spans is not None
     assert diagnose_generator_family_closure is not None
     assert render_generator_family is not None
@@ -61,6 +67,8 @@ def test_runtime_package_api_is_importable() -> None:
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
+    assert not hasattr(pdelie, "export_generator_family_manifest")
+    assert not hasattr(pdelie, "import_generator_family_manifest")
     assert not hasattr(pdelie, "compare_generator_spans")
     assert not hasattr(pdelie, "diagnose_generator_family_closure")
     assert not hasattr(pdelie, "render_generator_family")
@@ -84,6 +92,15 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
 
     assert hasattr(discovery_module, "to_pysindy_trajectories")
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
+
+
+def test_portability_package_runtime_api_matches_frozen_m1_surface() -> None:
+    portability_module = importlib.import_module("pdelie.portability")
+
+    assert hasattr(portability_module, "export_generator_family_manifest")
+    assert hasattr(portability_module, "import_generator_family_manifest")
+    assert not hasattr(portability_module, "coerce_generator_family")
+    assert not hasattr(portability_module, "GeneratorFamily")
 
 
 def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:


### PR DESCRIPTION
## Summary

Implements `v0.5` Milestone 1 only.

This PR adds a narrow manifest artifact layer around canonical `GeneratorFamily` payloads through a new runtime-only public module:

- `pdelie.portability.export_generator_family_manifest(...)`
- `pdelie.portability.import_generator_family_manifest(...)`

The milestone stays manifest-only:
- no new canonical object
- no root-level exports
- no broader external-family coercion yet
- no KdV work
- no prediction/downstream expansion
- no fitting/span/closure/viz semantic changes

## What Changed

### New runtime module
Added:
- `src/pdelie/portability/__init__.py`
- `src/pdelie/portability/manifest.py`

Exposed runtime public API:
- `export_generator_family_manifest`
- `import_generator_family_manifest`

No changes were made to `pdelie.__init__`.

### Frozen manifest semantics
The manifest schema is:
- `manifest_schema_version = "0.1"`
- `manifest_type = "pdelie.generator_family_export"`
- required:
  - `manifest_schema_version`
  - `manifest_type`
  - `generator_family`

Rules implemented:
- `generator_family` must be a canonical `GeneratorFamily.to_dict()` payload
- nested legacy `0.1` translation payloads are rejected inside manifests
- optional metadata is non-authoritative:
  - `pdelie_version`
  - `symbolic`
  - `diagnostics`
  - `provenance`
  - `compatibility_hints`
- import ignores optional metadata when reconstructing the canonical `GeneratorFamily`
- export does not compute symbolic or diagnostic content implicitly

### JSON compatibility policy
Export is intentionally strict:
- manifest payload must pass recursive JSON-compatibility validation
- optional metadata mapping keys must be strings
- non-finite floats are rejected
- non-JSON-compatible objects are rejected
- final validation uses `json.dumps(..., allow_nan=False)`

### Docs
Updated:
- `docs/specs/API_STABILITY.md`
- `docs/specs/SPEC.md`

These updates document the new runtime public API and clarify that the manifest is a stable artifact schema, not a canonical object.

### Tests
Added:
- `tests/test_portability_manifest.py`

Updated:
- `tests/test_public_api.py`

Coverage includes:
- canonical translation manifest export/import round-trip
- non-translation algebraic family round-trip
- literal JSON round-trip through `json.dumps` / `json.loads`
- optional metadata non-authority
- malformed manifest rejection
- typed propagation of malformed nested canonical family payloads
- strict rejection of non-finite / non-JSON-compatible optional metadata
- runtime package surface checks for `pdelie.portability`

## What Did Not Change

- no canonical object contracts
- no `pdelie.__init__` exports
- no `coerce_generator_family(...)`
- no file I/O helpers
- no downstream benchmark work
- no KdV work
- no prediction-facing scope
- no stable API widening outside `pdelie.portability`

## Validation

Ran:
- `pytest tests/test_portability_manifest.py tests/test_contracts.py tests/test_public_api.py`
- `pytest`

Results:
- `49 passed` on the narrow test pass
- `188 passed, 388 warnings` on the full suite

The warnings are the existing optional downstream/PySINDy warnings and are unchanged by this PR.
