### PR TITLE
Prepare v0.5.0rc1 release metadata and readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.5.0rc1
+
+First release candidate for the frozen V0.5 generator-family portability and external-compatibility core.
+
+- stable manifest export/import helpers added under `pdelie.portability`
+- strict external-family normalization added under `pdelie.portability.coerce_generator_family(...)`
+- compact portability benchmark / semantic-preservation layer added for canonical, manifest, and narrow legacy translation inputs
+- compact V0.5 release-gate layer and `v0_5-release-gate` CI visibility job added
+- normalized periodic KdV feasibility passes in the tests-first slice, but KdV remains non-stable in `v0.5`
+- package metadata, milestone docs, and release-readiness docs aligned with the implemented V0.5 state
+
+Explicitly deferred for this release candidate:
+
+- stable KdV API or stable KdV runtime module
+- weak-form methods
+- operator methods
+- broad dataset adapters or interoperability expansion
+- prediction-facing utility work
+- new canonical stable objects beyond the current V0.5 slice
+
 ## 0.4.0
 
 First final release for the frozen V0.4 stable core.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the stable V0.4 core on the frozen synthetic Heat/Burgers slice:
+The current repository implements the frozen V0.5 portability and external-compatibility core on the synthetic Heat/Burgers slice:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -16,6 +16,7 @@ The current repository implements the stable V0.4 core on the frozen synthetic H
 - one stable invariant canonical object: `InvariantMapSpec`
 - one runtime-only invariant path retained from V0.3: `pdelie.invariants.InvariantApplier`
 - one runtime-only backend-specific downstream bridge retained from V0.3: `pdelie.discovery.to_pysindy_trajectories`
+- one runtime-only portability layer retained from V0.5: `pdelie.portability`
 
 ## Setup
 
@@ -98,13 +99,18 @@ Included in the current stable core:
 - polynomial translation baseline for the stable PDE slice
 - finite-transform verification for the stable PDE slice
 - family-shaped `GeneratorFamily` serialization and narrow translation compatibility migration
+- manifest export/import for canonical `GeneratorFamily` portability
+- strict external-family normalization for canonical payloads, manifests, and the narrow legacy translation payload
 - single-generator invariant map support
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
+- KdV feasibility passed in a tests-first slice, but KdV remains non-stable in V0.5
 
-Runtime-level public APIs in the frozen V0.4 slice:
+Runtime-level public APIs in the frozen V0.5 slice:
 
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
+- `pdelie.portability.export_generator_family_manifest` and `pdelie.portability.import_generator_family_manifest` for manifest-level generator-family portability
+- `pdelie.portability.coerce_generator_family` for strict normalization of canonical, manifest, and narrow legacy translation inputs
 - `pdelie.symmetry.render_generator_family` for deterministic symbolic display
 - `pdelie.symmetry.to_sympy_component_expressions` when `sympy` is installed at runtime
 - `pdelie.symmetry.compare_generator_spans` for runtime span diagnostics

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.5 Milestone 5 — V0.5 release gate**
+**V0.5 milestone execution complete**
 
 This file is the active execution plan for the current `v0.5` release series.
 
@@ -223,7 +223,7 @@ Current kickoff outcome:
 
 ## Milestone 5 — V0.5 Release Gate
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -261,6 +261,13 @@ Run at minimum:
 
 - `tests/test_v0_5_release_gate.py`
 - full `pytest`
+
+Current outcome:
+
+- the `v0.5` release gate is complete
+- the compact release-gate aggregation slice passes
+- KdV remains recorded as feasibility-passed in tests-first scope only
+- KdV is not promoted to a stable `v0.5` API surface
 
 ### Follow-on CI Hygiene Notes
 
@@ -323,4 +330,4 @@ Hard sequencing rules:
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE / GATED
-- Milestone 5: ACTIVE
+- Milestone 5: COMPLETE

--- a/docs/planning/V0_5_SCOPE.md
+++ b/docs/planning/V0_5_SCOPE.md
@@ -191,7 +191,7 @@ Current kickoff outcome:
 - stable KdV promotion remains deferred to the release gate
 
 ### Milestone 5 — V0.5 release gate
-**Status:** Active
+**Status:** Complete
 
 - compact, high-signal release-gate aggregation only
 - manifest export/import stability on representative canonical families
@@ -206,6 +206,13 @@ Current kickoff outcome:
 - no new canonical object
 - no new numerics work
 - no prediction/downstream expansion
+
+Current outcome:
+
+- the `v0.5` release gate is complete
+- the compact release-gate aggregation slice passes
+- KdV feasibility is recorded as passed in the tests-first slice
+- KdV remains non-stable in `v0.5` with no stable KdV API added
 
 ---
 

--- a/docs/releases/V0_5_RELEASE_READINESS.md
+++ b/docs/releases/V0_5_RELEASE_READINESS.md
@@ -1,0 +1,81 @@
+# V0.5 Release Readiness
+
+## Release Target
+
+- package version: `0.5.0rc1`
+- git tag: `v0.5.0rc1`
+
+## Done
+
+- canonical `GeneratorFamily` family semantics from `v0.4` remain in place with `schema_version = "0.2"`, family-shaped coefficients, and explicit `basis_spec`
+- the narrow legacy single-generator translation compatibility path remains in place via `GeneratorFamily.from_dict()`
+- Heat remains supported under the existing stable path
+- Burgers remains supported under the existing stable path
+- the stable derivative backend remains `spectral_fd`
+- analytic Heat and Burgers residual evaluators remain in place
+- the polynomial spatial-translation fitting path remains the stable PDE fitting slice
+- the finite-transform verification path remains the stable verification slice
+- runtime-only symbolic generator rendering remains implemented under `pdelie.symmetry`
+- optional runtime-only SymPy component expressions remain implemented under `pdelie.symmetry`
+- runtime-only span diagnostics remain implemented under `pdelie.symmetry`
+- runtime-only closure / structure-constant diagnostics remain implemented under `pdelie.symmetry`
+- optional Matplotlib visualization remains implemented under `pdelie.viz`
+- M1 is complete:
+  - stable manifest export/import helpers are implemented under `pdelie.portability`
+  - manifest payloads are JSON-compatible and round-trip to canonical `GeneratorFamily`
+- M2 is complete:
+  - strict external-family normalization is implemented under `pdelie.portability.coerce_generator_family(...)`
+  - malformed, unsupported, and shape-invalid inputs fail with typed errors
+- M3 is complete:
+  - the portability benchmark proves semantic preservation across canonical payloads, manifest payloads, and the narrow legacy translation path
+- M4 is complete / gated:
+  - normalized periodic KdV feasibility passes in the tests-first slice
+  - stable KdV promotion remains deferred
+- M5 is complete:
+  - the compact `v0.5` release gate is implemented
+  - the `v0_5-release-gate` CI visibility job is implemented
+- the full test suite passes from the repo root
+- package metadata, changelog, milestone docs, and release-readiness docs can be aligned with the implemented `v0.5` surface
+
+## Explicitly Deferred
+
+- stable KdV API or stable KdV runtime module
+- weak-form methods beyond the reserved interface surface
+- operator methods
+- neural generators as stable API
+- broad dataset adapters or interoperability expansion
+- prediction-facing utility work
+- stable multi-generator PDE fitting
+- new canonical stable objects beyond the current `v0.5` slice
+- paper-specific experiment logic
+
+## Release Candidate View
+
+The current repository is ready for the `0.5.0rc1` release candidate for the frozen `v0.5` portability and external-compatibility slice, subject to the release-path checks passing on the release branch and CI passing on the release PR.
+
+There are no known scientific-scope blockers inside the current `v0.5` slice.
+
+## Packaging And Public API Notes
+
+- canonical `GeneratorFamily` output remains `schema_version = "0.2"` with explicit `basis_spec`
+- the legacy translation compatibility path remains narrow and runtime-gated through `GeneratorFamily.from_dict()` only
+- `pdelie.portability.export_generator_family_manifest` and `pdelie.portability.import_generator_family_manifest` are stable runtime public APIs for the frozen `v0.5` manifest artifact surface
+- `pdelie.portability.coerce_generator_family` is the stable runtime public API for the frozen `v0.5` external-family normalization surface
+- the manifest is a stable artifact schema, not a new canonical object
+- the runtime downstream bridge remains optional via `pdelie[downstream]`
+- `pdelie.viz` remains optional via `pdelie[viz]`
+- SymPy support remains optional at runtime and is not part of the core install
+- KdV remains tests-first feasibility only in `v0.5` and does not add a stable runtime API
+- the `v0_4-release-gate` and `v0_5-release-gate` CI jobs are explicit visibility checks; if they should block merges, repository branch-protection settings must be updated separately
+
+## Release Candidate Tag Checklist
+
+Before tagging `v0.5.0rc1`:
+
+- run `python -m pytest` from the repo root
+- run `python -m build --sdist --wheel`
+- install the built wheel into a clean environment and verify stable imports
+- run `python -m pdelie.examples.heat_vertical_slice`
+- confirm GitHub Actions jobs `v0_4-release-gate`, `v0_5-release-gate`, `editable-tests`, and `package-smoke` pass on the release PR commit
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.5.0rc1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.4.0"
-description = "Stable V0.4 polynomial generator-family core with algebra diagnostics and optional visualization for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
+version = "0.5.0rc1"
+description = "V0.5 generator-family portability and external-family compatibility core with optional algebra diagnostics and visualization for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",


### PR DESCRIPTION
## Summary

Prepares the `v0.5.0rc1` release candidate.

This PR:
- closes M5 in the planning docs
- adds the `v0.5` release-readiness note
- aligns release metadata to `0.5.0rc1`
- updates the README to reflect the implemented `v0.5` surface
- does not add any new runtime functionality

## What Changed

### Planning closeout
Updated:
- `docs/planning/PLAN.md`
- `docs/planning/V0_5_SCOPE.md`

These now mark:
- M5 complete
- the `v0.5` release gate complete
- KdV feasibility passed in the tests-first slice but still non-stable in `v0.5`

### Release-readiness doc
Added:
- `docs/releases/V0_5_RELEASE_READINESS.md`

This captures:
- the `v0.5.0rc1` release target
- completed M1–M5 outcomes
- explicitly deferred items
- the final release-candidate checklist

### Release metadata
Updated:
- `pyproject.toml`
- `CHANGELOG.md`

These now align on:
- package version `0.5.0rc1`
- the implemented `v0.5` portability / external-compatibility surface
- the deferred items for the RC

### README refresh
Updated:
- `README.md`

This removes stale `v0.4` wording and reflects the current `v0.5` surface, including:
- `pdelie.portability`
- manifest export/import
- strict external-family normalization
- KdV feasibility remaining non-stable

## What Did Not Change

- no `src/` runtime code
- no public API additions
- no canonical object changes
- no new numerics work
- no stable KdV promotion

## Release-path validation

Local RC release path completed successfully:

- `python -m pytest`
- `python -m build --sdist --wheel`
- `python -m pdelie.examples.heat_vertical_slice`

Built artifacts:
- `pdelie-0.5.0rc1.tar.gz`
- `pdelie-0.5.0rc1-py3-none-any.whl`

Clean wheel smoke also passed in a fresh virtual environment:
- stable import smoke passed
- packaged example ran successfully
- installed package version verified as `0.5.0rc1`

## CI To Watch On This PR

- `v0_4-release-gate`
- `v0_5-release-gate`
- `editable-tests`
- `package-smoke`