### PR TITLE
narrow backend-fit adapter over the existing flattened PySINDy bridge

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.6 Milestone 1 — Discovery recovery metrics**
+**V0.6 Milestone 2 — Thin PySINDy backend-fit adapter**
 
 This file is the active execution plan for the current `v0.6` release series.
 
@@ -43,7 +43,7 @@ It does not broaden the stable numerics regime beyond the current Heat/Burgers c
 
 ## Milestone 1 — Discovery Recovery Metrics
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -93,27 +93,34 @@ Run at minimum:
 
 ## Milestone 2 — Thin PySINDy Discovery Adapter
 
-**Status:** Pending
+**Status:** Active
 
 ### Goal
 
-Add one narrow PySINDy-only discovery adapter for the existing scalar periodic trajectory bridge without creating a general discovery-backend framework.
+Add one narrow PySINDy-only backend-fit adapter for the existing scalar periodic trajectory bridge without creating a general discovery-backend framework or claiming canonical PDE-level equation extraction.
 
 ### Frozen Decisions
 
 - add `pdelie.discovery.fit_pysindy_discovery(...)`
 - PySINDy only
 - continuous-time only
-- target derivative is exactly `"u_t"`
 - accept only the current trajectory shape from `to_pysindy_trajectories(...)`
-- `feature_names` are the input trajectory columns
+- all trajectories must share identical shape as a frozen M2 simplification, not as a general PySINDy limitation
+- `feature_names` are the input state-feature columns and must be unique non-empty strings
+- runtime owns a private frozen deterministic PySINDy default profile
+- `config` must be `None`
+- return a runtime backend report dict, not a JSON-compatible artifact schema
 - return:
   - `library_feature_names`
-  - dense `coefficients`
-  - sparse `equation_terms`
+  - dense 2D `coefficients` as NumPy arrays
+  - sparse backend-native `equation_terms`
+  - backend-native debug `equation_strings`
 - default coefficient threshold is `1e-8`
 - backend fitting failures return `status="failed"`
 - missing dependency remains `ImportError`
+- `equation_terms` and `equation_strings` are backend-native and non-canonical
+- `equation_terms` and `equation_strings` must not be fed directly into `evaluate_discovery_recovery(...)` without a later canonicalization step
+- do not promise a true `u_t = ...` PDE equation in M2
 - do not generalize into a backend framework
 
 ---
@@ -227,8 +234,8 @@ Hard sequencing rules:
 ## Status
 
 - `v0.5`: COMPLETE
-- Milestone 1: ACTIVE
-- Milestone 2: PENDING
+- Milestone 1: COMPLETE
+- Milestone 2: ACTIVE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/V0_6_SCOPE.md
+++ b/docs/planning/V0_6_SCOPE.md
@@ -68,7 +68,7 @@ Unsupported in stable `v0.6`:
 ---
 
 ## Milestone 1 — Discovery recovery metrics
-**Status:** Active
+**Status:** Complete
 
 Public runtime API:
 
@@ -110,7 +110,7 @@ Frozen outputs:
 ---
 
 ## Milestone 2 — Thin PySINDy discovery adapter
-**Status:** Pending
+**Status:** Active
 
 Public runtime API:
 
@@ -120,19 +120,26 @@ Frozen scope:
 
 - PySINDy only
 - continuous-time only
-- target derivative exactly `"u_t"`
 - accepts only the current trajectory shape from `to_pysindy_trajectories(...)`
-- `feature_names` are the input trajectory columns
-- default config is the current deterministic downstream benchmark profile
+- all trajectories must share identical shape as a frozen M2 simplification, not as a general PySINDy limitation
+- `feature_names` are the input trajectory columns and must be unique non-empty strings
+- default config is a private runtime deterministic PySINDy profile
+- `config` must be `None` in `v0.6` M2
 - this is not a general discovery-backend framework
+- this is not yet a canonical PDE-level `u_t = ...` equation extractor
+- this returns a runtime backend report dict, not a JSON-compatible artifact schema
 
 Frozen extraction policy:
 
 - returns `library_feature_names`
-- returns a dense `coefficients` vector aligned 1:1 with `library_feature_names`
-- returns sparse `equation_terms`
+- returns a dense 2D `coefficients` matrix with rows aligned to `feature_names` and columns aligned to `library_feature_names`
+- `coefficients` remain runtime NumPy arrays in `v0.6` M2
+- returns sparse backend-native `equation_terms`
+- returns backend-native debug `equation_strings`
 - default coefficient threshold is `1e-8`
 - raw multi-target backend matrices are out of scope
+- canonical PDE term extraction is out of scope
+- `equation_terms` and `equation_strings` must not be fed directly into `evaluate_discovery_recovery(...)` without a later canonicalization step
 
 Frozen failure policy:
 
@@ -144,12 +151,11 @@ Frozen returned fields:
 
 - `status`
 - `backend`
-- `target_derivative`
 - `feature_names`
 - `library_feature_names`
 - `coefficients`
 - `equation_terms`
-- `equation_string`
+- `equation_strings`
 - `fit_config`
 - `fit_diagnostics`
 - `failure_reason` when failed

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -65,6 +65,12 @@ Runtime public API for the frozen `v0.6` Milestone 1 slice:
 
 - `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support and coefficient recovery metrics over caller-supplied canonical term strings
 
+Runtime public API for the frozen `v0.6` Milestone 2 slice:
+
+- `pdelie.discovery.fit_pysindy_discovery` for a runtime-only, backend-native PySINDy fit adapter over the current flattened `to_pysindy_trajectories(...)` bridge
+- this M2 API returns a runtime backend report dict, not a stable JSON-compatible artifact schema
+- its `coefficients` field is runtime NumPy data, and its `equation_terms` / `equation_strings` fields are backend-native, non-canonical debug outputs
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,4 +1,5 @@
 from pdelie.discovery.evaluation import evaluate_discovery_recovery
+from pdelie.discovery.pysindy_adapter import fit_pysindy_discovery
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
 
-__all__ = ["evaluate_discovery_recovery", "to_pysindy_trajectories"]
+__all__ = ["evaluate_discovery_recovery", "fit_pysindy_discovery", "to_pysindy_trajectories"]

--- a/src/pdelie/discovery/_pysindy_defaults.py
+++ b/src/pdelie/discovery/_pysindy_defaults.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+DEFAULT_PYSINDY_DISCOVERY_CONFIG: dict[str, object] = {
+    "coefficient_threshold": 1e-8,
+    "pysindy_model": {
+        "optimizer": {
+            "threshold": 0.1,
+            "alpha": 0.05,
+            "max_iter": 20,
+            "normalize_columns": False,
+            "fit_intercept": False,
+            "copy_X": True,
+            "verbose": False,
+        },
+        "feature_library": {
+            "degree": 2,
+            "include_interaction": True,
+            "interaction_only": False,
+            "include_bias": True,
+            "order": "C",
+            "library_ensemble": False,
+        },
+        "differentiation_method": {
+            "order": 2,
+            "d": 1,
+            "axis": 0,
+            "is_uniform": False,
+            "drop_endpoints": False,
+            "periodic": False,
+        },
+        "discrete_time": False,
+    },
+    "pysindy_fit": {
+        "multiple_trajectories": True,
+        "unbias": True,
+        "quiet": True,
+        "ensemble": False,
+        "library_ensemble": False,
+        "replace": True,
+        "n_candidates_to_drop": 1,
+        "n_subset": None,
+        "n_models": None,
+        "ensemble_aggregator": None,
+    },
+}
+
+
+def get_default_pysindy_discovery_config() -> dict[str, object]:
+    model_config = dict(DEFAULT_PYSINDY_DISCOVERY_CONFIG["pysindy_model"])
+    return {
+        "coefficient_threshold": float(DEFAULT_PYSINDY_DISCOVERY_CONFIG["coefficient_threshold"]),
+        "pysindy_model": {
+            "optimizer": dict(model_config["optimizer"]),
+            "feature_library": dict(model_config["feature_library"]),
+            "differentiation_method": dict(model_config["differentiation_method"]),
+            "discrete_time": bool(model_config["discrete_time"]),
+        },
+        "pysindy_fit": dict(DEFAULT_PYSINDY_DISCOVERY_CONFIG["pysindy_fit"]),
+    }

--- a/src/pdelie/discovery/pysindy_adapter.py
+++ b/src/pdelie/discovery/pysindy_adapter.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Sequence
+
+import numpy as np
+
+from pdelie.discovery._pysindy_defaults import get_default_pysindy_discovery_config
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+def _require_discovery_dependencies():
+    try:
+        pysindy = importlib.import_module("pysindy")
+        importlib.import_module("sklearn")
+    except (ModuleNotFoundError, ImportError, ValueError) as exc:
+        raise ImportError(
+            "PySINDy discovery adapter requires pdelie[downstream] or pdelie[test]."
+        ) from exc
+    return pysindy
+
+
+def _validate_trajectories(trajectories: object) -> list[np.ndarray]:
+    if not isinstance(trajectories, (list, tuple)) or not trajectories:
+        raise SchemaValidationError("trajectories must be a non-empty list or tuple of 2D finite numeric arrays.")
+
+    normalized: list[np.ndarray] = []
+    expected_shape: tuple[int, int] | None = None
+    for index, trajectory in enumerate(trajectories):
+        try:
+            array = np.asarray(trajectory, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError(
+                "trajectories must contain only 2D finite numeric arrays."
+            ) from exc
+        if array.ndim != 2:
+            raise SchemaValidationError("each trajectory must be a 2D finite numeric array.")
+        if not np.all(np.isfinite(array)):
+            raise SchemaValidationError("trajectories must contain only finite values.")
+        if expected_shape is None:
+            expected_shape = tuple(int(dim) for dim in array.shape)
+        elif tuple(array.shape) != expected_shape:
+            raise SchemaValidationError("all trajectories must share identical shape in V0.6 Milestone 2.")
+        normalized.append(array.copy())
+    return normalized
+
+
+def _validate_time_values(time_values: object, *, num_times: int) -> np.ndarray:
+    try:
+        array = np.asarray(time_values, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError("time_values must be a one-dimensional finite numeric array.") from exc
+    if array.ndim != 1:
+        raise SchemaValidationError("time_values must be a one-dimensional finite numeric array.")
+    if array.size < 3:
+        raise SchemaValidationError("time_values must have at least 3 entries.")
+    if array.size != num_times:
+        raise SchemaValidationError("time_values length must match the trajectory time dimension.")
+    if not np.all(np.isfinite(array)):
+        raise SchemaValidationError("time_values must contain only finite values.")
+    if not np.all(np.diff(array) > 0.0):
+        raise SchemaValidationError("time_values must be strictly increasing.")
+    return array.copy()
+
+
+def _validate_feature_names(feature_names: object, *, num_state_features: int) -> list[str]:
+    if isinstance(feature_names, (str, bytes)) or not isinstance(feature_names, Sequence):
+        raise SchemaValidationError("feature_names must be a sequence of unique non-empty strings.")
+
+    normalized = list(feature_names)
+    if len(normalized) != num_state_features:
+        raise SchemaValidationError("feature_names length must match the trajectory feature dimension.")
+    if any(not isinstance(name, str) or not name for name in normalized):
+        raise SchemaValidationError("feature_names must contain only non-empty strings.")
+    if len(set(normalized)) != len(normalized):
+        raise SchemaValidationError("feature_names must be unique in V0.6 Milestone 2.")
+    return normalized
+
+
+def _build_pysindy_model(pysindy, *, feature_names: list[str], fit_config: dict[str, object]):
+    model_config = dict(fit_config["pysindy_model"])
+    return pysindy.SINDy(
+        optimizer=pysindy.STLSQ(**dict(model_config["optimizer"])),
+        feature_library=pysindy.PolynomialLibrary(**dict(model_config["feature_library"])),
+        differentiation_method=pysindy.FiniteDifference(**dict(model_config["differentiation_method"])),
+        feature_names=list(feature_names),
+        discrete_time=bool(model_config["discrete_time"]),
+    )
+
+
+def _format_backend_equation(terms: dict[str, float]) -> str:
+    if not terms:
+        return "0"
+
+    parts: list[str] = []
+    for index, (term, coefficient) in enumerate(terms.items()):
+        if index == 0:
+            parts.append(f"{coefficient:.12g}*{term}")
+            continue
+        if coefficient < 0.0:
+            parts.append(f"- {abs(coefficient):.12g}*{term}")
+        else:
+            parts.append(f"+ {coefficient:.12g}*{term}")
+    return " ".join(parts)
+
+
+def _extract_backend_terms(
+    coefficients: np.ndarray,
+    *,
+    feature_names: list[str],
+    library_feature_names: list[str],
+    coefficient_threshold: float,
+) -> tuple[dict[str, dict[str, float]], dict[str, str], dict[str, int]]:
+    expected_shape = (len(feature_names), len(library_feature_names))
+    if coefficients.ndim != 2 or tuple(coefficients.shape) != expected_shape:
+        raise SchemaValidationError(
+            f"PySINDy coefficients must have shape {expected_shape}, got {tuple(coefficients.shape)}."
+        )
+
+    equation_terms: dict[str, dict[str, float]] = {}
+    equation_strings: dict[str, str] = {}
+    nonzero_term_counts: dict[str, int] = {}
+
+    for row_index, feature_name in enumerate(feature_names):
+        sparse_terms: dict[str, float] = {}
+        for column_index, library_feature_name in enumerate(library_feature_names):
+            coefficient = float(coefficients[row_index, column_index])
+            if abs(coefficient) > coefficient_threshold:
+                sparse_terms[library_feature_name] = coefficient
+        equation_terms[feature_name] = sparse_terms
+        equation_strings[feature_name] = _format_backend_equation(sparse_terms)
+        nonzero_term_counts[feature_name] = len(sparse_terms)
+
+    return equation_terms, equation_strings, nonzero_term_counts
+
+
+def _success_result(
+    *,
+    feature_names: list[str],
+    library_feature_names: list[str],
+    coefficients: np.ndarray,
+    equation_terms: dict[str, dict[str, float]],
+    equation_strings: dict[str, str],
+    fit_config: dict[str, object],
+    num_trajectories: int,
+    num_times: int,
+    nonzero_term_counts: dict[str, int],
+) -> dict[str, object]:
+    return {
+        "status": "success",
+        "backend": "pysindy",
+        "feature_names": list(feature_names),
+        "library_feature_names": list(library_feature_names),
+        "coefficients": coefficients.copy(),
+        "equation_terms": equation_terms,
+        "equation_strings": equation_strings,
+        "fit_config": fit_config,
+        "fit_diagnostics": {
+            "num_trajectories": num_trajectories,
+            "num_times": num_times,
+            "num_state_features": len(feature_names),
+            "num_library_features": len(library_feature_names),
+            "coefficient_threshold": float(fit_config["coefficient_threshold"]),
+            "nonzero_term_counts": nonzero_term_counts,
+            "terms_are_backend_native": True,
+            "canonicalized": False,
+        },
+    }
+
+
+def _failed_result(
+    *,
+    feature_names: list[str],
+    fit_config: dict[str, object],
+    exc: Exception,
+) -> dict[str, object]:
+    return {
+        "status": "failed",
+        "backend": "pysindy",
+        "feature_names": list(feature_names),
+        "library_feature_names": [],
+        "coefficients": None,
+        "equation_terms": {},
+        "equation_strings": {},
+        "fit_config": fit_config,
+        "fit_diagnostics": {
+            "exception_type": type(exc).__name__,
+            "exception_message": str(exc),
+            "terms_are_backend_native": True,
+            "canonicalized": False,
+        },
+        "failure_reason": "backend_fit_failed",
+    }
+
+
+def fit_pysindy_discovery(
+    trajectories: object,
+    time_values: object,
+    feature_names: object,
+    *,
+    config: object | None = None,
+) -> dict[str, object]:
+    if config is not None:
+        raise ScopeValidationError("fit_pysindy_discovery only supports config=None in V0.6 Milestone 2.")
+
+    normalized_trajectories = _validate_trajectories(trajectories)
+    num_times, num_state_features = normalized_trajectories[0].shape
+    normalized_time_values = _validate_time_values(time_values, num_times=num_times)
+    normalized_feature_names = _validate_feature_names(feature_names, num_state_features=num_state_features)
+
+    pysindy = _require_discovery_dependencies()
+    fit_config = get_default_pysindy_discovery_config()
+
+    try:
+        model = _build_pysindy_model(
+            pysindy,
+            feature_names=normalized_feature_names,
+            fit_config=fit_config,
+        )
+        model.fit(
+            normalized_trajectories,
+            t=normalized_time_values,
+            **dict(fit_config["pysindy_fit"]),
+        )
+        coefficients = np.asarray(model.coefficients(), dtype=float)
+        library_feature_names = list(model.get_feature_names())
+    except Exception as exc:  # noqa: BLE001
+        return _failed_result(
+            feature_names=normalized_feature_names,
+            fit_config=fit_config,
+            exc=exc,
+        )
+
+    if not np.all(np.isfinite(coefficients)):
+        raise SchemaValidationError("PySINDy coefficients must be finite.")
+
+    equation_terms, equation_strings, nonzero_term_counts = _extract_backend_terms(
+        coefficients,
+        feature_names=normalized_feature_names,
+        library_feature_names=library_feature_names,
+        coefficient_threshold=float(fit_config["coefficient_threshold"]),
+    )
+
+    return _success_result(
+        feature_names=normalized_feature_names,
+        library_feature_names=library_feature_names,
+        coefficients=coefficients,
+        equation_terms=equation_terms,
+        equation_strings=equation_strings,
+        fit_config=fit_config,
+        num_trajectories=len(normalized_trajectories),
+        num_times=num_times,
+        nonzero_term_counts=nonzero_term_counts,
+    )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,7 +29,7 @@ def test_stable_public_api_is_importable() -> None:
 
 
 def test_runtime_package_api_is_importable() -> None:
-    from pdelie.discovery import evaluate_discovery_recovery, to_pysindy_trajectories
+    from pdelie.discovery import evaluate_discovery_recovery, fit_pysindy_discovery, to_pysindy_trajectories
     from pdelie.invariants import InvariantApplier
     from pdelie.portability import (
         coerce_generator_family,
@@ -52,6 +52,7 @@ def test_runtime_package_api_is_importable() -> None:
 
     assert InvariantApplier is not None
     assert evaluate_discovery_recovery is not None
+    assert fit_pysindy_discovery is not None
     assert to_pysindy_trajectories is not None
     assert coerce_generator_family is not None
     assert export_generator_family_manifest is not None
@@ -70,6 +71,7 @@ def test_runtime_package_api_is_importable() -> None:
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
+    assert not hasattr(pdelie, "fit_pysindy_discovery")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
     assert not hasattr(pdelie, "coerce_generator_family")
     assert not hasattr(pdelie, "export_generator_family_manifest")
@@ -96,6 +98,7 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
     discovery_module = importlib.import_module("pdelie.discovery")
 
     assert hasattr(discovery_module, "evaluate_discovery_recovery")
+    assert hasattr(discovery_module, "fit_pysindy_discovery")
     assert hasattr(discovery_module, "to_pysindy_trajectories")
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 

--- a/tests/test_pysindy_discovery_adapter.py
+++ b/tests/test_pysindy_discovery_adapter.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pdelie import SchemaValidationError, ScopeValidationError
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.discovery import fit_pysindy_discovery, to_pysindy_trajectories
+
+
+def _adapter_module():
+    return importlib.import_module("pdelie.discovery.pysindy_adapter")
+
+
+def _small_bridge_from_field(field):
+    trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+    return trajectories, time_values, feature_names
+
+
+@pytest.mark.parametrize(
+    ("field_factory", "seed"),
+    (
+        (generate_heat_1d_field_batch, 901),
+        (generate_burgers_1d_field_batch, 902),
+    ),
+)
+def test_fit_pysindy_discovery_succeeds_on_tiny_representative_bridge(field_factory, seed: int) -> None:
+    try:
+        _adapter_module()._require_discovery_dependencies()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+    field = field_factory(batch_size=2, num_times=9, num_points=4, seed=seed)
+    trajectories, time_values, feature_names = _small_bridge_from_field(field)
+
+    result = fit_pysindy_discovery(trajectories, time_values, feature_names)
+
+    assert result["status"] == "success"
+    assert result["backend"] == "pysindy"
+    assert result["feature_names"] == feature_names
+    assert result["fit_config"]["coefficient_threshold"] == pytest.approx(1e-8)
+    assert result["fit_diagnostics"]["terms_are_backend_native"] is True
+    assert result["fit_diagnostics"]["canonicalized"] is False
+    assert result["fit_diagnostics"]["num_trajectories"] == len(trajectories)
+    assert result["fit_diagnostics"]["num_times"] == len(time_values)
+
+    coefficients = result["coefficients"]
+    library_feature_names = result["library_feature_names"]
+    assert isinstance(library_feature_names, list)
+    assert coefficients.shape == (len(feature_names), len(library_feature_names))
+    assert np.all(np.isfinite(coefficients))
+
+    assert set(result["equation_terms"]) == set(feature_names)
+    assert set(result["equation_strings"]) == set(feature_names)
+    for name in feature_names:
+        assert isinstance(result["equation_terms"][name], dict)
+        assert isinstance(result["equation_strings"][name], str)
+
+
+def test_fit_pysindy_discovery_freezes_row_orientation_for_extraction() -> None:
+    adapter_module = _adapter_module()
+
+    equation_terms, equation_strings, nonzero_term_counts = adapter_module._extract_backend_terms(
+        np.asarray([[0.0, 1.0, 0.0], [2.0, 0.0, -3.0]], dtype=float),
+        feature_names=["lhs0", "lhs1"],
+        library_feature_names=["1", "a", "b"],
+        coefficient_threshold=1e-8,
+    )
+
+    assert equation_terms == {
+        "lhs0": {"a": 1.0},
+        "lhs1": {"1": 2.0, "b": -3.0},
+    }
+    assert equation_strings == {
+        "lhs0": "1*a",
+        "lhs1": "2*1 - 3*b",
+    }
+    assert nonzero_term_counts == {"lhs0": 1, "lhs1": 2}
+
+
+def test_fit_pysindy_discovery_real_backend_orientation_is_rows_by_feature() -> None:
+    try:
+        _adapter_module()._require_discovery_dependencies()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+    time_values = np.linspace(0.0, 0.9, 10)
+    trajectories = [np.column_stack((time_values, 2.0 * time_values))]
+    feature_names = ["a", "b"]
+
+    result = fit_pysindy_discovery(trajectories, time_values, feature_names)
+
+    assert result["status"] == "success"
+    assert result["coefficients"].shape[0] == 2
+    assert list(result["equation_terms"]) == ["a", "b"]
+    assert result["fit_diagnostics"]["num_state_features"] == 2
+
+
+def test_fit_pysindy_discovery_rejects_non_none_config() -> None:
+    with pytest.raises(ScopeValidationError, match="only supports config=None"):
+        fit_pysindy_discovery(
+            [np.ones((4, 2), dtype=float)],
+            np.linspace(0.0, 0.3, 4),
+            ["a", "b"],
+            config={},
+        )
+
+
+@pytest.mark.parametrize(
+    ("trajectories", "match"),
+    (
+        ([], "non-empty list or tuple"),
+        ([np.ones(4, dtype=float)], "each trajectory must be a 2D finite numeric array"),
+        ([np.ones((4, 2), dtype=float), np.ones((5, 2), dtype=float)], "must share identical shape"),
+        ([np.array([[1.0, np.nan]])], "must contain only finite values"),
+    ),
+)
+def test_fit_pysindy_discovery_rejects_invalid_trajectories(trajectories, match: str) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        fit_pysindy_discovery(trajectories, np.linspace(0.0, 0.3, 4), ["a", "b"])
+
+
+@pytest.mark.parametrize(
+    ("time_values", "match"),
+    (
+        (np.ones((4, 1), dtype=float), "one-dimensional"),
+        (np.array([0.0, 0.1]), "at least 3 entries"),
+        (np.array([0.0, 0.2, 0.1, 0.3]), "strictly increasing"),
+        (np.array([0.0, 0.1, np.nan, 0.3]), "contain only finite values"),
+        (np.linspace(0.0, 0.2, 3), "length must match"),
+    ),
+)
+def test_fit_pysindy_discovery_rejects_invalid_time_values(time_values, match: str) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        fit_pysindy_discovery([np.ones((4, 2), dtype=float)], time_values, ["a", "b"])
+
+
+@pytest.mark.parametrize(
+    ("feature_names", "match"),
+    (
+        ("ab", "sequence of unique non-empty strings"),
+        (["a"], "length must match"),
+        (["a", ""], "non-empty strings"),
+        (["a", "a"], "must be unique"),
+    ),
+)
+def test_fit_pysindy_discovery_rejects_invalid_feature_names(feature_names, match: str) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        fit_pysindy_discovery([np.ones((4, 2), dtype=float)], np.linspace(0.0, 0.3, 4), feature_names)
+
+
+def test_fit_pysindy_discovery_raises_clear_import_error_when_dependency_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter_module = _adapter_module()
+    real_import_module = importlib.import_module
+
+    def _fake_import_module(name: str, package: str | None = None):
+        if name == "pysindy":
+            raise ModuleNotFoundError("No module named 'pysindy'")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(adapter_module.importlib, "import_module", _fake_import_module)
+
+    with pytest.raises(ImportError, match=r"pdelie\[downstream\] or pdelie\[test\]"):
+        fit_pysindy_discovery(
+            [np.ones((4, 2), dtype=float)],
+            np.linspace(0.0, 0.3, 4),
+            ["a", "b"],
+        )
+
+
+def test_fit_pysindy_discovery_converts_backend_fit_exception_to_failed_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter_module = _adapter_module()
+
+    class _FailingModel:
+        def fit(self, *args, **kwargs):
+            raise RuntimeError("synthetic backend failure")
+
+    try:
+        adapter_module._require_discovery_dependencies()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+    monkeypatch.setattr(adapter_module, "_build_pysindy_model", lambda *args, **kwargs: _FailingModel())
+
+    result = fit_pysindy_discovery(
+        [np.ones((4, 2), dtype=float)],
+        np.linspace(0.0, 0.3, 4),
+        ["a", "b"],
+    )
+
+    assert result["status"] == "failed"
+    assert result["backend"] == "pysindy"
+    assert result["feature_names"] == ["a", "b"]
+    assert result["library_feature_names"] == []
+    assert result["coefficients"] is None
+    assert result["equation_terms"] == {}
+    assert result["equation_strings"] == {}
+    assert result["failure_reason"] == "backend_fit_failed"
+    assert result["fit_diagnostics"]["exception_type"] == "RuntimeError"
+    assert "synthetic backend failure" in result["fit_diagnostics"]["exception_message"]


### PR DESCRIPTION
## Summary

Implements `v0.6` Milestone 2 as a thin PySINDy backend-fit adapter over the existing flattened `to_pysindy_trajectories(...)` bridge.

This PR adds:
- `pdelie.discovery.fit_pysindy_discovery(...)`
- a private runtime PySINDy default-profile module
- focused adapter tests
- M2 doc tightening so the milestone no longer overclaims canonical PDE-level extraction

This milestone stays narrow:
- one backend only: PySINDy
- one frozen input shape only: the current flattened bridge
- backend-native terms only
- no general backend framework
- no new canonical object
- no root exports

## What Changed

### New runtime API
Added:
- `src/pdelie/discovery/pysindy_adapter.py`
- `src/pdelie/discovery/_pysindy_defaults.py`

Updated:
- `src/pdelie/discovery/__init__.py`

New public runtime API:
- `pdelie.discovery.fit_pysindy_discovery(trajectories, time_values, feature_names, *, config=None)`

It is exported from `pdelie.discovery` only and is not added to `pdelie.__init__`.

### Frozen M2 behavior
The adapter is intentionally narrow and backend-native.

Frozen scope:
- PySINDy only
- continuous-time only
- accepts only the current flattened trajectory shape from `to_pysindy_trajectories(...)`
- all trajectories must share identical shape as a frozen M2 simplification
- `feature_names` must be unique non-empty strings
- `config` must be `None`
- runtime owns a private deterministic default profile and does not depend on test helpers

Frozen success result:
- `status = "success"`
- `backend = "pysindy"`
- echoed `feature_names`
- `library_feature_names`
- dense 2D `coefficients`
- sparse backend-native `equation_terms`
- backend-native debug `equation_strings`
- `fit_config`
- `fit_diagnostics`

Frozen failure behavior:
- backend fitting failures return `status = "failed"` with `failure_reason = "backend_fit_failed"`
- invalid inputs still raise typed validation errors
- missing dependency still raises `ImportError`

### Important non-goals
This PR does **not** make M2 into a PDE-level equation extractor.

Explicitly out of scope:
- canonical PDE term extraction
- true `u_t = ...` PDE reporting
- direct compatibility between backend-native `equation_terms` / `equation_strings` and `evaluate_discovery_recovery(...)`
- any general multi-backend discovery framework

### Docs tightening
Updated:
- `docs/planning/PLAN.md`
- `docs/planning/V0_6_SCOPE.md`
- `docs/specs/API_STABILITY.md`

These now make explicit that:
- M2 is a backend-fit adapter over the flattened bridge
- the returned report is a runtime backend dict, not a JSON-compatible artifact schema
- `coefficients` are runtime NumPy data
- `equation_terms` and `equation_strings` are backend-native and non-canonical
- same-shape trajectories are an M2 simplification, not a general PySINDy limitation

## Tests

Added:
- `tests/test_pysindy_discovery_adapter.py`

Updated:
- `tests/test_public_api.py`

Coverage includes:
- importability from `pdelie.discovery`
- no root-package export
- `config=None` only
- malformed trajectories / time arrays / feature names
- clear `ImportError` on missing dependency
- backend-fit exception conversion to failed status
- explicit coefficient-orientation coverage
- tiny representative Heat/Burgers success-path fits