### PR TITLE
Add V0.5 M2 strict generator-family coercion

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.5 Milestone 1 — Generator-family export/import manifest**
+**V0.5 Milestone 2 — External-family compatibility**
 
 This file is the active execution plan for the current `v0.5` release series.
 
@@ -44,6 +44,8 @@ It does not broaden numerics beyond the current Heat/Burgers stable regime.
 ---
 
 ## Milestone 1 — Generator-family Export/Import Manifest
+
+**Status:** Complete
 
 ### Goal
 
@@ -97,6 +99,33 @@ Run at minimum:
 
 ---
 
+## Milestone 2 — External-family Compatibility
+
+**Status:** Active
+
+### Goal
+
+Normalize the frozen `v0.5` input forms into canonical `GeneratorFamily` objects without widening the existing symbolic/span/closure/viz helper signatures.
+
+### Frozen Decisions
+
+- add `pdelie.portability.coerce_generator_family(...)`
+- accept only:
+  - canonical in-memory `GeneratorFamily`
+  - canonical `GeneratorFamily.to_dict()` payloads
+  - frozen manifest payloads
+  - the existing legacy `0.1` translation payload
+- canonical in-memory input returns as-is after validation
+- malformed structure -> schema error
+- unsupported external conventions -> scope error
+- shape mismatch -> shape error
+- unknown top-level manifest fields are rejected
+- no downstream smoke in M2
+- no KdV work in M2
+- no prediction work in M2
+
+---
+
 ## Later Milestones
 
 Locked sequence:
@@ -137,8 +166,8 @@ Hard sequencing rules:
 ## Status
 
 - `v0.4`: COMPLETE
-- Milestone 1: ACTIVE
-- Milestone 2: PLANNED
+- Milestone 1: COMPLETE
+- Milestone 2: ACTIVE
 - Milestone 3: PLANNED
 - Milestone 4: PLANNED / GATED
 - Milestone 5: PLANNED

--- a/docs/planning/V0_5_SCOPE.md
+++ b/docs/planning/V0_5_SCOPE.md
@@ -85,6 +85,12 @@ Optional fields:
 - `provenance`
 - downstream compatibility hints
 
+Top-level manifest field policy in stable `v0.5`:
+
+- required fields must exist
+- known optional fields may exist
+- unknown top-level manifest fields are rejected
+
 The mathematical content of the manifest is the canonical `GeneratorFamily`.
 
 Symbolic summaries, span diagnostics, closure diagnostics, visualization hints, and provenance are optional metadata. They are not canonical meaning.
@@ -135,7 +141,7 @@ Until that is frozen, prediction utility remains `v0.6+` planning.
 ## Frozen Milestones
 
 ### Milestone 1 — Generator-family export/import manifest
-**Status:** Planned
+**Status:** Complete
 
 - define manifest schema
 - export canonical `GeneratorFamily`
@@ -143,7 +149,7 @@ Until that is frozen, prediction utility remains `v0.6+` planning.
 - no new canonical object unless unavoidable
 
 ### Milestone 2 — External-family compatibility
-**Status:** Planned
+**Status:** Active
 
 - validate externally supplied canonical generator families
 - support runtime dict/object ingestion

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -57,6 +57,10 @@ Runtime public API for the frozen `v0.5` Milestone 1 slice:
 - `pdelie.portability.export_generator_family_manifest` for dict-level export of a stable manifest artifact schema around canonical `GeneratorFamily` payloads
 - `pdelie.portability.import_generator_family_manifest` for dict-level validation/import of the frozen manifest schema back into canonical `GeneratorFamily`
 
+Runtime public API for the frozen `v0.5` Milestone 2 slice:
+
+- `pdelie.portability.coerce_generator_family` for strict normalization of canonical in-memory families, canonical family payloads, manifests, and the narrow legacy translation payload into canonical `GeneratorFamily`
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -114,6 +114,7 @@ Stable `v0.5` runtime artifact note:
 - `pdelie.portability` may wrap a canonical `GeneratorFamily` payload in a stable export/import manifest artifact
 - the manifest is not a canonical object
 - canonical meaning remains only the nested `GeneratorFamily`
+- stable `v0.5` manifest validation rejects unknown top-level manifest fields
 
 ---
 

--- a/src/pdelie/portability/__init__.py
+++ b/src/pdelie/portability/__init__.py
@@ -1,9 +1,11 @@
+from pdelie.portability.coercion import coerce_generator_family
 from pdelie.portability.manifest import (
     export_generator_family_manifest,
     import_generator_family_manifest,
 )
 
 __all__ = [
+    "coerce_generator_family",
     "export_generator_family_manifest",
     "import_generator_family_manifest",
 ]

--- a/src/pdelie/portability/_validation.py
+++ b/src/pdelie/portability/_validation.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pdelie.contracts import GeneratorFamily
+from pdelie.errors import ScopeValidationError
+
+
+def _validate_supported_external_family(generator: GeneratorFamily) -> None:
+    if not generator.parameterization.startswith("polynomial_"):
+        raise ScopeValidationError(
+            "V0.5 Milestone 2 only supports polynomial GeneratorFamily parameterizations."
+        )

--- a/src/pdelie/portability/coercion.py
+++ b/src/pdelie/portability/coercion.py
@@ -4,15 +4,9 @@ from collections.abc import Mapping
 from typing import Any
 
 from pdelie.contracts import GeneratorFamily
-from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.errors import SchemaValidationError
 from pdelie.portability.manifest import import_generator_family_manifest
-
-
-def _validate_supported_external_family(generator: GeneratorFamily) -> None:
-    if not generator.parameterization.startswith("polynomial_"):
-        raise ScopeValidationError(
-            "coerce_generator_family only supports polynomial GeneratorFamily parameterizations in V0.5 Milestone 2."
-        )
+from pdelie.portability._validation import _validate_supported_external_family
 
 
 def coerce_generator_family(source: Any) -> GeneratorFamily:
@@ -31,7 +25,13 @@ def coerce_generator_family(source: Any) -> GeneratorFamily:
         return import_generator_family_manifest(source)
 
     if "schema_version" in source and "parameterization" in source:
-        generator = GeneratorFamily.from_dict(source)
+        try:
+            generator = GeneratorFamily.from_dict(source)
+        except KeyError as exc:
+            missing_key = exc.args[0] if exc.args else "<unknown>"
+            raise SchemaValidationError(
+                f"Invalid canonical GeneratorFamily payload: missing required field {missing_key!r}."
+            ) from exc
         _validate_supported_external_family(generator)
         return generator
 

--- a/src/pdelie/portability/coercion.py
+++ b/src/pdelie/portability/coercion.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from pdelie.contracts import GeneratorFamily
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.portability.manifest import import_generator_family_manifest
+
+
+def _validate_supported_external_family(generator: GeneratorFamily) -> None:
+    if not generator.parameterization.startswith("polynomial_"):
+        raise ScopeValidationError(
+            "coerce_generator_family only supports polynomial GeneratorFamily parameterizations in V0.5 Milestone 2."
+        )
+
+
+def coerce_generator_family(source: Any) -> GeneratorFamily:
+    if isinstance(source, GeneratorFamily):
+        source.validate()
+        _validate_supported_external_family(source)
+        return source
+
+    if not isinstance(source, Mapping):
+        raise SchemaValidationError(
+            "coerce_generator_family supports only GeneratorFamily objects, canonical GeneratorFamily payloads, "
+            "generator-family manifests, and the legacy 0.1 translation payload."
+        )
+
+    if "manifest_type" in source:
+        return import_generator_family_manifest(source)
+
+    if "schema_version" in source and "parameterization" in source:
+        generator = GeneratorFamily.from_dict(source)
+        _validate_supported_external_family(generator)
+        return generator
+
+    raise SchemaValidationError(
+        "coerce_generator_family supports only GeneratorFamily objects, canonical GeneratorFamily payloads, "
+        "generator-family manifests, and the legacy 0.1 translation payload."
+    )
+
+
+__all__ = ["coerce_generator_family"]

--- a/src/pdelie/portability/manifest.py
+++ b/src/pdelie/portability/manifest.py
@@ -6,7 +6,8 @@ from collections.abc import Mapping
 from typing import Any
 
 from pdelie.contracts import GeneratorFamily
-from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.errors import SchemaValidationError
+from pdelie.portability._validation import _validate_supported_external_family
 
 
 MANIFEST_SCHEMA_VERSION = "0.1"
@@ -53,13 +54,6 @@ def _validate_json_dump(payload: dict[str, Any]) -> None:
         json.dumps(payload, allow_nan=False)
     except (TypeError, ValueError) as exc:
         raise SchemaValidationError("Manifest payload must be strict JSON-compatible.") from exc
-
-
-def _validate_supported_external_family(generator: GeneratorFamily) -> None:
-    if not generator.parameterization.startswith("polynomial_"):
-        raise ScopeValidationError(
-            "Manifest import only supports polynomial GeneratorFamily parameterizations in V0.5 Milestone 2."
-        )
 
 
 def _validate_manifest_generator_family_payload(payload: Any) -> Mapping[str, Any]:
@@ -126,6 +120,7 @@ def export_generator_family_manifest(
     if not isinstance(generator, GeneratorFamily):
         raise SchemaValidationError("generator must be an in-memory GeneratorFamily.")
     generator.validate()
+    _validate_supported_external_family(generator)
 
     manifest: dict[str, Any] = {
         "manifest_schema_version": MANIFEST_SCHEMA_VERSION,

--- a/src/pdelie/portability/manifest.py
+++ b/src/pdelie/portability/manifest.py
@@ -6,11 +6,16 @@ from collections.abc import Mapping
 from typing import Any
 
 from pdelie.contracts import GeneratorFamily
-from pdelie.errors import SchemaValidationError
+from pdelie.errors import SchemaValidationError, ScopeValidationError
 
 
 MANIFEST_SCHEMA_VERSION = "0.1"
 MANIFEST_TYPE = "pdelie.generator_family_export"
+_REQUIRED_MANIFEST_FIELDS = frozenset({"manifest_schema_version", "manifest_type", "generator_family"})
+_OPTIONAL_MANIFEST_FIELDS = frozenset(
+    {"pdelie_version", "symbolic", "diagnostics", "provenance", "compatibility_hints"}
+)
+_ALLOWED_MANIFEST_FIELDS = _REQUIRED_MANIFEST_FIELDS | _OPTIONAL_MANIFEST_FIELDS
 
 
 def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
@@ -50,6 +55,13 @@ def _validate_json_dump(payload: dict[str, Any]) -> None:
         raise SchemaValidationError("Manifest payload must be strict JSON-compatible.") from exc
 
 
+def _validate_supported_external_family(generator: GeneratorFamily) -> None:
+    if not generator.parameterization.startswith("polynomial_"):
+        raise ScopeValidationError(
+            "Manifest import only supports polynomial GeneratorFamily parameterizations in V0.5 Milestone 2."
+        )
+
+
 def _validate_manifest_generator_family_payload(payload: Any) -> Mapping[str, Any]:
     generator_family_payload = _require_mapping(payload, "generator_family")
 
@@ -76,6 +88,32 @@ def _validate_manifest_generator_family_payload(payload: Any) -> Mapping[str, An
     return generator_family_payload
 
 
+def _validate_manifest_top_level_fields(manifest: Mapping[str, Any]) -> None:
+    unknown_fields = sorted(set(manifest) - _ALLOWED_MANIFEST_FIELDS)
+    if unknown_fields:
+        raise SchemaValidationError(
+            f"Manifest payload includes unknown top-level fields: {unknown_fields}."
+        )
+
+
+def _validate_manifest_optional_metadata(manifest: Mapping[str, Any]) -> None:
+    if "pdelie_version" in manifest:
+        value = manifest["pdelie_version"]
+        if not isinstance(value, str) or not value:
+            raise SchemaValidationError("pdelie_version must be a non-empty string when provided.")
+
+    if "symbolic" in manifest:
+        _validate_json_compatible(manifest["symbolic"], "manifest['symbolic']")
+
+    for name in ("diagnostics", "provenance", "compatibility_hints"):
+        if name not in manifest:
+            continue
+        value = manifest[name]
+        if not isinstance(value, Mapping):
+            raise SchemaValidationError(f"{name} must be a mapping when provided.")
+        _validate_json_compatible(value, f"manifest['{name}']")
+
+
 def export_generator_family_manifest(
     generator: GeneratorFamily,
     *,
@@ -96,8 +134,6 @@ def export_generator_family_manifest(
     }
 
     if pdelie_version is not None:
-        if not isinstance(pdelie_version, str) or not pdelie_version:
-            raise SchemaValidationError("pdelie_version must be a non-empty string when provided.")
         manifest["pdelie_version"] = pdelie_version
 
     if symbolic is not None:
@@ -114,6 +150,8 @@ def export_generator_family_manifest(
             raise SchemaValidationError(f"{name} must be a mapping when provided.")
         manifest[name] = value
 
+    _validate_manifest_top_level_fields(manifest)
+    _validate_manifest_optional_metadata(manifest)
     _validate_json_compatible(manifest, "manifest")
     _validate_json_dump(manifest)
     return manifest
@@ -121,10 +159,11 @@ def export_generator_family_manifest(
 
 def import_generator_family_manifest(payload: Mapping[str, Any]) -> GeneratorFamily:
     manifest = _require_mapping(payload, "payload")
+    _validate_manifest_top_level_fields(manifest)
 
     missing_fields = [
         field
-        for field in ("manifest_schema_version", "manifest_type", "generator_family")
+        for field in _REQUIRED_MANIFEST_FIELDS
         if field not in manifest
     ]
     if missing_fields:
@@ -140,5 +179,8 @@ def import_generator_family_manifest(payload: Mapping[str, Any]) -> GeneratorFam
     if manifest_type != MANIFEST_TYPE:
         raise SchemaValidationError(f"Unsupported manifest_type: {manifest_type}.")
 
+    _validate_manifest_optional_metadata(manifest)
     generator_family_payload = _validate_manifest_generator_family_payload(manifest["generator_family"])
-    return GeneratorFamily.from_dict(generator_family_payload)
+    generator = GeneratorFamily.from_dict(generator_family_payload)
+    _validate_supported_external_family(generator)
+    return generator

--- a/tests/test_portability_coercion.py
+++ b/tests/test_portability_coercion.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import importlib
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from pdelie import GeneratorFamily, SchemaValidationError, ScopeValidationError, ShapeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.portability import (
+    coerce_generator_family,
+    export_generator_family_manifest,
+)
+from pdelie.symmetry import (
+    compare_generator_spans,
+    diagnose_generator_family_closure,
+    render_generator_family,
+    to_sympy_component_expressions,
+)
+from pdelie.viz import (
+    plot_closure_diagnostics,
+    plot_generator_coefficients,
+    plot_generator_symbolic_summary,
+    plot_span_diagnostics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures() -> None:
+    yield
+    plt.close("all")
+
+
+def _make_translation_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={"source": "translation"},
+    )
+
+
+def _x_basis_spec(*, labels: list[str], powers: list[list[int]]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": label, "powers": power}
+            for label, power in zip(labels, powers)
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _velocity_basis_spec(labels: list[str]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["velocity"],
+        "basis_terms": [
+            {"label": labels[0], "powers": [0]},
+            {"label": labels[1], "powers": [1]},
+        ],
+        "component_ordering": ["velocity"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _make_polynomial_family(
+    coefficients: np.ndarray,
+    *,
+    basis_spec: dict[str, object],
+    normalization: str = "runtime_fixture",
+    parameterization: str = "polynomial_point_family",
+) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization=parameterization,
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization=normalization,
+        diagnostics={},
+    )
+
+
+def test_coerce_generator_family_returns_same_canonical_object_for_in_memory_input() -> None:
+    generator = _make_translation_family()
+
+    coerced = coerce_generator_family(generator)
+
+    assert coerced is generator
+
+
+def test_coerce_generator_family_accepts_canonical_family_payload() -> None:
+    generator = _make_polynomial_family(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+
+    coerced = coerce_generator_family(generator.to_dict())
+
+    assert coerced.to_dict() == generator.to_dict()
+
+
+def test_coerce_generator_family_accepts_manifest_payload() -> None:
+    generator = _make_translation_family()
+    manifest = export_generator_family_manifest(generator, symbolic=["xi = 1"])
+
+    coerced = coerce_generator_family(manifest)
+
+    assert coerced.to_dict() == generator.to_dict()
+
+
+def test_coerce_generator_family_upgrades_legacy_translation_payload() -> None:
+    legacy_payload = {
+        "schema_version": "0.1",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [1.0, 0.0, 0.0, 0.0],
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+    coerced = coerce_generator_family(legacy_payload)
+
+    assert coerced.schema_version == "0.2"
+    assert coerced.to_dict()["basis_spec"]["variables"] == ["t", "x", "u"]
+    np.testing.assert_allclose(coerced.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
+
+
+@pytest.mark.parametrize("value", ["not-a-mapping", 123, 1.5, ["x"]])
+def test_coerce_generator_family_rejects_non_mapping_non_family_inputs(value: object) -> None:
+    with pytest.raises(SchemaValidationError, match="supports only GeneratorFamily objects"):
+        coerce_generator_family(value)
+
+
+def test_coerce_generator_family_treats_manifest_like_payload_only_as_manifest() -> None:
+    payload = {
+        "manifest_type": "pdelie.generator_family_export",
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [[1.0, 0.0, 0.0, 0.0]],
+        "basis_spec": _translation_generator_basis_spec(),
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+    with pytest.raises(SchemaValidationError, match="unknown top-level fields|missing required fields"):
+        coerce_generator_family(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"schema_version": "0.2"},
+        {"parameterization": "polynomial_translation_affine"},
+        {"generator_family": _make_translation_family().to_dict()},
+    ],
+)
+def test_coerce_generator_family_rejects_partial_or_discriminator_free_payloads(
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(SchemaValidationError, match="supports only GeneratorFamily objects"):
+        coerce_generator_family(payload)
+
+
+def test_coerce_generator_family_rejects_well_formed_but_out_of_scope_parameterizations() -> None:
+    payload = {
+        "schema_version": "0.2",
+        "parameterization": "affine_external_family",
+        "coefficients": [[1.0, 0.0]],
+        "basis_spec": _x_basis_spec(labels=["1", "x"], powers=[[0], [1]]),
+        "normalization": "runtime_fixture",
+        "diagnostics": {},
+    }
+
+    with pytest.raises(ScopeValidationError, match="only supports polynomial GeneratorFamily parameterizations"):
+        coerce_generator_family(payload)
+
+
+def test_coerce_generator_family_preserves_shape_validation_errors() -> None:
+    payload = {
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [1.0, 0.0, 0.0, 0.0],
+        "basis_spec": _translation_generator_basis_spec(),
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+    with pytest.raises(ShapeValidationError, match="coefficients must be a non-empty two-dimensional array"):
+        coerce_generator_family(payload)
+
+
+def test_coerced_translation_family_matches_canonical_symbolic_rendering() -> None:
+    canonical = _make_translation_family()
+    from_dict = coerce_generator_family(canonical.to_dict())
+    from_manifest = coerce_generator_family(export_generator_family_manifest(canonical))
+    from_legacy = coerce_generator_family(
+        {
+            "schema_version": "0.1",
+            "parameterization": "polynomial_translation_affine",
+            "coefficients": [1.0, 0.0, 0.0, 0.0],
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        }
+    )
+
+    expected = render_generator_family(canonical)
+
+    assert render_generator_family(from_dict) == expected
+    assert render_generator_family(from_manifest) == expected
+    assert render_generator_family(from_legacy) == expected
+
+
+def test_coerced_translation_family_matches_canonical_sympy_expressions_when_available() -> None:
+    if importlib.util.find_spec("sympy") is None:
+        pytest.skip("sympy is not installed")
+
+    canonical = _make_translation_family()
+    coerced = coerce_generator_family(export_generator_family_manifest(canonical))
+
+    assert to_sympy_component_expressions(coerced) == to_sympy_component_expressions(canonical)
+
+
+def test_coerced_polynomial_family_matches_canonical_span_diagnostics() -> None:
+    canonical = _make_polynomial_family(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+    coerced = coerce_generator_family(canonical.to_dict())
+
+    report = compare_generator_spans(canonical, coerced)
+
+    assert report["comparison_rank"] == 2
+    np.testing.assert_allclose(report["principal_angles_radians"], [0.0, 0.0], atol=1e-7)
+    assert report["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+
+def test_coerced_fallback_closure_fixture_matches_canonical_closure_diagnostics() -> None:
+    canonical = _make_polynomial_family(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(["offset", "linear"]),
+    )
+    coerced = coerce_generator_family(export_generator_family_manifest(canonical))
+
+    canonical_report = diagnose_generator_family_closure(
+        canonical,
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+    coerced_report = diagnose_generator_family_closure(
+        coerced,
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+
+    assert coerced_report["computation_mode"] == canonical_report["computation_mode"] == "sampled_projection"
+    assert coerced_report["family_rank"] == canonical_report["family_rank"]
+    assert coerced_report["closure"]["summary"] == pytest.approx(canonical_report["closure"]["summary"], abs=1e-12)
+    assert coerced_report["antisymmetry"]["summary"] == pytest.approx(
+        canonical_report["antisymmetry"]["summary"],
+        abs=1e-12,
+    )
+    assert coerced_report["jacobi"]["summary"] == pytest.approx(canonical_report["jacobi"]["summary"], abs=1e-12)
+    np.testing.assert_allclose(
+        coerced_report["structure_constants"]["tensor"],
+        canonical_report["structure_constants"]["tensor"],
+        atol=1e-12,
+    )
+
+
+def test_coerced_families_work_with_existing_viz_helpers() -> None:
+    translation = _make_translation_family()
+    translation_coerced = coerce_generator_family(export_generator_family_manifest(translation))
+
+    span_reference = _make_polynomial_family(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+    span_candidate = coerce_generator_family(span_reference.to_dict())
+    span_report = compare_generator_spans(span_reference, span_candidate)
+
+    closure_family = _make_polynomial_family(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(["offset", "linear"]),
+    )
+    closure_report = diagnose_generator_family_closure(
+        coerce_generator_family(export_generator_family_manifest(closure_family)),
+        component_targets={"velocity": "x"},
+        computation_mode="auto",
+    )
+
+    figures = [
+        plot_generator_coefficients(translation_coerced),
+        plot_generator_symbolic_summary(translation_coerced),
+        plot_span_diagnostics(span_report),
+        plot_closure_diagnostics(closure_report),
+    ]
+
+    assert all(isinstance(figure, Figure) for figure in figures)

--- a/tests/test_portability_coercion.py
+++ b/tests/test_portability_coercion.py
@@ -199,6 +199,16 @@ def test_coerce_generator_family_preserves_shape_validation_errors() -> None:
         coerce_generator_family(payload)
 
 
+def test_coerce_generator_family_rejects_incomplete_canonical_payload_with_typed_schema_error() -> None:
+    payload = {
+        "schema_version": "0.2",
+        "parameterization": "polynomial_translation_affine",
+    }
+
+    with pytest.raises(SchemaValidationError, match="missing required field 'coefficients'"):
+        coerce_generator_family(payload)
+
+
 def test_coerced_translation_family_matches_canonical_symbolic_rendering() -> None:
     canonical = _make_translation_family()
     from_dict = coerce_generator_family(canonical.to_dict())

--- a/tests/test_portability_manifest.py
+++ b/tests/test_portability_manifest.py
@@ -168,6 +168,14 @@ def test_manifest_import_rejects_malformed_manifest_shapes(payload: object, matc
         import_generator_family_manifest(payload)  # type: ignore[arg-type]
 
 
+def test_manifest_import_rejects_unknown_top_level_fields() -> None:
+    manifest = export_generator_family_manifest(_make_translation_family())
+    manifest["unexpected"] = "field"
+
+    with pytest.raises(SchemaValidationError, match="unknown top-level fields"):
+        import_generator_family_manifest(manifest)
+
+
 def test_manifest_import_rejects_legacy_nested_generator_family_payload() -> None:
     manifest = {
         "manifest_schema_version": "0.1",
@@ -197,6 +205,27 @@ def test_manifest_import_propagates_typed_canonical_nested_payload_errors() -> N
     }
 
     with pytest.raises(SchemaValidationError, match="diagnostics must be a mapping"):
+        import_generator_family_manifest(manifest)
+
+
+@pytest.mark.parametrize(
+    "field_name,value,match",
+    [
+        ("diagnostics", {"bad": float("nan")}, "non-finite"),
+        ("diagnostics", {1: "value"}, "keys must be strings"),
+        ("provenance", {"ok": object()}, "not strict JSON-compatible"),
+        ("compatibility_hints", ["not", "a", "mapping"], "must be a mapping"),
+    ],
+)
+def test_manifest_import_rejects_invalid_recognized_optional_metadata(
+    field_name: str,
+    value: object,
+    match: str,
+) -> None:
+    manifest = export_generator_family_manifest(_make_translation_family())
+    manifest[field_name] = value
+
+    with pytest.raises(SchemaValidationError, match=match):
         import_generator_family_manifest(manifest)
 
 

--- a/tests/test_portability_manifest.py
+++ b/tests/test_portability_manifest.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 import pytest
 
-from pdelie import GeneratorFamily, SchemaValidationError
+from pdelie import GeneratorFamily, SchemaValidationError, ScopeValidationError
 from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.portability import (
     export_generator_family_manifest,
@@ -23,9 +23,9 @@ def _make_translation_family() -> GeneratorFamily:
     )
 
 
-def _make_algebraic_family() -> GeneratorFamily:
+def _make_algebraic_family(*, parameterization: str = "polynomial_point_family") -> GeneratorFamily:
     return GeneratorFamily(
-        parameterization="polynomial_point_family",
+        parameterization=parameterization,
         coefficients=np.array(
             [
                 [1.0, 0.0, 0.0],
@@ -71,6 +71,31 @@ def test_manifest_export_import_round_trip_for_non_translation_family() -> None:
 
     assert manifest["generator_family"] == generator.to_dict()
     assert imported.to_dict() == generator.to_dict()
+
+
+def test_manifest_export_rejects_well_formed_but_out_of_scope_parameterizations() -> None:
+    generator = _make_algebraic_family(parameterization="affine_external_family")
+
+    with pytest.raises(
+        ScopeValidationError,
+        match="only supports polynomial GeneratorFamily parameterizations",
+    ):
+        export_generator_family_manifest(generator)
+
+
+def test_manifest_import_rejects_well_formed_but_out_of_scope_parameterizations() -> None:
+    generator = _make_algebraic_family(parameterization="affine_external_family")
+    manifest = {
+        "manifest_schema_version": "0.1",
+        "manifest_type": "pdelie.generator_family_export",
+        "generator_family": generator.to_dict(),
+    }
+
+    with pytest.raises(
+        ScopeValidationError,
+        match="only supports polynomial GeneratorFamily parameterizations",
+    ):
+        import_generator_family_manifest(manifest)
 
 
 def test_manifest_supports_literal_json_round_trip() -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -32,6 +32,7 @@ def test_runtime_package_api_is_importable() -> None:
     from pdelie.discovery import to_pysindy_trajectories
     from pdelie.invariants import InvariantApplier
     from pdelie.portability import (
+        coerce_generator_family,
         export_generator_family_manifest,
         import_generator_family_manifest,
     )
@@ -51,6 +52,7 @@ def test_runtime_package_api_is_importable() -> None:
 
     assert InvariantApplier is not None
     assert to_pysindy_trajectories is not None
+    assert coerce_generator_family is not None
     assert export_generator_family_manifest is not None
     assert import_generator_family_manifest is not None
     assert compare_generator_spans is not None
@@ -67,6 +69,7 @@ def test_runtime_package_api_is_importable() -> None:
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
+    assert not hasattr(pdelie, "coerce_generator_family")
     assert not hasattr(pdelie, "export_generator_family_manifest")
     assert not hasattr(pdelie, "import_generator_family_manifest")
     assert not hasattr(pdelie, "compare_generator_spans")
@@ -94,12 +97,12 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 
 
-def test_portability_package_runtime_api_matches_frozen_m1_surface() -> None:
+def test_portability_package_runtime_api_matches_frozen_m2_surface() -> None:
     portability_module = importlib.import_module("pdelie.portability")
 
+    assert hasattr(portability_module, "coerce_generator_family")
     assert hasattr(portability_module, "export_generator_family_manifest")
     assert hasattr(portability_module, "import_generator_family_manifest")
-    assert not hasattr(portability_module, "coerce_generator_family")
     assert not hasattr(portability_module, "GeneratorFamily")
 
 


### PR DESCRIPTION
## Summary

Implements `v0.5` Milestone 2 only.

This PR adds strict external-family normalization through one new runtime public API:

- `pdelie.portability.coerce_generator_family(...)`

The milestone remains narrowly scoped:
- no new canonical object
- no root-level exports
- no widening of existing symbolic/span/closure/viz helper signatures
- no downstream smoke yet
- no file I/O
- no KdV or prediction work

## What Changed

### New runtime API
Added:
- `src/pdelie/portability/coercion.py`

Updated:
- `src/pdelie/portability/__init__.py`

New runtime public API:
- `pdelie.portability.coerce_generator_family`

No changes were made to `pdelie.__init__`.

### Frozen coercion semantics
`coerce_generator_family(...)` accepts exactly:
1. in-memory canonical `GeneratorFamily`
2. canonical `GeneratorFamily.to_dict()` payload
3. manifest payload with `manifest_type = "pdelie.generator_family_export"`
4. the existing narrow legacy `0.1` translation payload

Dispatch is strict:
- canonical in-memory `GeneratorFamily` is validated and returned as the same object
- manifest-like mappings are treated only as manifests
- family-payload-like mappings are treated only as `GeneratorFamily` payloads
- no fallback guessing across shapes

### Error taxonomy
The coercion layer keeps the typed validation boundary explicit:
- malformed structure -> `SchemaValidationError`
- unsupported convention -> `ScopeValidationError`
- shape mismatch -> `ShapeValidationError`

In `v0.5` M2, out-of-scope external conventions are kept narrow:
- non-polynomial parameterization names are rejected as outside stable scope

### Manifest import hardening
Tightened manifest validation for M2:
- required fields must exist
- known optional fields may exist
- unknown top-level manifest fields are rejected
- recognized optional metadata is validated strictly on import as well as export
- optional metadata remains non-authoritative and does not affect the returned canonical `GeneratorFamily`

### Compatibility proof scope
The existing helper boundaries stay unchanged:
- `render_generator_family`
- `to_sympy_component_expressions`
- `compare_generator_spans`
- `diagnose_generator_family_closure`
- generator-family-dependent viz helpers

This PR proves compatibility by:
- coercing first
- then passing the resulting canonical `GeneratorFamily` into the existing helpers unchanged

The compatibility fixture set stays intentionally small:
- one canonical translation family
- one non-translation algebraic family
- one fallback-compatible closure fixture
- one reused viz smoke path

## Tests

Added:
- `tests/test_portability_coercion.py`

Extended:
- `tests/test_portability_manifest.py`
- `tests/test_public_api.py`

Coverage includes:
- identity preservation for canonical in-memory `GeneratorFamily`
- semantic equivalence for canonical dict, manifest, and legacy translation inputs
- strict manifest-only vs family-payload-only dispatch
- malformed structure / unsupported convention / shape mismatch taxonomy
- manifest import rejection of unknown top-level fields
- import-side validation of recognized optional metadata
- small symbolic/span/closure/viz compatibility proofs over coerced families
- frozen `pdelie.portability` runtime package surface

## Docs / Planning Updates

Updated:
- `docs/specs/API_STABILITY.md`
- `docs/specs/SPEC.md`
- `docs/planning/PLAN.md`
- `docs/planning/V0_5_SCOPE.md`

These updates:
- document `coerce_generator_family(...)` as the frozen M2 runtime public API
- align manifest-key policy across spec/planning docs
- mark M1 complete and M2 active in the planning docs

## What Did Not Change

- no canonical object contracts
- no root exports
- no helper-signature widening
- no downstream benchmark/smoke expansion
- no file I/O helpers
- no KdV work
- no prediction-facing scope

## Validation

Ran:
- `pytest tests/test_portability_manifest.py tests/test_portability_coercion.py tests/test_public_api.py`
- `pytest tests/test_symbolic_runtime.py tests/test_span_runtime.py tests/test_closure_runtime.py tests/test_viz_runtime.py`
- `pytest`

Results:
- `51 passed` on the narrow portability/API pass
- `53 passed` on the symbolic/span/closure/viz pass
- `212 passed, 388 warnings` on the full suite

The warnings are the existing optional downstream/PySINDy warnings and are unchanged by this PR.
