### PR TITLE
Start V0.5 M4 with tests-first KdV feasibility coverage

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.5 Milestone 3 — Portability benchmark**
+**V0.5 Milestone 4 — KdV feasibility**
 
 This file is the active execution plan for the current `v0.5` release series.
 
@@ -128,7 +128,7 @@ Normalize the frozen `v0.5` input forms into canonical `GeneratorFamily` objects
 
 ## Milestone 3 — Portability Benchmark
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -177,6 +177,48 @@ Run at minimum:
 
 ---
 
+## Milestone 4 — KdV Feasibility
+
+**Status:** Active
+
+### Goal
+
+Assess whether clean periodic KdV is a comfortable fit for the current uniform-grid, synthetic-data, `spectral_fd` regime without introducing a stable KdV runtime API.
+
+### Frozen Decisions
+
+- M4 remains feasibility only; no stable KdV API yet
+- no root exports
+- no broad numerics expansion
+- no prediction/downstream broadening
+- normalized periodic KdV form only:
+  - `u_t + 6*u*u_x + u_xxx = 0`
+- tests-first implementation only in `tests/_helpers/` and test-local helpers
+- fixed rollout numerics:
+  - periodic spectral spatial derivatives
+  - two-thirds dealiasing for the nonlinear term
+  - explicit RK4 time stepping
+  - short-horizon only
+- no contract changes unless feasibility proves impossible otherwise
+
+### Acceptance Criteria
+
+M4 is complete only if:
+
+- third-derivative Fourier-mode accuracy passes
+- synthetic KdV rollout is reproducible
+- KdV residual is near zero within the frozen tolerance
+- short-horizon mass and `L2` conservation look sane
+- Heat/Burgers regressions remain unchanged
+- the outcome is recorded explicitly as:
+  - feasibility passed, stable promotion deferred
+  - or deferred to `v0.6+` with rationale
+
+Current kickoff outcome:
+
+- tests-first normalized periodic KdV feasibility passes under the frozen short-horizon numerics
+- stable promotion remains deferred to the `v0.5` release-gate review
+
 ## Later Milestones
 
 Locked sequence:
@@ -219,6 +261,6 @@ Hard sequencing rules:
 - `v0.4`: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: ACTIVE
-- Milestone 4: PLANNED / GATED
+- Milestone 3: COMPLETE
+- Milestone 4: ACTIVE / GATED
 - Milestone 5: PLANNED

--- a/docs/planning/V0_5_SCOPE.md
+++ b/docs/planning/V0_5_SCOPE.md
@@ -157,7 +157,7 @@ Until that is frozen, prediction utility remains `v0.6+` planning.
 - typed failures for unsupported families
 
 ### Milestone 3 — Portability benchmark
-**Status:** Active
+**Status:** Complete
 
 Compare:
 
@@ -170,12 +170,25 @@ The goal is semantic preservation after export/import, not a repeat of the `v0.3
 Legacy `0.1` translation compatibility remains a narrow smoke path only, not a first-class benchmark branch.
 
 ### Milestone 4 — KdV feasibility
-**Status:** Planned / gated
+**Status:** Active / gated
 
 - spectral third-derivative stress tests
 - synthetic KdV data feasibility
 - KdV residual feasibility
+- short-horizon conservation sanity
 - promotion decision: stable path or defer to `v0.6+`
+
+M4 remains tests-first and feasibility-only:
+
+- no stable KdV API yet
+- no root exports
+- no broad numerics expansion
+- no prediction/downstream broadening
+
+Current kickoff outcome:
+
+- normalized periodic KdV feasibility passes in the tests-first slice
+- stable KdV promotion remains deferred to the release gate
 
 ### Milestone 5 — V0.5 release gate
 **Status:** Planned

--- a/tests/_helpers/kdv_feasibility.py
+++ b/tests/_helpers/kdv_feasibility.py
@@ -182,7 +182,11 @@ def compute_kdv_feasibility_derivatives(field: FieldBatch) -> DerivativeBatch:
     x = np.asarray(field.coords["x"], dtype=float)
     t = np.asarray(field.coords["time"], dtype=float)
     dx = float(x[1] - x[0])
+    if t.ndim != 1 or t.size < 3:
+        raise ShapeValidationError("KdV feasibility derivatives require a one-dimensional time coordinate with at least 3 points.")
     dt = float(t[1] - t[0])
+    if not np.allclose(np.diff(t), dt, atol=1e-12, rtol=0.0):
+        raise ShapeValidationError("KdV feasibility derivatives require a uniform time grid.")
 
     u_x, u_xx, u_xxx = _spectral_spatial_derivatives(values, dx=dx)
     u_t = np.gradient(values, dt, axis=1, edge_order=2)

--- a/tests/_helpers/kdv_feasibility.py
+++ b/tests/_helpers/kdv_feasibility.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie import DerivativeBatch, FieldBatch, ResidualBatch
+from pdelie.data.heat_1d import DEFAULT_DOMAIN_LENGTH
+from pdelie.errors import ShapeValidationError
+
+
+KDV_FEASIBILITY_CONFIG: dict[str, object] = {
+    "batch_size": 2,
+    "num_times": 17,
+    "num_points": 64,
+    "max_time": 0.03,
+    "num_modes": 3,
+    "amplitude": 0.08,
+    "num_substeps": 8,
+    "domain_length": DEFAULT_DOMAIN_LENGTH,
+    "equation": "u_t + 6*u*u_x + u_xxx = 0",
+}
+
+
+def sample_kdv_mode_coefficients(
+    *,
+    batch_size: int,
+    num_modes: int,
+    seed: int,
+    amplitude: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    mode_scale = amplitude / np.arange(1, num_modes + 1, dtype=float)
+    cosine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    sine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    return cosine, sine
+
+
+def evaluate_kdv_fourier_series(
+    *,
+    x: np.ndarray,
+    cosine_coefficients: np.ndarray,
+    sine_coefficients: np.ndarray,
+) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    cosine_coefficients = np.asarray(cosine_coefficients, dtype=float)
+    sine_coefficients = np.asarray(sine_coefficients, dtype=float)
+
+    if cosine_coefficients.shape != sine_coefficients.shape:
+        raise ShapeValidationError("cosine_coefficients and sine_coefficients must match.")
+    if cosine_coefficients.ndim != 2:
+        raise ShapeValidationError("Coefficient arrays must have shape (batch, num_modes).")
+
+    modes = np.arange(1, cosine_coefficients.shape[1] + 1, dtype=float)
+    spatial_cos = np.cos(np.outer(modes, x))
+    spatial_sin = np.sin(np.outer(modes, x))
+    batch_cos = cosine_coefficients[:, :, None]
+    batch_sin = sine_coefficients[:, :, None]
+    values = np.sum(batch_cos * spatial_cos[None, :, :] + batch_sin * spatial_sin[None, :, :], axis=1)
+    return _apply_two_thirds_filter(values)
+
+
+def _reshape_last_axis(values: np.ndarray) -> tuple[int, ...]:
+    shape = [1] * values.ndim
+    shape[-1] = values.shape[-1]
+    return tuple(shape)
+
+
+def _apply_two_thirds_filter(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    mode_numbers = np.fft.fftfreq(values.shape[-1]) * values.shape[-1]
+    mask = (np.abs(mode_numbers) <= values.shape[-1] / 3.0).reshape(_reshape_last_axis(values))
+    spectrum = np.fft.fft(values, axis=-1)
+    return np.real(np.fft.ifft(spectrum * mask, axis=-1))
+
+
+def _spectral_spatial_derivatives(values: np.ndarray, *, dx: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    values = np.asarray(values, dtype=float)
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(values.shape[-1], d=dx).reshape(_reshape_last_axis(values))
+    spectrum = np.fft.fft(values, axis=-1)
+    u_x = np.real(np.fft.ifft((1j * wavenumbers) * spectrum, axis=-1))
+    u_xx = np.real(np.fft.ifft(-(wavenumbers**2) * spectrum, axis=-1))
+    u_xxx = np.real(np.fft.ifft(-(1j) * (wavenumbers**3) * spectrum, axis=-1))
+    return u_x, u_xx, u_xxx
+
+
+def _kdv_rhs(values: np.ndarray, *, dx: float) -> np.ndarray:
+    filtered = _apply_two_thirds_filter(values)
+    u_x, _, u_xxx = _spectral_spatial_derivatives(filtered, dx=dx)
+    nonlinear = _apply_two_thirds_filter(filtered * u_x)
+    return _apply_two_thirds_filter(-6.0 * nonlinear - u_xxx)
+
+
+def _rollout_kdv_periodic(
+    initial_values: np.ndarray,
+    *,
+    output_times: np.ndarray,
+    domain_length: float,
+    num_substeps: int,
+) -> np.ndarray:
+    initial_values = np.asarray(initial_values, dtype=float)
+    output_times = np.asarray(output_times, dtype=float)
+
+    if initial_values.ndim != 2:
+        raise ShapeValidationError("initial_values must have shape (batch, x).")
+    if output_times.ndim != 1 or output_times.size < 2:
+        raise ShapeValidationError("output_times must be one-dimensional with at least two entries.")
+    if num_substeps < 1:
+        raise ShapeValidationError("num_substeps must be at least 1.")
+
+    output_dt = float(output_times[1] - output_times[0])
+    if not np.allclose(np.diff(output_times), output_dt, atol=1e-12, rtol=0.0):
+        raise ShapeValidationError("output_times must be uniformly spaced.")
+
+    dx = float(domain_length / initial_values.shape[-1])
+    internal_dt = output_dt / float(num_substeps)
+    state = _apply_two_thirds_filter(initial_values)
+    rollout = np.empty((initial_values.shape[0], output_times.size, initial_values.shape[-1]), dtype=float)
+    rollout[:, 0, :] = state
+
+    for time_index in range(1, output_times.size):
+        for _ in range(num_substeps):
+            k1 = _kdv_rhs(state, dx=dx)
+            k2 = _kdv_rhs(state + 0.5 * internal_dt * k1, dx=dx)
+            k3 = _kdv_rhs(state + 0.5 * internal_dt * k2, dx=dx)
+            k4 = _kdv_rhs(state + internal_dt * k3, dx=dx)
+            state = _apply_two_thirds_filter(state + (internal_dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4))
+        rollout[:, time_index, :] = state
+
+    return rollout
+
+
+def generate_kdv_1d_field_batch(
+    *,
+    batch_size: int = 2,
+    num_times: int = 17,
+    num_points: int = 64,
+    max_time: float = 0.05,
+    num_modes: int = 3,
+    amplitude: float = 0.08,
+    seed: int = 0,
+    num_substeps: int = 8,
+    domain_length: float = DEFAULT_DOMAIN_LENGTH,
+) -> FieldBatch:
+    x = np.linspace(0.0, domain_length, num_points, endpoint=False, dtype=float)
+    t = np.linspace(0.0, max_time, num_times, dtype=float)
+    cosine, sine = sample_kdv_mode_coefficients(
+        batch_size=batch_size,
+        num_modes=num_modes,
+        seed=seed,
+        amplitude=amplitude,
+    )
+    initial_values = evaluate_kdv_fourier_series(
+        x=x,
+        cosine_coefficients=cosine,
+        sine_coefficients=sine,
+    )
+    values = _rollout_kdv_periodic(
+        initial_values,
+        output_times=t,
+        domain_length=domain_length,
+        num_substeps=num_substeps,
+    )
+
+    return FieldBatch(
+        values=values[..., None],
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {"equation": "kdv_normalized"},
+        },
+        preprocess_log=[],
+    )
+
+
+def compute_kdv_feasibility_derivatives(field: FieldBatch) -> DerivativeBatch:
+    field.validate()
+    values = np.asarray(field.values[..., 0], dtype=float)
+    x = np.asarray(field.coords["x"], dtype=float)
+    t = np.asarray(field.coords["time"], dtype=float)
+    dx = float(x[1] - x[0])
+    dt = float(t[1] - t[0])
+
+    u_x, u_xx, u_xxx = _spectral_spatial_derivatives(values, dx=dx)
+    u_t = np.gradient(values, dt, axis=1, edge_order=2)
+
+    derivatives = DerivativeBatch(
+        derivatives={
+            "u_x": u_x[..., None],
+            "u_xx": u_xx[..., None],
+            "u_xxx": u_xxx[..., None],
+            "u_t": u_t[..., None],
+        },
+        backend="spectral_fd",
+        config={
+            "spatial_method": "spectral",
+            "temporal_method": "finite_difference",
+            "temporal_edge_order": 2,
+            "spatial_max_order": 3,
+            "dealiasing": "two_thirds",
+        },
+        boundary_assumptions="periodic in x; finite differences in time",
+        diagnostics={
+            "dx": dx,
+            "dt": dt,
+            "x_points": int(x.size),
+            "time_points": int(t.size),
+        },
+    )
+    derivatives.validate_against(field)
+    return derivatives
+
+
+def evaluate_kdv_feasibility_residual(
+    field: FieldBatch,
+    derivatives: DerivativeBatch | None = None,
+) -> ResidualBatch:
+    field.validate()
+    if derivatives is None:
+        derivatives = compute_kdv_feasibility_derivatives(field)
+    derivatives.validate_against(field)
+
+    u = np.asarray(field.values, dtype=float)
+    residual = (
+        derivatives.derivatives["u_t"]
+        + 6.0 * u * derivatives.derivatives["u_x"]
+        + derivatives.derivatives["u_xxx"]
+    )
+    batch = ResidualBatch(
+        residual=residual,
+        definition_type="analytic",
+        normalization="none",
+        diagnostics={
+            "backend": derivatives.backend,
+            "equation": KDV_FEASIBILITY_CONFIG["equation"],
+            "max_abs_residual": float(np.max(np.abs(residual))),
+        },
+    )
+    batch.validate_against(field)
+    return batch
+
+
+def exact_fourier_third_derivative(
+    *,
+    x: np.ndarray,
+    cosine_coefficients: np.ndarray,
+    sine_coefficients: np.ndarray,
+) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    cosine_coefficients = np.asarray(cosine_coefficients, dtype=float)
+    sine_coefficients = np.asarray(sine_coefficients, dtype=float)
+
+    modes = np.arange(1, cosine_coefficients.shape[1] + 1, dtype=float)
+    spatial_cos = np.cos(np.outer(modes, x))
+    spatial_sin = np.sin(np.outer(modes, x))
+    batch_cos = cosine_coefficients[:, :, None]
+    batch_sin = sine_coefficients[:, :, None]
+
+    values = np.sum(
+        batch_cos * (modes[None, :, None] ** 3) * spatial_sin[None, :, :]
+        - batch_sin * (modes[None, :, None] ** 3) * spatial_cos[None, :, :],
+        axis=1,
+    )
+    return values
+
+
+def compute_mass(field: FieldBatch) -> np.ndarray:
+    values = np.asarray(field.values[..., 0], dtype=float)
+    dx = float(field.coords["x"][1] - field.coords["x"][0])
+    return dx * np.sum(values, axis=-1)
+
+
+def compute_l2_norm(field: FieldBatch) -> np.ndarray:
+    values = np.asarray(field.values[..., 0], dtype=float)
+    dx = float(field.coords["x"][1] - field.coords["x"][0])
+    return np.sqrt(dx * np.sum(values**2, axis=-1))

--- a/tests/test_kdv_feasibility.py
+++ b/tests/test_kdv_feasibility.py
@@ -83,6 +83,14 @@ def test_kdv_field_generation_is_reproducible_and_shape_valid() -> None:
     assert first.metadata["grid_type"] == "rectilinear"
 
 
+def test_kdv_feasibility_derivatives_require_uniform_time_grid() -> None:
+    field = generate_kdv_1d_field_batch(seed=12, **_generation_kwargs())
+    field.coords["time"] = np.array([0.0, 0.01, 0.025, 0.045] + list(field.coords["time"][4:]), dtype=float)
+
+    with pytest.raises(pdelie.ShapeValidationError, match="require a uniform time grid"):
+        compute_kdv_feasibility_derivatives(field)
+
+
 def test_kdv_residual_is_near_zero_on_clean_short_horizon_data() -> None:
     field = generate_kdv_1d_field_batch(seed=13, **_generation_kwargs())
     residual = evaluate_kdv_feasibility_residual(field)

--- a/tests/test_kdv_feasibility.py
+++ b/tests/test_kdv_feasibility.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+import pdelie
+from tests._helpers.kdv_feasibility import (
+    KDV_FEASIBILITY_CONFIG,
+    compute_kdv_feasibility_derivatives,
+    compute_l2_norm,
+    compute_mass,
+    evaluate_kdv_feasibility_residual,
+    exact_fourier_third_derivative,
+    generate_kdv_1d_field_batch,
+    sample_kdv_mode_coefficients,
+)
+
+
+def _generation_kwargs() -> dict[str, object]:
+    return {
+        key: KDV_FEASIBILITY_CONFIG[key]
+        for key in ("batch_size", "num_times", "num_points", "max_time", "num_modes", "amplitude", "num_substeps")
+    }
+
+
+def test_kdv_fourier_mode_third_derivative_matches_exact() -> None:
+    x = np.linspace(
+        0.0,
+        float(KDV_FEASIBILITY_CONFIG["domain_length"]),
+        int(KDV_FEASIBILITY_CONFIG["num_points"]),
+        endpoint=False,
+        dtype=float,
+    )
+    t = np.linspace(0.0, 0.1, 3, dtype=float)
+    cosine, sine = sample_kdv_mode_coefficients(
+        batch_size=1,
+        num_modes=2,
+        seed=7,
+        amplitude=0.08,
+    )
+    spatial_values = np.sum(
+        cosine[:, :, None] * np.cos(np.outer(np.arange(1, 3, dtype=float), x))[None, :, :]
+        + sine[:, :, None] * np.sin(np.outer(np.arange(1, 3, dtype=float), x))[None, :, :],
+        axis=1,
+    )
+    values = np.repeat(spatial_values[:, None, :, None], t.size, axis=1)
+    field = pdelie.FieldBatch(
+        values=values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {"equation": "kdv_normalized"},
+        },
+        preprocess_log=[],
+    )
+
+    derivatives = compute_kdv_feasibility_derivatives(field)
+    expected = exact_fourier_third_derivative(x=x, cosine_coefficients=cosine, sine_coefficients=sine)
+    np.testing.assert_allclose(
+        derivatives.derivatives["u_xxx"][:, 0, :, 0],
+        expected,
+        atol=1e-9,
+        rtol=1e-9,
+    )
+
+
+def test_kdv_field_generation_is_reproducible_and_shape_valid() -> None:
+    first = generate_kdv_1d_field_batch(seed=11, **_generation_kwargs())
+    second = generate_kdv_1d_field_batch(seed=11, **_generation_kwargs())
+
+    np.testing.assert_allclose(first.values, second.values)
+    assert first.dims == ("batch", "time", "x", "var")
+    assert first.var_names == ["u"]
+    assert first.metadata["boundary_conditions"] == {"x": "periodic"}
+    assert first.metadata["grid_regularity"] == "uniform"
+    assert first.metadata["grid_type"] == "rectilinear"
+
+
+def test_kdv_residual_is_near_zero_on_clean_short_horizon_data() -> None:
+    field = generate_kdv_1d_field_batch(seed=13, **_generation_kwargs())
+    residual = evaluate_kdv_feasibility_residual(field)
+
+    assert residual.definition_type == "analytic"
+    assert residual.normalization == "none"
+    assert np.max(np.abs(residual.residual)) < 1e-2
+
+
+def test_kdv_short_horizon_mass_and_l2_drift_are_small() -> None:
+    field = generate_kdv_1d_field_batch(seed=17, **_generation_kwargs())
+
+    mass = compute_mass(field)
+    l2 = compute_l2_norm(field)
+    mass_drift = np.max(np.abs(mass - mass[:, [0]]))
+    relative_l2_drift = np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12))
+
+    assert mass_drift <= 1e-8
+    assert relative_l2_drift <= 5e-3
+
+
+def test_m4_kdv_feasibility_adds_no_stable_surface() -> None:
+    assert not hasattr(pdelie, "KdVResidualEvaluator")
+    assert not hasattr(pdelie, "generate_kdv_1d_field_batch")
+
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+    assert not hasattr(data_module, "generate_kdv_1d_field_batch")
+    assert not hasattr(residuals_module, "KdVResidualEvaluator")


### PR DESCRIPTION
## Summary

Starts `v0.5` Milestone 4 as a tests-first KdV feasibility pass.

This PR:
- marks M3 complete and M4 active in the planning docs
- adds tests-only KdV feasibility helpers
- adds KdV feasibility coverage for:
  - exact `u_xxx` accuracy on Fourier modes
  - deterministic short-horizon periodic rollout
  - near-zero KdV residual
  - short-horizon mass / `L2` sanity

## Constraints kept

- no stable KdV API
- no root exports
- no runtime public API changes
- no broad numerics expansion

## Validation

- `pytest tests/test_kdv_feasibility.py`
- `pytest tests/test_derivatives.py tests/test_heat_residual.py tests/test_burgers_residual.py tests/test_synthetic_heat.py tests/test_synthetic_burgers.py`
- `pytest tests/test_v0_4_release_gate.py`
- `pytest`

Result:
- `225 passed, 388 warnings`
