### PR TITLE
Add V0.5 M3 portability benchmark coverage

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.5 Milestone 2 — External-family compatibility**
+**V0.5 Milestone 3 — Portability benchmark**
 
 This file is the active execution plan for the current `v0.5` release series.
 
@@ -101,7 +101,7 @@ Run at minimum:
 
 ## Milestone 2 — External-family Compatibility
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -123,6 +123,57 @@ Normalize the frozen `v0.5` input forms into canonical `GeneratorFamily` objects
 - no downstream smoke in M2
 - no KdV work in M2
 - no prediction work in M2
+
+---
+
+## Milestone 3 — Portability Benchmark
+
+**Status:** Active
+
+### Goal
+
+Prove that the frozen `v0.5` portability inputs preserve the behavior of the existing symbolic/span/closure/viz helpers and the existing narrow downstream bridge.
+
+### Frozen Decisions
+
+- M3 is docs/tests only; no new runtime public API
+- benchmark semantic preservation only
+- positive branches are:
+  - in-memory canonical family
+  - canonical payload via `coerce_generator_family(...)`
+  - manifest payload via `coerce_generator_family(...)`
+- legacy `0.1` translation payload is included only as a narrow compatibility smoke
+- downstream coverage is limited to:
+  - `InvariantMapSpec`
+  - `InvariantApplier`
+  - `to_pysindy_trajectories`
+- do not fit or score PySINDy models in M3
+- negative controls remain typed:
+  - malformed manifest -> schema error
+  - unsupported non-polynomial family -> scope error
+- no KdV work in M3
+- no prediction work in M3
+- no broad numerics expansion in M3
+
+### Acceptance Criteria
+
+M3 is complete only if:
+
+- positive branches show no semantic drift in symbolic rendering
+- positive branches show no semantic drift in span diagnostics
+- positive branches show no semantic drift in closure diagnostics
+- translation branches produce identical downstream transformed fields and bridge trajectories
+- legacy translation remains compatible in the narrow smoke path
+- malformed and unsupported controls fail with typed errors
+
+### Test Plan
+
+Run at minimum:
+
+- portability benchmark reproducibility tests
+- portability manifest/coercion regression tests
+- narrow downstream bridge tests
+- full `pytest`
 
 ---
 
@@ -167,7 +218,7 @@ Hard sequencing rules:
 
 - `v0.4`: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: ACTIVE
-- Milestone 3: PLANNED
+- Milestone 2: COMPLETE
+- Milestone 3: ACTIVE
 - Milestone 4: PLANNED / GATED
 - Milestone 5: PLANNED

--- a/docs/planning/V0_5_SCOPE.md
+++ b/docs/planning/V0_5_SCOPE.md
@@ -149,7 +149,7 @@ Until that is frozen, prediction utility remains `v0.6+` planning.
 - no new canonical object unless unavoidable
 
 ### Milestone 2 — External-family compatibility
-**Status:** Active
+**Status:** Complete
 
 - validate externally supplied canonical generator families
 - support runtime dict/object ingestion
@@ -157,16 +157,17 @@ Until that is frozen, prediction utility remains `v0.6+` planning.
 - typed failures for unsupported families
 
 ### Milestone 3 — Portability benchmark
-**Status:** Planned
+**Status:** Active
 
 Compare:
 
 - in-memory family
-- exported/imported manifest family
-- externally supplied canonical family
+- canonical payload normalized through `coerce_generator_family(...)`
+- exported/imported manifest family normalized through `coerce_generator_family(...)`
 - nuisance / malformed control
 
 The goal is semantic preservation after export/import, not a repeat of the `v0.3` downstream benchmark.
+Legacy `0.1` translation compatibility remains a narrow smoke path only, not a first-class benchmark branch.
 
 ### Milestone 4 — KdV feasibility
 **Status:** Planned / gated

--- a/tests/_helpers/portability_benchmark.py
+++ b/tests/_helpers/portability_benchmark.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie import GeneratorFamily, InvariantMapSpec
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.discovery import to_pysindy_trajectories
+from pdelie.invariants import InvariantApplier
+from pdelie.portability import coerce_generator_family, export_generator_family_manifest
+from pdelie.symmetry import (
+    compare_generator_spans,
+    diagnose_generator_family_closure,
+    render_generator_family,
+)
+
+
+PORTABILITY_BENCHMARK_BRANCHES = ("in_memory", "canonical_payload", "manifest")
+PORTABILITY_BENCHMARK_CONFIG: dict[str, object] = {
+    "heat_seed": 510,
+    "num_times": 17,
+    "num_points": 16,
+    "translation_shift_rule": "shift = x[1]",
+}
+
+
+def _make_translation_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={"source": "portability_benchmark"},
+    )
+
+
+def _x_basis_spec(*, labels: list[str], powers: list[list[int]]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": label, "powers": power}
+            for label, power in zip(labels, powers)
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _velocity_basis_spec(labels: list[str]) -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["velocity"],
+        "basis_terms": [
+            {"label": labels[0], "powers": [0]},
+            {"label": labels[1], "powers": [1]},
+        ],
+        "component_ordering": ["velocity"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _make_polynomial_family(
+    coefficients: np.ndarray,
+    *,
+    basis_spec: dict[str, object],
+    normalization: str = "runtime_fixture",
+    parameterization: str = "polynomial_point_family",
+) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization=parameterization,
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=basis_spec,
+        normalization=normalization,
+        diagnostics={},
+    )
+
+
+def _legacy_translation_payload() -> dict[str, object]:
+    return {
+        "schema_version": "0.1",
+        "parameterization": "polynomial_translation_affine",
+        "coefficients": [1.0, 0.0, 0.0, 0.0],
+        "normalization": "l2_unit",
+        "diagnostics": {},
+    }
+
+
+def _make_branch_families(canonical: GeneratorFamily) -> dict[str, GeneratorFamily]:
+    return {
+        "in_memory": canonical,
+        "canonical_payload": coerce_generator_family(canonical.to_dict()),
+        "manifest": coerce_generator_family(export_generator_family_manifest(canonical)),
+    }
+
+
+def _make_invariant_spec(generator_metadata: dict[str, object], shift: float) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=generator_metadata,
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": shift},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+
+def _make_downstream_branch_result(
+    generator: GeneratorFamily,
+    *,
+    shift: float,
+) -> dict[str, object]:
+    field = generate_heat_1d_field_batch(
+        batch_size=1,
+        num_times=int(PORTABILITY_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(PORTABILITY_BENCHMARK_CONFIG["num_points"]),
+        seed=int(PORTABILITY_BENCHMARK_CONFIG["heat_seed"]),
+    )
+    transformed = InvariantApplier().apply(field, _make_invariant_spec(generator.to_dict(), shift))
+    trajectories, time_values, feature_names = to_pysindy_trajectories(transformed)
+    return {
+        "transformed": transformed,
+        "trajectories": trajectories,
+        "time_values": np.asarray(time_values, dtype=float),
+        "feature_names": list(feature_names),
+    }
+
+
+def run_portability_benchmark() -> dict[str, object]:
+    translation_family = _make_translation_family()
+    translation_branches = _make_branch_families(translation_family)
+    legacy_translation = coerce_generator_family(_legacy_translation_payload())
+
+    span_family = _make_polynomial_family(
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 1.0]], dtype=float),
+        basis_spec=_x_basis_spec(labels=["1", "x", "x^2"], powers=[[0], [1], [2]]),
+    )
+    span_branches = _make_branch_families(span_family)
+
+    closure_family = _make_polynomial_family(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec=_velocity_basis_spec(["offset", "linear"]),
+    )
+    closure_branches = _make_branch_families(closure_family)
+
+    base_field = generate_heat_1d_field_batch(
+        batch_size=1,
+        num_times=int(PORTABILITY_BENCHMARK_CONFIG["num_times"]),
+        num_points=int(PORTABILITY_BENCHMARK_CONFIG["num_points"]),
+        seed=int(PORTABILITY_BENCHMARK_CONFIG["heat_seed"]),
+    )
+    shift = float(base_field.coords["x"][1])
+
+    return {
+        "settings": dict(PORTABILITY_BENCHMARK_CONFIG),
+        "branch_names": list(PORTABILITY_BENCHMARK_BRANCHES),
+        "translation": {
+            "families": translation_branches,
+            "rendered": {
+                branch: render_generator_family(generator)
+                for branch, generator in translation_branches.items()
+            },
+            "legacy_family": legacy_translation,
+            "legacy_rendered": render_generator_family(legacy_translation),
+        },
+        "span": {
+            "reference_family": span_family,
+            "branches": span_branches,
+            "reports": {
+                branch: compare_generator_spans(span_family, generator)
+                for branch, generator in span_branches.items()
+            },
+        },
+        "closure": {
+            "reference_family": closure_family,
+            "branches": closure_branches,
+            "reports": {
+                branch: diagnose_generator_family_closure(
+                    generator,
+                    component_targets={"velocity": "x"},
+                    computation_mode="auto",
+                )
+                for branch, generator in closure_branches.items()
+            },
+        },
+        "downstream": {
+            "shift": shift,
+            "base_field": base_field,
+            "branches": {
+                branch: _make_downstream_branch_result(generator, shift=shift)
+                for branch, generator in translation_branches.items()
+            },
+            "legacy": _make_downstream_branch_result(legacy_translation, shift=shift),
+        },
+    }

--- a/tests/test_portability_benchmark.py
+++ b/tests/test_portability_benchmark.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pdelie import GeneratorFamily, SchemaValidationError, ScopeValidationError
+from pdelie.portability import coerce_generator_family, export_generator_family_manifest, import_generator_family_manifest
+from tests._helpers.portability_benchmark import run_portability_benchmark
+
+
+def _assert_trajectories_allclose(first: list[np.ndarray], second: list[np.ndarray]) -> None:
+    assert len(first) == len(second)
+    for first_trajectory, second_trajectory in zip(first, second):
+        np.testing.assert_allclose(first_trajectory, second_trajectory, rtol=1e-9, atol=1e-12)
+
+
+def test_portability_benchmark_is_reproducible() -> None:
+    first = run_portability_benchmark()
+    second = run_portability_benchmark()
+
+    assert first["settings"] == second["settings"]
+    assert first["branch_names"] == second["branch_names"]
+    assert first["translation"]["legacy_rendered"] == second["translation"]["legacy_rendered"]
+    assert first["downstream"]["shift"] == pytest.approx(second["downstream"]["shift"])
+
+    for branch_name in first["branch_names"]:
+        assert first["translation"]["rendered"][branch_name] == second["translation"]["rendered"][branch_name]
+
+        first_span = first["span"]["reports"][branch_name]
+        second_span = second["span"]["reports"][branch_name]
+        assert first_span["comparison_rank"] == second_span["comparison_rank"]
+        np.testing.assert_allclose(
+            first_span["principal_angles_radians"],
+            second_span["principal_angles_radians"],
+            rtol=1e-9,
+            atol=1e-12,
+        )
+        assert first_span["projection_residual"]["summary"] == pytest.approx(
+            second_span["projection_residual"]["summary"],
+            abs=1e-12,
+        )
+
+        first_closure = first["closure"]["reports"][branch_name]
+        second_closure = second["closure"]["reports"][branch_name]
+        assert first_closure["computation_mode"] == second_closure["computation_mode"]
+        assert first_closure["family_rank"] == second_closure["family_rank"]
+        assert first_closure["closure"]["summary"] == pytest.approx(
+            second_closure["closure"]["summary"],
+            abs=1e-12,
+        )
+        assert first_closure["antisymmetry"]["summary"] == pytest.approx(
+            second_closure["antisymmetry"]["summary"],
+            abs=1e-12,
+        )
+        assert first_closure["jacobi"]["summary"] == pytest.approx(
+            second_closure["jacobi"]["summary"],
+            abs=1e-12,
+        )
+        np.testing.assert_allclose(
+            first_closure["structure_constants"]["tensor"],
+            second_closure["structure_constants"]["tensor"],
+            rtol=1e-9,
+            atol=1e-12,
+        )
+
+        first_downstream = first["downstream"]["branches"][branch_name]
+        second_downstream = second["downstream"]["branches"][branch_name]
+        assert first_downstream["feature_names"] == second_downstream["feature_names"]
+        np.testing.assert_allclose(
+            first_downstream["time_values"],
+            second_downstream["time_values"],
+            rtol=1e-9,
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            first_downstream["transformed"].values,
+            second_downstream["transformed"].values,
+            rtol=1e-9,
+            atol=1e-12,
+        )
+        _assert_trajectories_allclose(
+            first_downstream["trajectories"],
+            second_downstream["trajectories"],
+        )
+
+
+def test_portability_benchmark_positive_branches_preserve_semantics() -> None:
+    benchmark = run_portability_benchmark()
+
+    expected_render = benchmark["translation"]["rendered"]["in_memory"]
+    for branch_name in benchmark["branch_names"]:
+        assert benchmark["translation"]["rendered"][branch_name] == expected_render
+
+        span_report = benchmark["span"]["reports"][branch_name]
+        assert span_report["comparison_rank"] == 2
+        np.testing.assert_allclose(span_report["principal_angles_radians"], [0.0, 0.0], atol=1e-7)
+        assert span_report["projection_residual"]["summary"] == pytest.approx(0.0, abs=1e-12)
+
+    reference_closure = benchmark["closure"]["reports"]["in_memory"]
+    for branch_name in benchmark["branch_names"]:
+        report = benchmark["closure"]["reports"][branch_name]
+        assert report["computation_mode"] == reference_closure["computation_mode"] == "sampled_projection"
+        assert report["family_rank"] == reference_closure["family_rank"]
+        assert report["closure"]["summary"] == pytest.approx(
+            reference_closure["closure"]["summary"],
+            abs=1e-12,
+        )
+        assert report["antisymmetry"]["summary"] == pytest.approx(
+            reference_closure["antisymmetry"]["summary"],
+            abs=1e-12,
+        )
+        assert report["jacobi"]["summary"] == pytest.approx(
+            reference_closure["jacobi"]["summary"],
+            abs=1e-12,
+        )
+        np.testing.assert_allclose(
+            report["structure_constants"]["tensor"],
+            reference_closure["structure_constants"]["tensor"],
+            atol=1e-12,
+        )
+
+
+def test_portability_benchmark_legacy_translation_branch_preserves_downstream_behavior() -> None:
+    benchmark = run_portability_benchmark()
+
+    expected_render = benchmark["translation"]["rendered"]["in_memory"]
+    assert benchmark["translation"]["legacy_rendered"] == expected_render
+
+    reference = benchmark["downstream"]["branches"]["in_memory"]
+    legacy = benchmark["downstream"]["legacy"]
+
+    assert legacy["feature_names"] == reference["feature_names"]
+    np.testing.assert_allclose(legacy["time_values"], reference["time_values"], rtol=1e-9, atol=1e-12)
+    np.testing.assert_allclose(legacy["transformed"].values, reference["transformed"].values, rtol=1e-9, atol=1e-12)
+    _assert_trajectories_allclose(legacy["trajectories"], reference["trajectories"])
+
+
+def test_portability_benchmark_negative_controls_remain_typed() -> None:
+    manifest = export_generator_family_manifest(run_portability_benchmark()["translation"]["families"]["in_memory"])
+    manifest["unexpected"] = "field"
+
+    with pytest.raises(SchemaValidationError, match="unknown top-level fields"):
+        import_generator_family_manifest(manifest)
+
+    unsupported_payload = GeneratorFamily(
+        parameterization="affine_external_family",
+        coefficients=np.array([[1.0, 0.0]], dtype=float),
+        basis_spec={
+            "variables": ["x"],
+            "component_names": ["xi"],
+            "basis_terms": [
+                {"label": "1", "powers": [0]},
+                {"label": "x", "powers": [1]},
+            ],
+            "component_ordering": ["xi"],
+            "term_ordering": ["1", "x"],
+            "layout": "component_major",
+        },
+        normalization="runtime_fixture",
+        diagnostics={},
+    ).to_dict()
+
+    with pytest.raises(ScopeValidationError, match="only supports polynomial GeneratorFamily parameterizations"):
+        coerce_generator_family(unsupported_payload)
+
+
+def test_portability_benchmark_viz_smoke_is_optional() -> None:
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg", force=True)
+    plt = importlib.import_module("matplotlib.pyplot")
+    Figure = importlib.import_module("matplotlib.figure").Figure
+    from pdelie.viz import (
+        plot_closure_diagnostics,
+        plot_generator_coefficients,
+        plot_generator_symbolic_summary,
+        plot_span_diagnostics,
+    )
+
+    benchmark = run_portability_benchmark()
+    figures = [
+        plot_generator_coefficients(benchmark["translation"]["families"]["in_memory"]),
+        plot_generator_symbolic_summary(benchmark["translation"]["families"]["manifest"]),
+        plot_span_diagnostics(benchmark["span"]["reports"]["manifest"]),
+        plot_closure_diagnostics(benchmark["closure"]["reports"]["manifest"]),
+    ]
+
+    try:
+        assert all(isinstance(figure, Figure) for figure in figures)
+    finally:
+        plt.close("all")


### PR DESCRIPTION
## Summary

Implements `v0.5` Milestone 3 as a docs/tests-only portability benchmark pass.

This PR:
- marks M2 complete and M3 active in the planning docs
- adds a tests-only portability benchmark helper
- adds benchmark coverage for semantic preservation across:
  - in-memory canonical families
  - canonical payloads normalized through `coerce_generator_family(...)`
  - manifest payloads normalized through `coerce_generator_family(...)`
- keeps legacy `0.1` translation handling as a narrow compatibility smoke only

## What Changed

- updated:
  - `docs/planning/PLAN.md`
  - `docs/planning/V0_5_SCOPE.md`
- added:
  - `tests/_helpers/portability_benchmark.py`
  - `tests/test_portability_benchmark.py`

The benchmark proves preservation of:
- symbolic rendering
- span diagnostics
- closure diagnostics
- the narrow downstream bridge path:
  - `InvariantMapSpec`
  - `InvariantApplier`
  - `to_pysindy_trajectories`

It also keeps typed negative controls for:
- malformed manifests
- unsupported non-polynomial payloads

## What Did Not Change

- no `src/` runtime API
- no `pdelie.__init__` changes
- no API-stability surface changes
- no PySINDy fit/score benchmarking
- no KdV work
- no prediction work

## Validation

- `pytest tests/test_portability_benchmark.py`
- `pytest tests/test_portability_benchmark.py tests/test_portability_manifest.py tests/test_portability_coercion.py tests/test_pysindy_bridge.py`
- `pytest`

Result:
- `220 passed, 388 warnings`
