### PR TITLE
Add V0.6 M3 translation-canonical discovery inputs

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.6 Milestone 2 — Thin PySINDy backend-fit adapter**
+**V0.6 Milestone 3 — Translation-canonical discovery inputs**
 
 This file is the active execution plan for the current `v0.6` release series.
 
@@ -93,7 +93,7 @@ Run at minimum:
 
 ## Milestone 2 — Thin PySINDy Discovery Adapter
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -127,21 +127,39 @@ Add one narrow PySINDy-only backend-fit adapter for the existing scalar periodic
 
 ## Milestone 3 — Translation-Canonical Discovery Inputs
 
-**Status:** Pending
+**Status:** Active
 
 ### Goal
 
-Bridge the current translation/invariant path into discovery-ready canonical inputs without implying full differential-invariant generation.
+Bridge the current translation/invariant path into discovery-ready canonical inputs without implying full differential-invariant generation or mathematically intrinsic invariant construction.
 
 ### Frozen Decisions
 
 - add `pdelie.discovery.build_translation_canonical_discovery_inputs(...)`
+- use `invariant_spec_template`, not `invariant_spec`
+- exactly one of `generator_family` or `invariant_spec_template`
 - translation/canonical path only
 - scalar variable only
 - periodic `x` only
+- reject masked fields
+- accept only single-row translation generators within `DEFAULT_TRANSLATION_SPAN_TOLERANCE`
+- `invariant_spec_template` is explicit template mode and must not include `shift`
 - per-sample initial-time peak alignment
 - first-index tie-breaking
 - deterministic reported shifts in batch order
+- peak alignment is a heuristic canonicalization policy, not a strong invariant-theoretic guarantee
+- split/apply/reassemble through the existing `InvariantApplier`
+- reassembled field appends exactly one batch-level preprocess entry
+- return a runtime dict with:
+  - `transformed_field`
+  - `trajectories`
+  - `time_values`
+  - `feature_names`
+  - `generator_metadata`
+  - `construction_method`
+  - `alignment_policy`
+  - `alignment_shifts`
+  - `provenance`
 - no general invariant-theory engine
 - no full differential-invariant generation
 
@@ -235,7 +253,7 @@ Hard sequencing rules:
 
 - `v0.5`: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: ACTIVE
-- Milestone 3: PENDING
+- Milestone 2: COMPLETE
+- Milestone 3: ACTIVE
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/V0_6_SCOPE.md
+++ b/docs/planning/V0_6_SCOPE.md
@@ -110,7 +110,7 @@ Frozen outputs:
 ---
 
 ## Milestone 2 — Thin PySINDy discovery adapter
-**Status:** Active
+**Status:** Complete
 
 Public runtime API:
 
@@ -163,11 +163,11 @@ Frozen returned fields:
 ---
 
 ## Milestone 3 — Translation-canonical discovery inputs
-**Status:** Pending
+**Status:** Active
 
 Public runtime API:
 
-- `pdelie.discovery.build_translation_canonical_discovery_inputs(field, *, generator_family=None, invariant_spec=None) -> dict[str, object]`
+- `pdelie.discovery.build_translation_canonical_discovery_inputs(field, *, generator_family=None, invariant_spec_template=None) -> dict[str, object]`
 
 Frozen scope:
 
@@ -175,10 +175,14 @@ Frozen scope:
 - current invariant-application path only
 - scalar variable only
 - periodic `x` only
+- masked fields are rejected
 - supports known/oracle translation families
 - supports imported/coerced translation families
 - supports discovered translation families
-- rejects unsupported non-translation families
+- rejects unsupported non-translation families and non-uniform translation-like families
+- `invariant_spec_template` is explicit template mode, not direct fixed-shift mode
+- template parameters may be `{}` or `{"axis": "x"}`
+- template parameters must not include `shift`
 - no full differential-invariant generation
 
 Frozen alignment behavior:
@@ -189,6 +193,14 @@ Frozen alignment behavior:
 - peak index selection uses first-index tie-breaking
 - shift is `x[peak_index] - x[0]`
 - output shifts are deterministic and reported in batch order
+- alignment policy is a deterministic heuristic canonicalization rule, not a strong invariant-theoretic guarantee
+
+Frozen implementation policy:
+
+- split batch inputs into single-sample fields
+- apply the existing `InvariantApplier` one sample at a time
+- reassemble into one batched `FieldBatch`
+- append exactly one batch-level preprocess-log entry instead of concatenating per-sample logs
 
 Frozen returned fields:
 

--- a/docs/planning/V0_6_SCOPE.md
+++ b/docs/planning/V0_6_SCOPE.md
@@ -191,7 +191,7 @@ Frozen alignment behavior:
 - alignment uses the initial-time slice only
 - alignment uses `values[batch, 0, :, 0]`
 - peak index selection uses first-index tie-breaking
-- shift is `x[peak_index] - x[0]`
+- shift is `x[0] - x[peak_index]`
 - output shifts are deterministic and reported in batch order
 - alignment policy is a deterministic heuristic canonicalization rule, not a strong invariant-theoretic guarantee
 

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -71,6 +71,12 @@ Runtime public API for the frozen `v0.6` Milestone 2 slice:
 - this M2 API returns a runtime backend report dict, not a stable JSON-compatible artifact schema
 - its `coefficients` field is runtime NumPy data, and its `equation_terms` / `equation_strings` fields are backend-native, non-canonical debug outputs
 
+Runtime public API for the frozen `v0.6` Milestone 3 slice:
+
+- `pdelie.discovery.build_translation_canonical_discovery_inputs` for a runtime-only, heuristic translation-canonical discovery-input helper over canonical Heat/Burgers `FieldBatch` data
+- this M3 API returns a runtime dict containing a transformed `FieldBatch`, the narrow `to_pysindy_trajectories(...)` bridge output, and deterministic alignment metadata
+- its canonicalization policy is heuristic peak alignment, not a strong invariant-theoretic guarantee
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,5 +1,11 @@
 from pdelie.discovery.evaluation import evaluate_discovery_recovery
 from pdelie.discovery.pysindy_adapter import fit_pysindy_discovery
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
+from pdelie.discovery.translation_canonical import build_translation_canonical_discovery_inputs
 
-__all__ = ["evaluate_discovery_recovery", "fit_pysindy_discovery", "to_pysindy_trajectories"]
+__all__ = [
+    "build_translation_canonical_discovery_inputs",
+    "evaluate_discovery_recovery",
+    "fit_pysindy_discovery",
+    "to_pysindy_trajectories",
+]

--- a/src/pdelie/discovery/translation_canonical.py
+++ b/src/pdelie/discovery/translation_canonical.py
@@ -21,7 +21,7 @@ _ALIGNMENT_POLICY = {
     "time_index": 0,
     "var_index": 0,
     "tie_break": "first_index",
-    "shift_formula": "x[argmax(values[batch, 0, :, 0])] - x[0]",
+    "shift_formula": "x[0] - x[argmax(values[batch, 0, :, 0])]",
 }
 
 
@@ -123,7 +123,6 @@ def _normalize_invariant_spec_template(
 
 
 def _single_sample_fields(field: FieldBatch) -> list[FieldBatch]:
-    batch_axis = field.dims.index("batch")
     return [
         FieldBatch(
             values=field.values[index : index + 1].copy(),
@@ -134,14 +133,14 @@ def _single_sample_fields(field: FieldBatch) -> list[FieldBatch]:
             preprocess_log=list(field.preprocess_log),
             mask=None,
         )
-        for index in range(field.values.shape[batch_axis])
+        for index in range(field.values.shape[0])
     ]
 
 
 def _compute_alignment_shift(sample: FieldBatch) -> float:
     x = np.asarray(sample.coords["x"], dtype=float)
     peak_index = int(np.argmax(np.asarray(sample.values[0, 0, :, 0], dtype=float)))
-    return float(x[peak_index] - x[0])
+    return float(x[0] - x[peak_index])
 
 
 def _make_internal_spec(generator_metadata: dict[str, object], shift: float) -> InvariantMapSpec:

--- a/src/pdelie/discovery/translation_canonical.py
+++ b/src/pdelie/discovery/translation_canonical.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch, GeneratorFamily, InvariantMapSpec
+from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.invariants import InvariantApplier
+from pdelie.symmetry.parameterization.polynomial_translation import (
+    DEFAULT_TRANSLATION_SPAN_TOLERANCE,
+    _coerce_translation_coefficients,
+    translation_span_distance,
+)
+
+
+_ALIGNMENT_POLICY = {
+    "kind": "heuristic_peak_alignment",
+    "axis": "x",
+    "time_index": 0,
+    "var_index": 0,
+    "tie_break": "first_index",
+    "shift_formula": "x[argmax(values[batch, 0, :, 0])] - x[0]",
+}
+
+
+def _copy_mapping(value: dict[str, Any]) -> dict[str, Any]:
+    return {str(key): item for key, item in value.items()}
+
+
+def _validate_supported_field(field: FieldBatch) -> None:
+    field.validate()
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports dims ('batch', 'time', 'x', 'var') in V0.6 Milestone 3."
+        )
+    if len(field.var_names) != 1:
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports a single scalar variable in V0.6 Milestone 3."
+        )
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs requires periodic boundary conditions in x."
+        )
+    if field.mask is not None:
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs does not support masked fields in V0.6 Milestone 3."
+        )
+    if field.values.shape[field.dims.index("batch")] == 0:
+        raise SchemaValidationError(
+            "build_translation_canonical_discovery_inputs requires at least one batch sample."
+        )
+
+
+def _validate_translation_generator(generator: GeneratorFamily) -> GeneratorFamily:
+    generator.validate()
+    if generator.parameterization != "polynomial_translation_affine":
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports polynomial_translation_affine generators."
+        )
+
+    coefficients = _coerce_translation_coefficients(generator.coefficients)
+    span_distance = translation_span_distance(coefficients)
+    if span_distance > DEFAULT_TRANSLATION_SPAN_TOLERANCE:
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs requires a generator within the stable translation-span tolerance."
+        )
+    return generator
+
+
+def _normalize_generator_family(generator_family: object) -> tuple[GeneratorFamily, str]:
+    if not isinstance(generator_family, GeneratorFamily):
+        raise SchemaValidationError("generator_family must be a GeneratorFamily object.")
+    return _validate_translation_generator(generator_family), "generator_family"
+
+
+def _normalize_invariant_spec_template(
+    invariant_spec_template: object,
+) -> tuple[GeneratorFamily, str]:
+    if not isinstance(invariant_spec_template, InvariantMapSpec):
+        raise SchemaValidationError("invariant_spec_template must be an InvariantMapSpec object.")
+
+    invariant_spec_template.validate()
+    if invariant_spec_template.construction_method != "uniform_translation":
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports 'uniform_translation' invariant templates."
+        )
+    if invariant_spec_template.domain_validity != "global":
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports global invariant templates."
+        )
+    if invariant_spec_template.diagnostics.get("approximate", False):
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs does not support approximate invariant templates."
+        )
+
+    parameters = dict(invariant_spec_template.parameters)
+    if "shift" in parameters:
+        raise SchemaValidationError(
+            "invariant_spec_template parameters must not include 'shift' in V0.6 Milestone 3."
+        )
+    unsupported_keys = sorted(key for key in parameters if key != "axis")
+    if unsupported_keys:
+        raise SchemaValidationError(
+            f"invariant_spec_template parameters include unsupported keys: {unsupported_keys}."
+        )
+    axis = parameters.get("axis", "x")
+    if axis != "x":
+        raise ScopeValidationError(
+            "build_translation_canonical_discovery_inputs only supports invariant templates along x."
+        )
+
+    try:
+        generator = GeneratorFamily.from_dict(invariant_spec_template.generator_metadata)
+    except KeyError as exc:
+        missing_key = exc.args[0] if exc.args else "<unknown>"
+        raise SchemaValidationError(
+            f"invariant_spec_template.generator_metadata is missing required GeneratorFamily field {missing_key!r}."
+        ) from exc
+
+    return _validate_translation_generator(generator), "invariant_spec_template"
+
+
+def _single_sample_fields(field: FieldBatch) -> list[FieldBatch]:
+    batch_axis = field.dims.index("batch")
+    return [
+        FieldBatch(
+            values=field.values[index : index + 1].copy(),
+            dims=field.dims,
+            coords={name: coord.copy() for name, coord in field.coords.items()},
+            var_names=list(field.var_names),
+            metadata=dict(field.metadata),
+            preprocess_log=list(field.preprocess_log),
+            mask=None,
+        )
+        for index in range(field.values.shape[batch_axis])
+    ]
+
+
+def _compute_alignment_shift(sample: FieldBatch) -> float:
+    x = np.asarray(sample.coords["x"], dtype=float)
+    peak_index = int(np.argmax(np.asarray(sample.values[0, 0, :, 0], dtype=float)))
+    return float(x[peak_index] - x[0])
+
+
+def _make_internal_spec(generator_metadata: dict[str, object], shift: float) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=generator_metadata,
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": float(shift)},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+
+def _reassemble_transformed_field(
+    field: FieldBatch,
+    transformed_samples: list[FieldBatch],
+    *,
+    input_mode: str,
+    alignment_shifts: list[float],
+) -> FieldBatch:
+    values = np.concatenate([sample.values for sample in transformed_samples], axis=field.dims.index("batch"))
+    preprocess_entry = {
+        "operation": "translation_canonical_discovery_inputs",
+        "construction_method": "uniform_translation",
+        "alignment_policy": dict(_ALIGNMENT_POLICY),
+        "alignment_shifts": [float(shift) for shift in alignment_shifts],
+        "input_mode": input_mode,
+    }
+    return FieldBatch(
+        values=values,
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=[*field.preprocess_log, preprocess_entry],
+        mask=None,
+    )
+
+
+def build_translation_canonical_discovery_inputs(
+    field: FieldBatch,
+    *,
+    generator_family: GeneratorFamily | None = None,
+    invariant_spec_template: InvariantMapSpec | None = None,
+) -> dict[str, object]:
+    _validate_supported_field(field)
+
+    if (generator_family is None) == (invariant_spec_template is None):
+        raise SchemaValidationError(
+            "Exactly one of generator_family or invariant_spec_template must be provided."
+        )
+
+    if generator_family is not None:
+        generator, input_mode = _normalize_generator_family(generator_family)
+    else:
+        generator, input_mode = _normalize_invariant_spec_template(invariant_spec_template)
+
+    generator_metadata = generator.to_dict()
+    applier = InvariantApplier()
+    transformed_samples: list[FieldBatch] = []
+    alignment_shifts: list[float] = []
+    for sample in _single_sample_fields(field):
+        shift = _compute_alignment_shift(sample)
+        transformed_samples.append(applier.apply(sample, _make_internal_spec(generator_metadata, shift)))
+        alignment_shifts.append(shift)
+
+    transformed_field = _reassemble_transformed_field(
+        field,
+        transformed_samples,
+        input_mode=input_mode,
+        alignment_shifts=alignment_shifts,
+    )
+    trajectories, time_values, feature_names = to_pysindy_trajectories(transformed_field)
+
+    return {
+        "transformed_field": transformed_field,
+        "trajectories": trajectories,
+        "time_values": time_values,
+        "feature_names": feature_names,
+        "generator_metadata": _copy_mapping(generator_metadata),
+        "construction_method": "uniform_translation",
+        "alignment_policy": dict(_ALIGNMENT_POLICY),
+        "alignment_shifts": [float(shift) for shift in alignment_shifts],
+        "provenance": {
+            "input_mode": input_mode,
+            "bridge": "to_pysindy_trajectories",
+            "runtime_only": True,
+        },
+    }

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,7 +29,12 @@ def test_stable_public_api_is_importable() -> None:
 
 
 def test_runtime_package_api_is_importable() -> None:
-    from pdelie.discovery import evaluate_discovery_recovery, fit_pysindy_discovery, to_pysindy_trajectories
+    from pdelie.discovery import (
+        build_translation_canonical_discovery_inputs,
+        evaluate_discovery_recovery,
+        fit_pysindy_discovery,
+        to_pysindy_trajectories,
+    )
     from pdelie.invariants import InvariantApplier
     from pdelie.portability import (
         coerce_generator_family,
@@ -51,6 +56,7 @@ def test_runtime_package_api_is_importable() -> None:
     )
 
     assert InvariantApplier is not None
+    assert build_translation_canonical_discovery_inputs is not None
     assert evaluate_discovery_recovery is not None
     assert fit_pysindy_discovery is not None
     assert to_pysindy_trajectories is not None
@@ -70,6 +76,7 @@ def test_runtime_package_api_is_importable() -> None:
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
+    assert not hasattr(pdelie, "build_translation_canonical_discovery_inputs")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "fit_pysindy_discovery")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
@@ -97,6 +104,7 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
 def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> None:
     discovery_module = importlib.import_module("pdelie.discovery")
 
+    assert hasattr(discovery_module, "build_translation_canonical_discovery_inputs")
     assert hasattr(discovery_module, "evaluate_discovery_recovery")
     assert hasattr(discovery_module, "fit_pysindy_discovery")
     assert hasattr(discovery_module, "to_pysindy_trajectories")

--- a/tests/test_translation_canonical_discovery_inputs.py
+++ b/tests/test_translation_canonical_discovery_inputs.py
@@ -279,10 +279,44 @@ def test_alignment_is_deterministic_for_flat_and_repeated_maxima() -> None:
 
     result = build_translation_canonical_discovery_inputs(field, generator_family=_make_translation_generator())
     x = field.coords["x"]
+    transformed = result["transformed_field"]
 
     assert result["alignment_policy"]["kind"] == "heuristic_peak_alignment"
     assert result["alignment_policy"]["tie_break"] == "first_index"
-    assert result["alignment_shifts"] == [pytest.approx(0.0), pytest.approx(float(x[1] - x[0]))]
+    assert result["alignment_shifts"] == [pytest.approx(0.0), pytest.approx(float(x[0] - x[1]))]
+    np.testing.assert_allclose(transformed.values[0, :, :, 0], values[0, :, :, 0])
+    assert int(np.argmax(transformed.values[1, 0, :, 0])) == 0
+
+
+def test_nonflat_peak_at_index_zero_reports_zero_shift_and_is_unchanged() -> None:
+    base = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=4, seed=1017)
+    values = np.array(
+        [
+            [
+                [[4.0], [2.0], [1.0], [0.5]],
+                [[4.0], [2.0], [1.0], [0.5]],
+                [[4.0], [2.0], [1.0], [0.5]],
+                [[4.0], [2.0], [1.0], [0.5]],
+                [[4.0], [2.0], [1.0], [0.5]],
+            ]
+        ],
+        dtype=float,
+    )
+    field = FieldBatch(
+        values=values,
+        dims=base.dims,
+        coords={name: coord.copy() for name, coord in base.coords.items()},
+        var_names=list(base.var_names),
+        metadata=dict(base.metadata),
+        preprocess_log=list(base.preprocess_log),
+        mask=None,
+    )
+
+    result = build_translation_canonical_discovery_inputs(field, generator_family=_make_translation_generator())
+    transformed = result["transformed_field"]
+
+    assert result["alignment_shifts"] == [pytest.approx(0.0)]
+    np.testing.assert_allclose(transformed.values, values)
 
 
 def test_bridge_outputs_match_direct_bridge_on_transformed_field() -> None:

--- a/tests/test_translation_canonical_discovery_inputs.py
+++ b/tests/test_translation_canonical_discovery_inputs.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from pdelie import FieldBatch, GeneratorFamily, InvariantMapSpec, SchemaValidationError, ScopeValidationError
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.discovery import (
+    build_translation_canonical_discovery_inputs,
+    fit_pysindy_discovery,
+    to_pysindy_trajectories,
+)
+from pdelie.portability import coerce_generator_family, export_generator_family_manifest
+from pdelie.residuals import HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+
+
+def _make_translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]]),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={},
+    )
+
+
+def _make_nonconstant_translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[0.0, 1.0, 0.0, 0.0]]),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={},
+    )
+
+
+def _make_template(
+    *,
+    parameters: dict[str, object] | None = None,
+    generator_metadata: dict[str, object] | None = None,
+) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=_make_translation_generator().to_dict() if generator_metadata is None else generator_metadata,
+        construction_method="uniform_translation",
+        parameters={} if parameters is None else parameters,
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    )
+
+
+def _make_multi_var_field(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=np.concatenate((field.values, field.values), axis=-1),
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=["u", "v"],
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None,
+    )
+
+
+def _make_reduced_field(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=field.values[:, 0, :, :].copy(),
+        dims=("batch", "x", "var"),
+        coords={"x": field.coords["x"].copy()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None,
+    )
+
+
+def _make_masked_field(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=field.values.copy(),
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=list(field.var_names),
+        metadata=dict(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=np.zeros_like(field.values, dtype=bool),
+    )
+
+
+def _adapter_module():
+    return importlib.import_module("pdelie.discovery.pysindy_adapter")
+
+
+def test_known_translation_family_path_succeeds_and_preserves_field_contracts() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=17, num_points=16, seed=1001)
+    generator = _make_translation_generator()
+
+    result = build_translation_canonical_discovery_inputs(field, generator_family=generator)
+    transformed = result["transformed_field"]
+
+    transformed.validate()
+    assert result["generator_metadata"] == generator.to_dict()
+    assert result["construction_method"] == "uniform_translation"
+    assert result["provenance"] == {
+        "input_mode": "generator_family",
+        "bridge": "to_pysindy_trajectories",
+        "runtime_only": True,
+    }
+    assert transformed.dims == field.dims
+    assert transformed.var_names == field.var_names
+    assert transformed.metadata == field.metadata
+    assert list(transformed.coords) == list(field.coords)
+    np.testing.assert_allclose(transformed.coords["x"], field.coords["x"])
+    np.testing.assert_allclose(transformed.coords["time"], field.coords["time"])
+    assert len(transformed.preprocess_log) == len(field.preprocess_log) + 1
+    assert transformed.preprocess_log[-1]["operation"] == "translation_canonical_discovery_inputs"
+    assert transformed.preprocess_log[-1]["input_mode"] == "generator_family"
+    assert transformed.preprocess_log[-1]["construction_method"] == "uniform_translation"
+    assert transformed.preprocess_log[-1]["alignment_policy"]["kind"] == "heuristic_peak_alignment"
+    assert transformed.preprocess_log[-1]["alignment_shifts"] == result["alignment_shifts"]
+
+
+def test_imported_coerced_translation_family_path_succeeds() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1002)
+    manifest = export_generator_family_manifest(_make_translation_generator())
+    coerced = coerce_generator_family(manifest)
+
+    result = build_translation_canonical_discovery_inputs(field, generator_family=coerced)
+
+    assert result["generator_metadata"] == coerced.to_dict()
+    assert result["provenance"]["input_mode"] == "generator_family"
+    assert len(result["alignment_shifts"]) == field.values.shape[0]
+
+
+def test_discovered_translation_family_path_succeeds_within_span_tolerance() -> None:
+    training = generate_heat_1d_field_batch(batch_size=4, num_times=17, num_points=16, seed=1003)
+    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=17, num_points=16, seed=1004)
+    discovered = fit_translation_generator(training, HeatResidualEvaluator(), epsilon=1e-4)
+
+    result = build_translation_canonical_discovery_inputs(heldout, generator_family=discovered)
+
+    assert result["generator_metadata"]["parameterization"] == "polynomial_translation_affine"
+    assert result["provenance"]["input_mode"] == "generator_family"
+
+
+def test_nonconstant_translation_family_is_rejected() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1005)
+
+    with pytest.raises(ScopeValidationError, match="translation-span tolerance"):
+        build_translation_canonical_discovery_inputs(field, generator_family=_make_nonconstant_translation_generator())
+
+
+def test_invariant_spec_template_path_succeeds() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1006)
+    template = _make_template(parameters={"axis": "x"})
+
+    result = build_translation_canonical_discovery_inputs(field, invariant_spec_template=template)
+
+    assert result["generator_metadata"] == _make_translation_generator().to_dict()
+    assert result["provenance"]["input_mode"] == "invariant_spec_template"
+
+
+def test_invariant_spec_template_rejects_fixed_shift() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1007)
+    template = _make_template(parameters={"axis": "x", "shift": 0.25})
+
+    with pytest.raises(SchemaValidationError, match="must not include 'shift'"):
+        build_translation_canonical_discovery_inputs(field, invariant_spec_template=template)
+
+
+def test_invariant_spec_template_rejects_unsupported_parameter_keys() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1008)
+    template = _make_template(parameters={"mode": "bad"})
+
+    with pytest.raises(SchemaValidationError, match="unsupported keys"):
+        build_translation_canonical_discovery_inputs(field, invariant_spec_template=template)
+
+
+def test_invariant_spec_template_rejects_non_translation_generator_metadata() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1009)
+    template = _make_template(
+        generator_metadata={
+            "schema_version": "0.2",
+            "parameterization": "polynomial_scaling_affine",
+            "coefficients": [[1.0]],
+            "basis_spec": {
+                "variables": ["t", "x", "u"],
+                "component_names": ["xi"],
+                "basis_terms": [{"label": "1", "powers": [0, 0, 0]}],
+                "component_ordering": ["xi"],
+                "term_ordering": ["1"],
+                "layout": "component_major",
+            },
+            "normalization": "l2_unit",
+            "diagnostics": {},
+        }
+    )
+
+    with pytest.raises(ScopeValidationError, match="polynomial_translation_affine"):
+        build_translation_canonical_discovery_inputs(field, invariant_spec_template=template)
+
+
+def test_requires_exactly_one_input_mode() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1010)
+    generator = _make_translation_generator()
+    template = _make_template()
+
+    with pytest.raises(SchemaValidationError, match="Exactly one"):
+        build_translation_canonical_discovery_inputs(field)
+    with pytest.raises(SchemaValidationError, match="Exactly one"):
+        build_translation_canonical_discovery_inputs(
+            field,
+            generator_family=generator,
+            invariant_spec_template=template,
+        )
+
+
+def test_rejects_wrong_input_types() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1011)
+
+    with pytest.raises(SchemaValidationError, match="GeneratorFamily"):
+        build_translation_canonical_discovery_inputs(field, generator_family={"bad": "type"})  # type: ignore[arg-type]
+    with pytest.raises(SchemaValidationError, match="InvariantMapSpec"):
+        build_translation_canonical_discovery_inputs(field, invariant_spec_template={"bad": "type"})  # type: ignore[arg-type]
+
+
+def test_rejects_masked_fields() -> None:
+    field = _make_masked_field(generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1012))
+
+    with pytest.raises(ScopeValidationError, match="does not support masked fields"):
+        build_translation_canonical_discovery_inputs(field, generator_family=_make_translation_generator())
+
+
+def test_rejects_non_periodic_wrong_dims_and_multi_variable_fields() -> None:
+    base = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1013)
+    non_periodic = FieldBatch(
+        values=base.values.copy(),
+        dims=base.dims,
+        coords={name: coord.copy() for name, coord in base.coords.items()},
+        var_names=list(base.var_names),
+        metadata={**base.metadata, "boundary_conditions": {"x": "dirichlet"}},
+        preprocess_log=list(base.preprocess_log),
+        mask=None,
+    )
+
+    with pytest.raises(ScopeValidationError, match="requires periodic boundary conditions in x"):
+        build_translation_canonical_discovery_inputs(non_periodic, generator_family=_make_translation_generator())
+    with pytest.raises(ScopeValidationError, match="only supports dims"):
+        build_translation_canonical_discovery_inputs(_make_reduced_field(base), generator_family=_make_translation_generator())
+    with pytest.raises(ScopeValidationError, match="single scalar variable"):
+        build_translation_canonical_discovery_inputs(_make_multi_var_field(base), generator_family=_make_translation_generator())
+
+
+def test_alignment_is_deterministic_for_flat_and_repeated_maxima() -> None:
+    base = generate_heat_1d_field_batch(batch_size=2, num_times=5, num_points=4, seed=1014)
+    values = np.zeros_like(base.values)
+    values[0, :, :, 0] = 1.0
+    values[1, :, :, 0] = np.array(
+        [
+            [0.0, 3.0, 3.0, 1.0],
+            [0.0, 3.0, 3.0, 1.0],
+            [0.0, 3.0, 3.0, 1.0],
+            [0.0, 3.0, 3.0, 1.0],
+            [0.0, 3.0, 3.0, 1.0],
+        ],
+        dtype=float,
+    )
+    field = FieldBatch(
+        values=values,
+        dims=base.dims,
+        coords={name: coord.copy() for name, coord in base.coords.items()},
+        var_names=list(base.var_names),
+        metadata=dict(base.metadata),
+        preprocess_log=list(base.preprocess_log),
+        mask=None,
+    )
+
+    result = build_translation_canonical_discovery_inputs(field, generator_family=_make_translation_generator())
+    x = field.coords["x"]
+
+    assert result["alignment_policy"]["kind"] == "heuristic_peak_alignment"
+    assert result["alignment_policy"]["tie_break"] == "first_index"
+    assert result["alignment_shifts"] == [pytest.approx(0.0), pytest.approx(float(x[1] - x[0]))]
+
+
+def test_bridge_outputs_match_direct_bridge_on_transformed_field() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=16, seed=1015)
+
+    result = build_translation_canonical_discovery_inputs(field, generator_family=_make_translation_generator())
+    expected_trajectories, expected_time_values, expected_feature_names = to_pysindy_trajectories(
+        result["transformed_field"]
+    )
+
+    assert result["feature_names"] == expected_feature_names
+    np.testing.assert_allclose(result["time_values"], expected_time_values)
+    assert len(result["trajectories"]) == len(expected_trajectories)
+    for actual, expected in zip(result["trajectories"], expected_trajectories):
+        np.testing.assert_allclose(actual, expected)
+
+
+def test_tiny_pysindy_integration_smoke_is_structural_only() -> None:
+    try:
+        _adapter_module()._require_discovery_dependencies()
+    except ImportError as exc:
+        pytest.skip(str(exc))
+
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=9, num_points=4, seed=1016)
+    discovery_inputs = build_translation_canonical_discovery_inputs(
+        field,
+        generator_family=_make_translation_generator(),
+    )
+
+    result = fit_pysindy_discovery(
+        discovery_inputs["trajectories"],
+        discovery_inputs["time_values"],
+        discovery_inputs["feature_names"],
+    )
+
+    assert result["status"] == "success"
+    assert result["backend"] == "pysindy"
+    assert isinstance(result["library_feature_names"], list)
+    assert result["coefficients"].shape == (
+        len(discovery_inputs["feature_names"]),
+        len(result["library_feature_names"]),
+    )
+    assert np.all(np.isfinite(result["coefficients"]))


### PR DESCRIPTION
## Summary

Implements `v0.6` Milestone 3.

This PR adds `pdelie.discovery.build_translation_canonical_discovery_inputs(...)`, a narrow runtime helper that:
- accepts canonical Heat/Burgers `FieldBatch` data plus a translation-family input
- applies deterministic per-sample heuristic peak alignment through the existing invariant runtime path
- returns a transformed `FieldBatch` plus the existing `to_pysindy_trajectories(...)` bridge outputs and provenance

## Scope

This milestone stays narrow:
- no new canonical object
- no root export
- no general invariant engine
- no mask-shift semantics
- no canonical PDE extraction
- no discovery-quality claims

The canonicalization policy is explicitly heuristic, not a mathematically intrinsic invariant coordinate system.

## What Changed

- added `pdelie.discovery.build_translation_canonical_discovery_inputs(...)`
- exported it from `pdelie.discovery`
- froze M3 docs in:
  - `docs/planning/PLAN.md`
  - `docs/planning/V0_6_SCOPE.md`
  - `docs/specs/API_STABILITY.md`
- added focused M3 tests and updated the public API surface test

## Frozen M3 behavior

- exactly one of `generator_family` or `invariant_spec_template`
- scalar periodic `x` only
- masked fields rejected
- accepted generators must be single-row `polynomial_translation_affine` families within the stable translation-span tolerance
- `invariant_spec_template` is explicit template mode and must not include `shift`
- per-sample alignment uses the initial-time peak with first-index tie-breaking
- reassembled output preserves dims, coords, metadata, var names, and batch order
- `transformed_field.preprocess_log` appends exactly one batch-level summary entry

The warnings are the existing PySINDy/dependency warnings plus the known STLSQ sparsity warning in smoke-fit paths.
