### PR TITLE
Add V0.6 M1 discovery recovery metrics

### DIFF
--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -260,22 +260,106 @@ Frozen release definition:
 
 ---
 
-## Medium-Term Horizon
+## Planned Next Step
 
-### `v0.7+` — Broader data-ingestion and numerics horizon
+### `v0.7` — Structured external data ingestion
 **Status:** Planned
 
-The following remain later directions after the `v0.6` discovery-utility release:
+`v0.7` is the planned release after the `v0.6` discovery-utility release.
 
-- broader external dataset ingestion
-- broader numerics beyond the current stable Heat/Burgers regime
+Its purpose is:
+
+> make PDELie able to ingest external structured 1D uniform rectilinear PDE data into canonical `FieldBatch`, so the existing symmetry and discovery utilities can run outside internally generated synthetic fixtures.
+
+### Candidate scope for `v0.7`
+
+- `pdelie.data.from_numpy(...)`
+- `pdelie.data.from_xarray(...)`
+- strict conversion to canonical `FieldBatch`
+- 1D uniform rectilinear inputs only
+- scalar-variable stable slice only
+- explicit dims, coords, metadata, and provenance validation
+- parity tests showing imported Heat/Burgers-like data behaves like native `FieldBatch`
+
+### Out of scope for `v0.7`
+
+- no PDEBench-specific loader
+- no The Well adapter
+- no HDF5, netCDF, or Zarr stable loader
+- no 2D/3D external-data ingestion
+- no nonuniform-grid support
+- no broad metadata inference
+- no weak-form methods
+- no operator methods
+
+`v0.7` is therefore not a broad dataset-support release. It is the first structured-ingestion release:
+
+> external structured arrays -> canonical `FieldBatch` -> existing PDELie pipeline.
+
+---
+
+## Medium-Term Horizon
+
+### `v0.8` — Robust high-derivative and weak-form numerics
+**Status:** Planned / Experimental
+
+`v0.8` is the likely next major numerical expansion after structured ingestion.
+
+Its purpose is:
+
+> add derivative-robust machinery for noisy, coarse, or high-derivative PDE discovery, while preserving the canonical data and generator-family contracts.
+
+Candidate directions:
+
 - weak-form derivatives / weak residual workflows
-- operator-level symmetry methods
-- larger external datasets
-- nonuniform-grid support in practice
-- broader adapter ecosystems and interoperability work
+- WSINDy-style integration tests
+- robust residual evaluation under noise
+- high-derivative stress tests
+- KdV promotion if the weak/spectral story is mature enough
 
-These may exist in experimental namespaces or downstream repos before they enter the stable roadmap.
+KdV does not require weak-form methods for clean synthetic periodic tests, but noisy or coarse KdV is a natural pressure point for weak-form machinery. `v0.8` is therefore the right place to decide whether weak methods become a stable numerical axis.
+
+### `v0.9` — Broader PDE and dataset coverage
+**Status:** Planned / Experimental
+
+`v0.9` may broaden PDE and dataset coverage once structured ingestion and robust numerics are stable.
+
+Candidate directions:
+
+- stable KdV if not already promoted
+- wave equation after second-time-derivative semantics are clarified
+- reaction-diffusion systems
+- Kuramoto-Sivashinsky as a harder high-derivative stress test
+- PDEBench / The Well adapters after generic ingestion is proven
+- multidimensional structured grids if the 1D path is stable
+
+### `v1.0` — Stable public engine
+**Status:** Deferred
+
+`v1.0` should only happen once PDELie has a stable, supportable public surface for:
+
+- canonical PDE field data
+- generator families
+- verification and diagnostics
+- portability manifests
+- discovery utilities
+- selected structured external-data ingestion
+
+`v1.0` should be a stabilization milestone, not a scope-expansion milestone.
+
+### Later / Experimental — Operator-facing symmetry discovery
+**Status:** Experimental / Deferred
+
+Operator-facing symmetry work remains a later or separate track.
+
+Candidate directions:
+
+- FNO / DeepONet-compatible symmetry diagnostics
+- operator-level generator probing
+- learned symmetry representations in neural operators
+- operator benchmark layers
+
+This is not part of the near-term non-operator Paper 1 path and should not be mixed into `v0.6` or `v0.7`.
 
 ---
 
@@ -314,4 +398,8 @@ It should **not** be edited every time a new idea appears.
 - `v0.4` = Lie-algebra span, symbolic reporting, and visual diagnostics
 - `v0.5` = generator-family portability and external-family compatibility, with KdV kept non-stable
 - `v0.6` = symmetry-guided PDE discovery utilities in the current Heat/Burgers regime
-- `v0.7+` = broader data ingestion, broader numerics, weak-form work, operator methods, and other later directions
+- `v0.7` = structured external data ingestion into canonical `FieldBatch`
+- `v0.8` = robust high-derivative / weak-form numerics
+- `v0.9` = broader PDE and dataset coverage
+- `v1.0` = stable public engine
+- later / experimental = operator-facing symmetry discovery

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -61,6 +61,10 @@ Runtime public API for the frozen `v0.5` Milestone 2 slice:
 
 - `pdelie.portability.coerce_generator_family` for strict normalization of canonical in-memory families, canonical family payloads, manifests, and the narrow legacy translation payload into canonical `GeneratorFamily`
 
+Runtime public API for the frozen `v0.6` Milestone 1 slice:
+
+- `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support and coefficient recovery metrics over caller-supplied canonical term strings
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,3 +1,4 @@
+from pdelie.discovery.evaluation import evaluate_discovery_recovery
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
 
-__all__ = ["to_pysindy_trajectories"]
+__all__ = ["evaluate_discovery_recovery", "to_pysindy_trajectories"]

--- a/src/pdelie/discovery/evaluation.py
+++ b/src/pdelie/discovery/evaluation.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+
+from pdelie.errors import SchemaValidationError
+
+
+def _validate_support_epsilon(support_epsilon: object) -> float:
+    try:
+        epsilon = float(support_epsilon)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError("support_epsilon must be a finite non-negative scalar.") from exc
+    if not np.isfinite(epsilon) or epsilon < 0.0:
+        raise SchemaValidationError("support_epsilon must be a finite non-negative scalar.")
+    return epsilon
+
+
+def _validate_term_mapping(name: str, value: object) -> dict[str, float]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping of canonical term strings to scalar coefficients.")
+
+    normalized: dict[str, float] = {}
+    for term, coefficient in value.items():
+        if not isinstance(term, str) or not term:
+            raise SchemaValidationError(f"{name} term keys must be non-empty strings.")
+        try:
+            coefficient_value = float(coefficient)
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError(f"{name} coefficients must be finite scalar values.") from exc
+        if not np.isfinite(coefficient_value):
+            raise SchemaValidationError(f"{name} coefficients must be finite scalar values.")
+        normalized[term] = coefficient_value
+    return normalized
+
+
+def _coerce_residual(name: str, residual: object) -> np.ndarray:
+    try:
+        array = np.asarray(residual, dtype=float).reshape(-1)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite numeric scalar or array-like.") from exc
+    if array.size == 0:
+        raise SchemaValidationError(f"{name} must be non-empty after flattening.")
+    if not np.all(np.isfinite(array)):
+        raise SchemaValidationError(f"{name} must contain only finite values.")
+    return array
+
+
+def _support_terms(terms: Mapping[str, float], support_epsilon: float) -> list[str]:
+    return sorted(term for term, coefficient in terms.items() if abs(coefficient) > support_epsilon)
+
+
+def _safe_precision_recall_f1(
+    target_support: set[str],
+    discovered_support: set[str],
+    true_positives: int,
+) -> tuple[float, float, float]:
+    if not target_support and not discovered_support:
+        return 1.0, 1.0, 1.0
+
+    precision = float(true_positives / len(discovered_support)) if discovered_support else 0.0
+    recall = float(true_positives / len(target_support)) if target_support else 0.0
+    if precision + recall == 0.0:
+        return precision, recall, 0.0
+    return precision, recall, float((2.0 * precision * recall) / (precision + recall))
+
+
+def _equation_string(terms: Mapping[str, float], support_terms: list[str]) -> str:
+    if not support_terms:
+        return "0"
+
+    parts: list[str] = []
+    for index, term in enumerate(support_terms):
+        coefficient = float(terms[term])
+        if index == 0:
+            parts.append(f"{coefficient:.12g}*{term}")
+            continue
+        if coefficient < 0.0:
+            parts.append(f"- {abs(coefficient):.12g}*{term}")
+        else:
+            parts.append(f"+ {coefficient:.12g}*{term}")
+    return " ".join(parts)
+
+
+def evaluate_discovery_recovery(
+    target_terms: object,
+    discovered_terms: object,
+    *,
+    support_epsilon: float = 1e-8,
+    train_residual: object | None = None,
+    heldout_residual: object | None = None,
+) -> dict[str, object]:
+    epsilon = _validate_support_epsilon(support_epsilon)
+    normalized_target = _validate_term_mapping("target_terms", target_terms)
+    normalized_discovered = _validate_term_mapping("discovered_terms", discovered_terms)
+
+    target_support_terms = _support_terms(normalized_target, epsilon)
+    discovered_support_terms = _support_terms(normalized_discovered, epsilon)
+    union_terms = sorted(set(normalized_target) | set(normalized_discovered))
+
+    target_support = set(target_support_terms)
+    discovered_support = set(discovered_support_terms)
+    true_positives = len(target_support & discovered_support)
+    false_positives = len(discovered_support - target_support)
+    false_negatives = len(target_support - discovered_support)
+
+    if target_support == discovered_support:
+        classification = "exact"
+    elif true_positives > 0:
+        classification = "partial"
+    else:
+        classification = "failed"
+
+    precision, recall, f1 = _safe_precision_recall_f1(target_support, discovered_support, true_positives)
+
+    target_vector = np.asarray([normalized_target.get(term, 0.0) for term in union_terms], dtype=float)
+    discovered_vector = np.asarray([normalized_discovered.get(term, 0.0) for term in union_terms], dtype=float)
+    difference = discovered_vector - target_vector
+
+    coefficient_l2_error = float(np.linalg.norm(difference))
+    target_norm = float(np.linalg.norm(target_vector))
+    coefficient_relative_l2_error = float(coefficient_l2_error / (target_norm + 1e-12))
+    coefficient_linf_error = 0.0 if difference.size == 0 else float(np.max(np.abs(difference)))
+
+    result: dict[str, object] = {
+        "support_epsilon": epsilon,
+        "classification": classification,
+        "classification_basis": "support",
+        "target_support_terms": target_support_terms,
+        "discovered_support_terms": discovered_support_terms,
+        "union_terms": union_terms,
+        "support_true_positives": true_positives,
+        "support_false_positives": false_positives,
+        "support_false_negatives": false_negatives,
+        "support_precision": precision,
+        "support_recall": recall,
+        "support_f1": f1,
+        "support_exact_match": target_support == discovered_support,
+        "target_sparsity": len(target_support_terms),
+        "discovered_sparsity": len(discovered_support_terms),
+        "coefficient_l2_error": coefficient_l2_error,
+        "coefficient_relative_l2_error": coefficient_relative_l2_error,
+        "coefficient_linf_error": coefficient_linf_error,
+        "equation_strings": {
+            "target": _equation_string(normalized_target, target_support_terms),
+            "discovered": _equation_string(normalized_discovered, discovered_support_terms),
+        },
+    }
+
+    if train_residual is not None:
+        train_residual_array = _coerce_residual("train_residual", train_residual)
+        result["train_residual_l2"] = float(np.linalg.norm(train_residual_array))
+
+    if heldout_residual is not None:
+        heldout_residual_array = _coerce_residual("heldout_residual", heldout_residual)
+        heldout_residual_l2 = float(np.linalg.norm(heldout_residual_array))
+        result["heldout_residual_l2"] = heldout_residual_l2
+        result["heldout_residual_rms"] = float(heldout_residual_l2 / np.sqrt(float(heldout_residual_array.size)))
+
+    return result

--- a/tests/test_discovery_evaluation.py
+++ b/tests/test_discovery_evaluation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from pdelie import SchemaValidationError
+from pdelie.discovery import evaluate_discovery_recovery
+
+
+def test_evaluate_discovery_recovery_is_deterministic_and_support_based() -> None:
+    target_terms = {"u": 1.0, "u_x": -2.0}
+    discovered_terms = {"u": 1.5, "u_x": -2.0}
+
+    first = evaluate_discovery_recovery(target_terms, discovered_terms)
+    second = evaluate_discovery_recovery(target_terms, discovered_terms)
+
+    assert first == second
+    assert first["classification"] == "exact"
+    assert first["classification_basis"] == "support"
+    assert first["support_exact_match"] is True
+    assert first["target_support_terms"] == ["u", "u_x"]
+    assert first["discovered_support_terms"] == ["u", "u_x"]
+    assert first["equation_strings"] == {
+        "target": "1*u - 2*u_x",
+        "discovered": "1.5*u - 2*u_x",
+    }
+    assert first["coefficient_l2_error"] == pytest.approx(0.5)
+    assert first["coefficient_linf_error"] == pytest.approx(0.5)
+
+
+def test_evaluate_discovery_recovery_handles_partial_and_failed_support() -> None:
+    partial = evaluate_discovery_recovery(
+        {"u": 1.0, "u_x": 2.0},
+        {"u_x": 2.0, "u_xx": 3.0},
+    )
+    failed = evaluate_discovery_recovery(
+        {"u": 1.0},
+        {"u_x": 2.0},
+    )
+
+    assert partial["classification"] == "partial"
+    assert partial["support_true_positives"] == 1
+    assert partial["support_false_positives"] == 1
+    assert partial["support_false_negatives"] == 1
+    assert partial["support_precision"] == pytest.approx(0.5)
+    assert partial["support_recall"] == pytest.approx(0.5)
+    assert partial["support_f1"] == pytest.approx(0.5)
+
+    assert failed["classification"] == "failed"
+    assert failed["support_true_positives"] == 0
+    assert failed["support_precision"] == pytest.approx(0.0)
+    assert failed["support_recall"] == pytest.approx(0.0)
+    assert failed["support_f1"] == pytest.approx(0.0)
+
+
+def test_evaluate_discovery_recovery_handles_empty_support_edge_cases() -> None:
+    empty_exact = evaluate_discovery_recovery({}, {})
+    empty_target = evaluate_discovery_recovery({}, {"u_x": 2.0})
+    empty_discovered = evaluate_discovery_recovery({"u_x": 2.0}, {})
+
+    assert empty_exact["classification"] == "exact"
+    assert empty_exact["support_precision"] == pytest.approx(1.0)
+    assert empty_exact["support_recall"] == pytest.approx(1.0)
+    assert empty_exact["support_f1"] == pytest.approx(1.0)
+    assert empty_exact["union_terms"] == []
+    assert empty_exact["coefficient_l2_error"] == pytest.approx(0.0)
+    assert empty_exact["coefficient_relative_l2_error"] == pytest.approx(0.0)
+    assert empty_exact["coefficient_linf_error"] == pytest.approx(0.0)
+    assert empty_exact["equation_strings"] == {"target": "0", "discovered": "0"}
+
+    assert empty_target["classification"] == "failed"
+    assert empty_discovered["classification"] == "failed"
+
+
+def test_evaluate_discovery_recovery_excludes_terms_at_or_below_support_threshold() -> None:
+    result = evaluate_discovery_recovery(
+        {"a": 1e-9, "b": 1.0},
+        {"b": 1.0, "c": 1e-8},
+        support_epsilon=1e-8,
+    )
+
+    assert result["target_support_terms"] == ["b"]
+    assert result["discovered_support_terms"] == ["b"]
+    assert result["union_terms"] == ["a", "b", "c"]
+    assert result["classification"] == "exact"
+    assert result["equation_strings"]["target"] == "1*b"
+    assert result["equation_strings"]["discovered"] == "1*b"
+
+
+def test_evaluate_discovery_recovery_uses_union_terms_for_coefficient_errors() -> None:
+    result = evaluate_discovery_recovery(
+        {"a": 0.0, "b": 1.0},
+        {"b": 1.0, "c": 2.0},
+    )
+
+    assert result["union_terms"] == ["a", "b", "c"]
+    assert result["coefficient_l2_error"] == pytest.approx(2.0)
+    assert result["coefficient_linf_error"] == pytest.approx(2.0)
+
+
+def test_evaluate_discovery_recovery_keeps_relative_l2_formula_for_zero_target_norm() -> None:
+    result = evaluate_discovery_recovery({}, {"u_x": 2.0})
+
+    assert result["coefficient_relative_l2_error"] == pytest.approx(2.0 / 1e-12)
+
+
+def test_evaluate_discovery_recovery_equation_strings_use_support_terms_only_and_lexicographic_order() -> None:
+    result = evaluate_discovery_recovery(
+        {"z": 0.5, "a": 1e-12, "b": -2.0},
+        {"b": -2.0, "z": 0.5},
+    )
+
+    assert result["union_terms"] == ["a", "b", "z"]
+    assert result["equation_strings"]["target"] == "-2*b + 0.5*z"
+    assert result["equation_strings"]["discovered"] == "-2*b + 0.5*z"
+    assert "a" not in result["equation_strings"]["target"]
+
+
+def test_evaluate_discovery_recovery_summarizes_residuals_for_scalar_and_array_inputs() -> None:
+    result = evaluate_discovery_recovery(
+        {"u": 1.0},
+        {"u": 1.0},
+        train_residual=3.0,
+        heldout_residual=np.array([3.0, 4.0]),
+    )
+
+    assert result["train_residual_l2"] == pytest.approx(3.0)
+    assert result["heldout_residual_l2"] == pytest.approx(5.0)
+    assert result["heldout_residual_rms"] == pytest.approx(5.0 / math.sqrt(2.0))
+
+
+@pytest.mark.parametrize(
+    ("target_terms", "discovered_terms", "match"),
+    (
+        ({}, {"": 1.0}, "term keys must be non-empty strings"),
+        ({1: 1.0}, {}, "term keys must be non-empty strings"),
+        ({"u": np.inf}, {}, "coefficients must be finite scalar values"),
+        ({}, {"u": np.nan}, "coefficients must be finite scalar values"),
+    ),
+)
+def test_evaluate_discovery_recovery_rejects_invalid_terms_and_coefficients(
+    target_terms: object,
+    discovered_terms: object,
+    match: str,
+) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        evaluate_discovery_recovery(target_terms, discovered_terms)
+
+
+@pytest.mark.parametrize("support_epsilon", (np.nan, -1.0, np.inf, "bad"))
+def test_evaluate_discovery_recovery_rejects_invalid_support_epsilon(support_epsilon: object) -> None:
+    with pytest.raises(SchemaValidationError, match="support_epsilon must be a finite non-negative scalar"):
+        evaluate_discovery_recovery({"u": 1.0}, {"u": 1.0}, support_epsilon=support_epsilon)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    (
+        ({"train_residual": []}, "train_residual must be non-empty after flattening"),
+        ({"heldout_residual": []}, "heldout_residual must be non-empty after flattening"),
+        ({"train_residual": [1.0, np.nan]}, "train_residual must contain only finite values"),
+        ({"heldout_residual": [1.0, np.inf]}, "heldout_residual must contain only finite values"),
+    ),
+)
+def test_evaluate_discovery_recovery_rejects_invalid_residual_inputs(
+    kwargs: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        evaluate_discovery_recovery({"u": 1.0}, {"u": 1.0}, **kwargs)
+
+
+@pytest.mark.parametrize("invalid_mapping", ([], 1.0, "u"))
+def test_evaluate_discovery_recovery_requires_term_mappings(invalid_mapping: object) -> None:
+    with pytest.raises(SchemaValidationError, match="must be a mapping of canonical term strings to scalar coefficients"):
+        evaluate_discovery_recovery(invalid_mapping, {})

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,7 +29,7 @@ def test_stable_public_api_is_importable() -> None:
 
 
 def test_runtime_package_api_is_importable() -> None:
-    from pdelie.discovery import to_pysindy_trajectories
+    from pdelie.discovery import evaluate_discovery_recovery, to_pysindy_trajectories
     from pdelie.invariants import InvariantApplier
     from pdelie.portability import (
         coerce_generator_family,
@@ -51,6 +51,7 @@ def test_runtime_package_api_is_importable() -> None:
     )
 
     assert InvariantApplier is not None
+    assert evaluate_discovery_recovery is not None
     assert to_pysindy_trajectories is not None
     assert coerce_generator_family is not None
     assert export_generator_family_manifest is not None
@@ -68,6 +69,7 @@ def test_runtime_package_api_is_importable() -> None:
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
+    assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
     assert not hasattr(pdelie, "coerce_generator_family")
     assert not hasattr(pdelie, "export_generator_family_manifest")
@@ -93,6 +95,7 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
 def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> None:
     discovery_module = importlib.import_module("pdelie.discovery")
 
+    assert hasattr(discovery_module, "evaluate_discovery_recovery")
     assert hasattr(discovery_module, "to_pysindy_trajectories")
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 


### PR DESCRIPTION
## Summary

Implements `v0.6` Milestone 1 only.

This PR adds a small runtime metrics layer under `pdelie.discovery` for comparing discovered PDE terms against known target terms in the current frozen `v0.6` discovery-utility scope.

Added:
- `pdelie.discovery.evaluate_discovery_recovery(...)`

This milestone stays narrow:
- no PySINDy fitting
- no translation-canonical input builder
- no robustness utilities
- no new canonical object
- no root exports

## What Changed

### New runtime API
Added:
- `src/pdelie/discovery/evaluation.py`

Updated:
- `src/pdelie/discovery/__init__.py`

New runtime public API:
- `pdelie.discovery.evaluate_discovery_recovery`

No changes were made to `pdelie.__init__`.

### Frozen input and output policy
The new API evaluates recovery over a caller-supplied term basis.

Frozen input behavior:
- `target_terms` and `discovered_terms` are mappings of canonical term string to scalar coefficient
- exact string equality defines support identity
- aliases, symbolic simplification, and term normalization remain out of scope
- term keys must be non-empty strings
- coefficients must be finite
- `support_epsilon` must be finite and non-negative
- support is defined by `abs(coef) > support_epsilon`

Frozen output behavior:
- support precision / recall / F1
- support exact-match flag
- support sparsity counts
- coefficient `L2`, relative-`L2`, and `Linf` errors over the union support
- optional train / held-out residual summaries
- deterministic equation strings
- `classification_basis = "support"` to make the support-only interpretation explicit

### Edge-case policy
This PR freezes the representative M1 edge cases:
- empty target support + empty discovered support -> `classification = "exact"`
- empty target support + non-empty discovered support -> `classification = "failed"`
- non-empty target support + empty discovered support -> `classification = "failed"`
- coefficients at or below `support_epsilon` do not enter support
- non-finite coefficients fail with `SchemaValidationError`
- non-finite residual inputs fail with `SchemaValidationError`
- empty residual inputs fail with `SchemaValidationError`

### Deterministic equation-string policy
Equation strings are intentionally narrow and deterministic:
- support terms only
- lexicographic term ordering
- empty support renders as `"0"`
- coefficient formatting uses fixed compact formatting:
  - `"{float(coef):.12g}"`

This API does not claim symbolic equation equivalence beyond exact term-string identity.

## Tests

Added:
- `tests/test_discovery_evaluation.py`

Updated:
- `tests/test_public_api.py`

Coverage includes:
- deterministic repeated outputs
- exact / partial / failed support classification
- empty-support edge cases
- thresholded support behavior
- union-support coefficient error behavior
- zero-target relative coefficient error behavior
- deterministic equation-string rendering
- scalar and array-like residual summaries
- invalid term keys / coefficients / residuals / `support_epsilon`
- frozen `pdelie.discovery` runtime package surface

## Docs

Updated:
- `docs/specs/API_STABILITY.md`

This records `evaluate_discovery_recovery(...)` as the frozen `v0.6` M1 runtime public API.

## Validation

Ran:
- `python -m pytest tests/test_discovery_evaluation.py tests/test_public_api.py`
- `python -m pytest`

Results:
- `32 passed` on the narrow M1/API slice
- `253 passed, 388 warnings` on the full suite

The warnings are the existing downstream/PySINDy warnings and are unchanged by this PR.
