### PR TITLE
Feat/v0 6 robustness m4

### DIFF
--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Active Milestone
 
-**V0.6 Milestone 3 — Translation-canonical discovery inputs**
+**V0.6 Milestone 4 — Robustness utilities**
 
 This file is the active execution plan for the current `v0.6` release series.
 
@@ -127,7 +127,7 @@ Add one narrow PySINDy-only backend-fit adapter for the existing scalar periodic
 
 ## Milestone 3 — Translation-Canonical Discovery Inputs
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -167,7 +167,7 @@ Bridge the current translation/invariant path into discovery-ready canonical inp
 
 ## Milestone 4 — Robustness Utilities
 
-**Status:** Pending
+**Status:** Active
 
 ### Goal
 
@@ -175,14 +175,25 @@ Add plain, deterministic robustness helpers that keep `FieldBatch` semantics int
 
 ### Frozen Decisions
 
-- `FieldBatch` in / `FieldBatch` out only
-- deterministic noise, subsampling, and splitting
-- coords are copied
-- masks are preserved
-- `NaN` values remain `NaN`
+- add `pdelie.data.add_gaussian_noise(...)`
+- add `pdelie.data.subsample_time(...)`
+- add `pdelie.data.subsample_x(...)`
+- add `pdelie.data.split_batch_train_heldout(...)`
+- add `pdelie.discovery.summarize_recovery_grid(...)`
+- `FieldBatch` in / `FieldBatch` out only for the data-side helpers
+- deep-copy metadata and existing preprocess-log entries before appending new entries
+- copy coord arrays, copy `var_names`, and copy/slice masks when present
+- deterministic noise, subsampling, and splitting only
 - noise applies only to finite unmasked values
-- stride-only subsampling
-- train/heldout split is deterministic and preserves original order within each split
+- `NaN` and other non-finite source values remain unchanged
+- `subsample_time` may leave one time point
+- `subsample_x` must leave at least two x-points
+- `train_size` is an integer count only
+- integer-like parameters allow Python `int` and NumPy integer types but reject `bool`
+- train/heldout split is deterministic and preserves original batch order within each split
+- `summarize_recovery_grid(...)` consumes nested `{"conditions": ..., "recovery": ...}` runtime records
+- grouped summary rows use deterministic typed sort keys over condition values
+- `summarize_recovery_grid(...)` is runtime convenience only, not a canonical artifact or manuscript-table schema
 - `preprocess_log` gets exactly one new plain-dict entry with `operation` and `parameters`
 - no dataframe, plotting, or report-rendering layer
 
@@ -254,6 +265,6 @@ Hard sequencing rules:
 - `v0.5`: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: ACTIVE
-- Milestone 4: PENDING
+- Milestone 3: COMPLETE
+- Milestone 4: ACTIVE
 - Milestone 5: PENDING

--- a/docs/planning/V0_6_SCOPE.md
+++ b/docs/planning/V0_6_SCOPE.md
@@ -163,7 +163,7 @@ Frozen returned fields:
 ---
 
 ## Milestone 3 — Translation-canonical discovery inputs
-**Status:** Active
+**Status:** Complete
 
 Public runtime API:
 
@@ -217,7 +217,7 @@ Frozen returned fields:
 ---
 
 ## Milestone 4 — Robustness utilities
-**Status:** Pending
+**Status:** Active
 
 Public runtime APIs under `pdelie.data`:
 
@@ -234,15 +234,43 @@ Frozen utility policy:
 
 - `FieldBatch` in / `FieldBatch` out
 - deterministic noise, subsampling, and splitting
+- metadata is deep-copied
+- existing preprocess-log entries are deep-copied before appending new entries
 - coords are copied
+- `var_names` are copied
 - masks are preserved
 - `NaN` values remain `NaN`
 - noise is applied only to finite unmasked values
 - subsampling is stride-only
+- `subsample_time` may leave one time point
+- `subsample_x` must leave at least two x-points
 - train/heldout split is deterministic and preserves original order within each split
+- `train_size` is an integer count only
+- integer-like parameters accept Python `int` and NumPy integer types but reject `bool`
 - no dataframe object
 - no plot layer
 - no table-rendering system
+- `summarize_recovery_grid(...)` is a runtime convenience API, not a canonical artifact schema and not a manuscript table format
+
+Frozen noise policy:
+
+- `add_gaussian_noise(...)` computes its reference RMS from finite unmasked values only
+- masked entries remain unchanged
+- existing non-finite values remain unchanged
+- no eligible finite unmasked values raises `SchemaValidationError`
+
+Frozen recovery-grid policy:
+
+- `summarize_recovery_grid(...)` accepts nested records of the form `{"conditions": {...}, "recovery": {...}}`
+- condition values must be JSON-scalar values only
+- condition floats must be finite
+- grouped output rows are sorted deterministically using typed condition sort keys
+- recovery `classification` must be one of:
+  - `exact`
+  - `partial`
+  - `failed`
+- required recovery metrics must be finite numeric scalars
+- optional residual means are included only when every record in a group contains that field
 
 Frozen preprocess-log policy:
 

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -77,6 +77,15 @@ Runtime public API for the frozen `v0.6` Milestone 3 slice:
 - this M3 API returns a runtime dict containing a transformed `FieldBatch`, the narrow `to_pysindy_trajectories(...)` bridge output, and deterministic alignment metadata
 - its canonicalization policy is heuristic peak alignment, not a strong invariant-theoretic guarantee
 
+Runtime public API for the frozen `v0.6` Milestone 4 slice:
+
+- `pdelie.data.add_gaussian_noise` for deterministic additive Gaussian perturbation of canonical `FieldBatch` data while preserving `FieldBatch` validity and preprocess provenance
+- `pdelie.data.subsample_time` for stride-only time-axis subsampling of canonical `FieldBatch` data
+- `pdelie.data.subsample_x` for stride-only x-axis subsampling of canonical `FieldBatch` data under the stable minimum-two-x-points rule
+- `pdelie.data.split_batch_train_heldout` for deterministic batch-axis train/held-out splitting of canonical `FieldBatch` data
+- `pdelie.discovery.summarize_recovery_grid` for runtime-only grouped aggregation of nested recovery-grid records
+- the M4 summarizer is runtime convenience only, not a canonical artifact schema, JSON contract, or manuscript-table format
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/src/pdelie/data/__init__.py
+++ b/src/pdelie/data/__init__.py
@@ -4,10 +4,20 @@ from pdelie.data.heat_1d import (
     generate_heat_1d_field_batch,
     sample_heat_mode_coefficients,
 )
+from pdelie.data.robustness import (
+    add_gaussian_noise,
+    split_batch_train_heldout,
+    subsample_time,
+    subsample_x,
+)
 
 __all__ = [
+    "add_gaussian_noise",
     "generate_burgers_1d_field_batch",
     "evaluate_heat_fourier_series",
     "generate_heat_1d_field_batch",
     "sample_heat_mode_coefficients",
+    "split_batch_train_heldout",
+    "subsample_time",
+    "subsample_x",
 ]

--- a/src/pdelie/data/robustness.py
+++ b/src/pdelie/data/robustness.py
@@ -89,8 +89,9 @@ def add_gaussian_noise(
 
     if noise_std != 0.0:
         rng = np.random.default_rng(normalized_seed)
-        noise = rng.normal(scale=noise_std, size=values.shape)
-        values[eligible] = values[eligible] + noise[eligible]
+        eligible_count = int(np.count_nonzero(eligible))
+        noise = rng.normal(scale=noise_std, size=eligible_count)
+        values[eligible] = values[eligible] + noise
 
     return _clone_field(
         field,

--- a/src/pdelie/data/robustness.py
+++ b/src/pdelie/data/robustness.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+def _validate_field(field: object, *, function_name: str) -> FieldBatch:
+    if not isinstance(field, FieldBatch):
+        raise SchemaValidationError(f"{function_name} requires a FieldBatch input.")
+    field.validate()
+    return field
+
+
+def _validate_nonnegative_scalar_float(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise SchemaValidationError(f"{name} must be a finite non-negative scalar.")
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite non-negative scalar.") from exc
+    if not np.isfinite(normalized) or normalized < 0.0:
+        raise SchemaValidationError(f"{name} must be a finite non-negative scalar.")
+    return normalized
+
+
+def _validate_positive_integer_like(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise SchemaValidationError(f"{name} must be a positive integer.")
+    normalized = int(value)
+    if normalized < 1:
+        raise SchemaValidationError(f"{name} must be a positive integer.")
+    return normalized
+
+
+def _validate_integer_like(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise SchemaValidationError(f"{name} must be an integer.")
+    return int(value)
+
+
+def _clone_field(
+    field: FieldBatch,
+    *,
+    values: np.ndarray,
+    coords: dict[str, np.ndarray],
+    preprocess_entry: dict[str, Any],
+    mask: np.ndarray | None,
+) -> FieldBatch:
+    return FieldBatch(
+        values=values,
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in coords.items()},
+        var_names=list(field.var_names),
+        metadata=deepcopy(field.metadata),
+        preprocess_log=[*deepcopy(field.preprocess_log), deepcopy(preprocess_entry)],
+        mask=None if mask is None else mask.copy(),
+    )
+
+
+def add_gaussian_noise(
+    field: FieldBatch,
+    *,
+    std_fraction: float,
+    seed: int,
+) -> FieldBatch:
+    field = _validate_field(field, function_name="add_gaussian_noise")
+    noise_fraction = _validate_nonnegative_scalar_float(std_fraction, name="std_fraction")
+    normalized_seed = _validate_integer_like(seed, name="seed")
+
+    values = np.asarray(field.values, dtype=float).copy()
+    finite_mask = np.isfinite(values)
+    if field.mask is None:
+        eligible = finite_mask
+        output_mask = None
+    else:
+        output_mask = field.mask.copy()
+        eligible = finite_mask & ~output_mask
+
+    if not np.any(eligible):
+        raise SchemaValidationError("add_gaussian_noise requires at least one finite unmasked value.")
+
+    reference_rms = float(np.sqrt(np.mean(np.square(values[eligible]))))
+    noise_std = float(noise_fraction * reference_rms)
+
+    if noise_std != 0.0:
+        rng = np.random.default_rng(normalized_seed)
+        noise = rng.normal(scale=noise_std, size=values.shape)
+        values[eligible] = values[eligible] + noise[eligible]
+
+    return _clone_field(
+        field,
+        values=values,
+        coords=field.coords,
+        mask=output_mask,
+        preprocess_entry={
+            "operation": "add_gaussian_noise",
+            "parameters": {
+                "std_fraction": noise_fraction,
+                "seed": normalized_seed,
+                "noise_std": noise_std,
+            },
+        },
+    )
+
+
+def _subsample_axis(
+    field: FieldBatch,
+    *,
+    dim_name: str,
+    stride: int,
+    function_name: str,
+) -> FieldBatch:
+    field = _validate_field(field, function_name=function_name)
+    normalized_stride = _validate_positive_integer_like(stride, name="stride")
+    if dim_name not in field.dims:
+        raise ScopeValidationError(f"{function_name} requires a '{dim_name}' dimension.")
+
+    axis = field.dims.index(dim_name)
+    slicer = [slice(None)] * field.values.ndim
+    slicer[axis] = slice(None, None, normalized_stride)
+    values = field.values[tuple(slicer)].copy()
+    coords = {name: coord.copy() for name, coord in field.coords.items()}
+    if dim_name in coords:
+        coords[dim_name] = coords[dim_name][::normalized_stride].copy()
+
+    if dim_name == "x" and coords["x"].size < 2:
+        raise ScopeValidationError("subsample_x must leave at least two x-points.")
+
+    output_mask = None if field.mask is None else field.mask[tuple(slicer)].copy()
+    return _clone_field(
+        field,
+        values=values,
+        coords=coords,
+        mask=output_mask,
+        preprocess_entry={
+            "operation": function_name,
+            "parameters": {
+                "stride": normalized_stride,
+                "original_length": int(field.values.shape[axis]),
+                "new_length": int(values.shape[axis]),
+            },
+        },
+    )
+
+
+def subsample_time(field: FieldBatch, *, stride: int) -> FieldBatch:
+    return _subsample_axis(field, dim_name="time", stride=stride, function_name="subsample_time")
+
+
+def subsample_x(field: FieldBatch, *, stride: int) -> FieldBatch:
+    return _subsample_axis(field, dim_name="x", stride=stride, function_name="subsample_x")
+
+
+def split_batch_train_heldout(
+    field: FieldBatch,
+    *,
+    train_size: int,
+    seed: int,
+) -> tuple[FieldBatch, FieldBatch]:
+    field = _validate_field(field, function_name="split_batch_train_heldout")
+    normalized_train_size = _validate_integer_like(train_size, name="train_size")
+    normalized_seed = _validate_integer_like(seed, name="seed")
+
+    if "batch" not in field.dims:
+        raise ScopeValidationError("split_batch_train_heldout requires a 'batch' dimension.")
+
+    batch_axis = field.dims.index("batch")
+    batch_size = int(field.values.shape[batch_axis])
+    if batch_size < 2:
+        raise SchemaValidationError("split_batch_train_heldout requires at least two batch items.")
+    if not 1 <= normalized_train_size < batch_size:
+        raise SchemaValidationError("train_size must satisfy 1 <= train_size < batch_size.")
+
+    permutation = np.random.default_rng(normalized_seed).permutation(batch_size)
+    train_indices = sorted(int(index) for index in permutation[:normalized_train_size])
+    heldout_indices = sorted(int(index) for index in permutation[normalized_train_size:])
+
+    def _slice_batch(indices: list[int], *, split_name: str) -> FieldBatch:
+        values = np.take(field.values, indices=indices, axis=batch_axis).copy()
+        mask = None if field.mask is None else np.take(field.mask, indices=indices, axis=batch_axis).copy()
+        return _clone_field(
+            field,
+            values=values,
+            coords=field.coords,
+            mask=mask,
+            preprocess_entry={
+                "operation": "split_batch_train_heldout",
+                "parameters": {
+                    "train_size": normalized_train_size,
+                    "seed": normalized_seed,
+                    "split": split_name,
+                    "selected_batch_indices": list(indices),
+                },
+            },
+        )
+
+    return _slice_batch(train_indices, split_name="train"), _slice_batch(heldout_indices, split_name="heldout")

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,11 +1,13 @@
 from pdelie.discovery.evaluation import evaluate_discovery_recovery
 from pdelie.discovery.pysindy_adapter import fit_pysindy_discovery
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
+from pdelie.discovery.recovery_grid import summarize_recovery_grid
 from pdelie.discovery.translation_canonical import build_translation_canonical_discovery_inputs
 
 __all__ = [
     "build_translation_canonical_discovery_inputs",
     "evaluate_discovery_recovery",
     "fit_pysindy_discovery",
+    "summarize_recovery_grid",
     "to_pysindy_trajectories",
 ]

--- a/src/pdelie/discovery/recovery_grid.py
+++ b/src/pdelie/discovery/recovery_grid.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import numpy as np
+
+from pdelie.errors import SchemaValidationError
+
+
+_REQUIRED_RECOVERY_NUMERIC_FIELDS = (
+    "support_precision",
+    "support_recall",
+    "support_f1",
+    "target_sparsity",
+    "discovered_sparsity",
+    "coefficient_l2_error",
+    "coefficient_relative_l2_error",
+    "coefficient_linf_error",
+)
+_OPTIONAL_RESIDUAL_FIELDS = (
+    "train_residual_l2",
+    "heldout_residual_l2",
+    "heldout_residual_rms",
+)
+_ALLOWED_CLASSIFICATIONS = frozenset({"exact", "partial", "failed"})
+
+
+def _validate_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _normalize_condition_value(key: str, value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    if isinstance(value, (float, np.floating)):
+        normalized = float(value)
+        if not np.isfinite(normalized):
+            raise SchemaValidationError(f"conditions[{key!r}] must be finite when provided as a float.")
+        return normalized
+    if isinstance(value, str):
+        return value
+    raise SchemaValidationError(
+        f"conditions[{key!r}] must be a JSON-scalar value (str, bool, int, finite float, or None)."
+    )
+
+
+def _condition_sort_token(value: object) -> tuple[str, str]:
+    if value is None:
+        return ("none", "None")
+    if isinstance(value, bool):
+        return ("bool", repr(value))
+    if isinstance(value, int):
+        return ("int", repr(value))
+    if isinstance(value, float):
+        return ("float", repr(value))
+    return ("str", repr(value))
+
+
+def _normalize_conditions(value: object) -> tuple[dict[str, object], tuple[tuple[str, str, str], ...]]:
+    mapping = _validate_mapping(value, name="conditions")
+    normalized: dict[str, object] = {}
+    for key, condition_value in mapping.items():
+        if not isinstance(key, str) or not key:
+            raise SchemaValidationError("conditions keys must be non-empty strings.")
+        normalized[key] = _normalize_condition_value(key, condition_value)
+
+    sorted_keys = sorted(normalized)
+    ordered_conditions = {key: normalized[key] for key in sorted_keys}
+    group_key = tuple((key, *_condition_sort_token(ordered_conditions[key])) for key in sorted_keys)
+    return ordered_conditions, group_key
+
+
+def _validate_numeric_scalar(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise SchemaValidationError(f"{name} must be a finite numeric scalar.")
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite numeric scalar.") from exc
+    if not np.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be a finite numeric scalar.")
+    return normalized
+
+
+def _normalize_recovery(value: object) -> dict[str, object]:
+    mapping = _validate_mapping(value, name="recovery")
+    missing = [
+        key for key in ("classification", *_REQUIRED_RECOVERY_NUMERIC_FIELDS) if key not in mapping
+    ]
+    if missing:
+        raise SchemaValidationError(f"recovery is missing required fields: {missing}.")
+
+    classification = mapping["classification"]
+    if not isinstance(classification, str) or classification not in _ALLOWED_CLASSIFICATIONS:
+        raise SchemaValidationError("recovery['classification'] must be one of: exact, partial, failed.")
+
+    normalized: dict[str, object] = {"classification": classification}
+    for key in _REQUIRED_RECOVERY_NUMERIC_FIELDS:
+        normalized[key] = _validate_numeric_scalar(mapping[key], name=f"recovery[{key!r}]")
+
+    for key in _OPTIONAL_RESIDUAL_FIELDS:
+        if key in mapping:
+            normalized[key] = _validate_numeric_scalar(mapping[key], name=f"recovery[{key!r}]")
+
+    return normalized
+
+
+def summarize_recovery_grid(records: Iterable[object]) -> list[dict[str, object]]:
+    grouped: dict[tuple[tuple[str, str, str], ...], dict[str, object]] = {}
+
+    for index, raw_record in enumerate(records):
+        record = _validate_mapping(raw_record, name=f"records[{index}]")
+        if "conditions" not in record or "recovery" not in record:
+            raise SchemaValidationError("Each record must include 'conditions' and 'recovery' mappings.")
+
+        conditions, group_key = _normalize_conditions(record["conditions"])
+        recovery = _normalize_recovery(record["recovery"])
+        group = grouped.setdefault(group_key, {"conditions": conditions, "records": []})
+        records_list = group["records"]
+        assert isinstance(records_list, list)
+        records_list.append(recovery)
+
+    rows: list[dict[str, object]] = []
+    for group_key in sorted(grouped):
+        group = grouped[group_key]
+        group_records = group["records"]
+        assert isinstance(group_records, list)
+        num_records = len(group_records)
+        exact_count = sum(1 for record in group_records if record["classification"] == "exact")
+        partial_count = sum(1 for record in group_records if record["classification"] == "partial")
+        failed_count = sum(1 for record in group_records if record["classification"] == "failed")
+
+        row: dict[str, object] = {
+            "conditions": group["conditions"],
+            "num_records": num_records,
+            "exact_count": exact_count,
+            "partial_count": partial_count,
+            "failed_count": failed_count,
+            "exact_rate": float(exact_count / num_records),
+            "partial_rate": float(partial_count / num_records),
+            "failed_rate": float(failed_count / num_records),
+        }
+
+        for key in _REQUIRED_RECOVERY_NUMERIC_FIELDS:
+            values = np.asarray([record[key] for record in group_records], dtype=float)
+            row[f"mean_{key}"] = float(np.mean(values))
+
+        for key in _OPTIONAL_RESIDUAL_FIELDS:
+            if all(key in record for record in group_records):
+                values = np.asarray([record[key] for record in group_records], dtype=float)
+                row[f"mean_{key}"] = float(np.mean(values))
+
+        rows.append(row)
+
+    return rows

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -29,10 +29,12 @@ def test_stable_public_api_is_importable() -> None:
 
 
 def test_runtime_package_api_is_importable() -> None:
+    from pdelie.data import add_gaussian_noise, split_batch_train_heldout, subsample_time, subsample_x
     from pdelie.discovery import (
         build_translation_canonical_discovery_inputs,
         evaluate_discovery_recovery,
         fit_pysindy_discovery,
+        summarize_recovery_grid,
         to_pysindy_trajectories,
     )
     from pdelie.invariants import InvariantApplier
@@ -55,10 +57,15 @@ def test_runtime_package_api_is_importable() -> None:
         plot_verification_curve,
     )
 
+    assert add_gaussian_noise is not None
+    assert split_batch_train_heldout is not None
+    assert subsample_time is not None
+    assert subsample_x is not None
     assert InvariantApplier is not None
     assert build_translation_canonical_discovery_inputs is not None
     assert evaluate_discovery_recovery is not None
     assert fit_pysindy_discovery is not None
+    assert summarize_recovery_grid is not None
     assert to_pysindy_trajectories is not None
     assert coerce_generator_family is not None
     assert export_generator_family_manifest is not None
@@ -76,9 +83,14 @@ def test_runtime_package_api_is_importable() -> None:
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
+    assert not hasattr(pdelie, "add_gaussian_noise")
     assert not hasattr(pdelie, "build_translation_canonical_discovery_inputs")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "fit_pysindy_discovery")
+    assert not hasattr(pdelie, "split_batch_train_heldout")
+    assert not hasattr(pdelie, "subsample_time")
+    assert not hasattr(pdelie, "subsample_x")
+    assert not hasattr(pdelie, "summarize_recovery_grid")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
     assert not hasattr(pdelie, "coerce_generator_family")
     assert not hasattr(pdelie, "export_generator_family_manifest")
@@ -101,12 +113,22 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
     assert not hasattr(invariants_module, "InvariantMapSpec")
 
 
+def test_data_package_runtime_api_matches_frozen_m4_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+
+    assert hasattr(data_module, "add_gaussian_noise")
+    assert hasattr(data_module, "subsample_time")
+    assert hasattr(data_module, "subsample_x")
+    assert hasattr(data_module, "split_batch_train_heldout")
+
+
 def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> None:
     discovery_module = importlib.import_module("pdelie.discovery")
 
     assert hasattr(discovery_module, "build_translation_canonical_discovery_inputs")
     assert hasattr(discovery_module, "evaluate_discovery_recovery")
     assert hasattr(discovery_module, "fit_pysindy_discovery")
+    assert hasattr(discovery_module, "summarize_recovery_grid")
     assert hasattr(discovery_module, "to_pysindy_trajectories")
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")
 

--- a/tests/test_robustness_utilities.py
+++ b/tests/test_robustness_utilities.py
@@ -257,6 +257,13 @@ def test_split_batch_train_heldout_rejects_invalid_train_size(train_size: object
         split_batch_train_heldout(field, train_size=train_size, seed=7)  # type: ignore[arg-type]
 
 
+def test_split_batch_train_heldout_rejects_bool_seed() -> None:
+    field = _make_field(batch_size=5)
+
+    with pytest.raises(SchemaValidationError):
+        split_batch_train_heldout(field, train_size=2, seed=True)  # type: ignore[arg-type]
+
+
 def test_split_batch_train_heldout_rejects_missing_batch_and_too_small_batch() -> None:
     field = _make_field(batch_size=1)
 
@@ -364,6 +371,18 @@ def test_summarize_recovery_grid_omits_optional_residual_means_when_not_universa
     row = summarize_recovery_grid(records)[0]
 
     assert "mean_heldout_residual_l2" not in row
+
+
+def test_summarize_recovery_grid_rejects_nonfinite_optional_residuals() -> None:
+    records = [
+        {
+            "conditions": {"noise": 0.1},
+            "recovery": _make_recovery(classification="exact", residuals={"heldout_residual_l2": np.nan}),
+        }
+    ]
+
+    with pytest.raises(SchemaValidationError):
+        summarize_recovery_grid(records)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_robustness_utilities.py
+++ b/tests/test_robustness_utilities.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from pdelie import FieldBatch, SchemaValidationError, ScopeValidationError
+from pdelie.data import add_gaussian_noise, split_batch_train_heldout, subsample_time, subsample_x
+from pdelie.discovery import summarize_recovery_grid
+
+
+def _make_metadata() -> dict[str, object]:
+    return {
+        "boundary_conditions": {"x": "periodic"},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {"nu": 0.1, "nested": {"tag": "source"}},
+    }
+
+
+def _make_field(
+    *,
+    batch_size: int = 4,
+    num_times: int = 5,
+    num_points: int = 4,
+    mask: np.ndarray | None = None,
+    with_nan: bool = False,
+) -> FieldBatch:
+    values = np.arange(batch_size * num_times * num_points, dtype=float).reshape(batch_size, num_times, num_points, 1) + 1.0
+    if with_nan:
+        values[0, 0, 2, 0] = np.nan
+    return FieldBatch(
+        values=values,
+        dims=("batch", "time", "x", "var"),
+        coords={
+            "time": np.linspace(0.0, 1.0, num_times, dtype=float),
+            "x": np.linspace(0.0, 2.0 * np.pi, num_points, endpoint=False, dtype=float),
+        },
+        var_names=["u"],
+        metadata=_make_metadata(),
+        preprocess_log=[{"operation": "source", "parameters": {"nested": {"level": 1}}}],
+        mask=None if mask is None else mask.copy(),
+    )
+
+
+def _make_reduced_field_without_time(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=field.values[:, 0, :, :].copy(),
+        dims=("batch", "x", "var"),
+        coords={"x": field.coords["x"].copy()},
+        var_names=list(field.var_names),
+        metadata=deepcopy(field.metadata),
+        preprocess_log=deepcopy(field.preprocess_log),
+        mask=None if field.mask is None else field.mask[:, 0, :, :].copy(),
+    )
+
+
+def _make_reduced_field_without_x(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=field.values[:, :, 0, :].copy(),
+        dims=("batch", "time", "var"),
+        coords={"time": field.coords["time"].copy()},
+        var_names=list(field.var_names),
+        metadata=deepcopy(field.metadata),
+        preprocess_log=deepcopy(field.preprocess_log),
+        mask=None if field.mask is None else field.mask[:, :, 0, :].copy(),
+    )
+
+
+def _make_reduced_field_without_batch(field: FieldBatch) -> FieldBatch:
+    return FieldBatch(
+        values=field.values[0].copy(),
+        dims=("time", "x", "var"),
+        coords={"time": field.coords["time"].copy(), "x": field.coords["x"].copy()},
+        var_names=list(field.var_names),
+        metadata=deepcopy(field.metadata),
+        preprocess_log=deepcopy(field.preprocess_log),
+        mask=None if field.mask is None else field.mask[0].copy(),
+    )
+
+
+def _make_recovery(
+    *,
+    classification: str = "exact",
+    residuals: dict[str, float] | None = None,
+) -> dict[str, object]:
+    recovery: dict[str, object] = {
+        "classification": classification,
+        "support_precision": 1.0,
+        "support_recall": 0.8,
+        "support_f1": 0.888,
+        "target_sparsity": 2.0,
+        "discovered_sparsity": 3.0,
+        "coefficient_l2_error": 0.1,
+        "coefficient_relative_l2_error": 0.2,
+        "coefficient_linf_error": 0.05,
+        "equation_strings": {"target": "1*u_xx", "discovered": "1*u_xx"},
+    }
+    if residuals is not None:
+        recovery.update(residuals)
+    return recovery
+
+
+def test_add_gaussian_noise_is_deterministic_for_a_fixed_seed() -> None:
+    field = _make_field()
+
+    first = add_gaussian_noise(field, std_fraction=0.1, seed=11)
+    second = add_gaussian_noise(field, std_fraction=0.1, seed=11)
+
+    np.testing.assert_allclose(first.values, second.values)
+    assert first.preprocess_log[-1] == second.preprocess_log[-1]
+
+
+def test_add_gaussian_noise_respects_mask_and_nonfinite_values() -> None:
+    mask = np.zeros((2, 3, 4, 1), dtype=bool)
+    mask[0, 0, 3, 0] = True
+    field = _make_field(batch_size=2, num_times=3, num_points=4, mask=mask, with_nan=True)
+
+    noisy = add_gaussian_noise(field, std_fraction=0.1, seed=3)
+    changed = add_gaussian_noise(field, std_fraction=0.1, seed=4)
+
+    assert np.isnan(noisy.values[0, 0, 2, 0])
+    assert noisy.values[0, 0, 3, 0] == field.values[0, 0, 3, 0]
+    assert changed.values[0, 0, 3, 0] == field.values[0, 0, 3, 0]
+    assert not np.allclose(noisy.values[np.isfinite(noisy.values)], changed.values[np.isfinite(changed.values)])
+
+
+def test_add_gaussian_noise_computes_noise_scale_from_finite_unmasked_rms_only() -> None:
+    values = np.array([[[[3.0], [4.0], [np.nan], [100.0]]]], dtype=float)
+    mask = np.array([[[[False], [False], [False], [True]]]], dtype=bool)
+    field = FieldBatch(
+        values=values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": np.array([0.0]), "x": np.linspace(0.0, 2.0 * np.pi, 4, endpoint=False)},
+        var_names=["u"],
+        metadata=_make_metadata(),
+        preprocess_log=[],
+        mask=mask,
+    )
+
+    noisy = add_gaussian_noise(field, std_fraction=0.5, seed=9)
+
+    expected_rms = float(np.sqrt(np.mean(np.square(np.array([3.0, 4.0])))))
+    assert noisy.preprocess_log[-1]["parameters"]["noise_std"] == pytest.approx(0.5 * expected_rms)
+    assert np.isnan(noisy.values[0, 0, 2, 0])
+    assert noisy.values[0, 0, 3, 0] == field.values[0, 0, 3, 0]
+
+
+def test_add_gaussian_noise_with_zero_fraction_is_value_stable_and_appends_log() -> None:
+    field = _make_field()
+
+    noisy = add_gaussian_noise(field, std_fraction=0.0, seed=1)
+
+    np.testing.assert_allclose(noisy.values, field.values)
+    assert noisy.preprocess_log[-1]["operation"] == "add_gaussian_noise"
+
+
+def test_add_gaussian_noise_rejects_missing_eligible_entries() -> None:
+    field = _make_field(mask=np.ones((4, 5, 4, 1), dtype=bool))
+
+    with pytest.raises(SchemaValidationError, match="finite unmasked"):
+        add_gaussian_noise(field, std_fraction=0.1, seed=1)
+
+
+@pytest.mark.parametrize(
+    ("std_fraction", "seed"),
+    [
+        (-0.1, 1),
+        (np.inf, 1),
+        ("bad", 1),
+        (0.1, 1.5),
+        (0.1, True),
+    ],
+)
+def test_add_gaussian_noise_rejects_invalid_parameter_types(std_fraction: object, seed: object) -> None:
+    field = _make_field()
+
+    with pytest.raises(SchemaValidationError):
+        add_gaussian_noise(field, std_fraction=std_fraction, seed=seed)  # type: ignore[arg-type]
+
+
+def test_subsample_time_slices_and_can_leave_one_time_point() -> None:
+    mask = np.zeros((4, 5, 4, 1), dtype=bool)
+    mask[1, 4, 2, 0] = True
+    field = _make_field(mask=mask)
+
+    reduced = subsample_time(field, stride=5)
+
+    reduced.validate()
+    assert reduced.values.shape == (4, 1, 4, 1)
+    np.testing.assert_allclose(reduced.coords["time"], field.coords["time"][::5])
+    np.testing.assert_allclose(reduced.values, field.values[:, ::5, :, :])
+    np.testing.assert_array_equal(reduced.mask, field.mask[:, ::5, :, :])
+    assert reduced.preprocess_log[-1]["operation"] == "subsample_time"
+
+
+def test_subsample_x_slices_values_and_mask() -> None:
+    mask = np.zeros((4, 5, 6, 1), dtype=bool)
+    mask[2, 1, 4, 0] = True
+    field = _make_field(num_points=6, mask=mask)
+
+    reduced = subsample_x(field, stride=2)
+
+    np.testing.assert_allclose(reduced.coords["x"], field.coords["x"][::2])
+    np.testing.assert_allclose(reduced.values, field.values[:, :, ::2, :])
+    np.testing.assert_array_equal(reduced.mask, field.mask[:, :, ::2, :])
+    assert reduced.preprocess_log[-1]["operation"] == "subsample_x"
+
+
+def test_subsample_x_rejects_stride_that_leaves_fewer_than_two_points() -> None:
+    field = _make_field(num_points=4)
+
+    with pytest.raises(ScopeValidationError, match="at least two x-points"):
+        subsample_x(field, stride=4)
+
+
+def test_subsample_helpers_reject_missing_required_dimensions() -> None:
+    field = _make_field()
+
+    with pytest.raises(ScopeValidationError, match="'time'"):
+        subsample_time(_make_reduced_field_without_time(field), stride=2)
+    with pytest.raises(ScopeValidationError, match="'x'"):
+        subsample_x(_make_reduced_field_without_x(field), stride=2)
+
+
+@pytest.mark.parametrize("stride", [0, -1, 1.5, True])
+def test_subsample_helpers_reject_invalid_stride(stride: object) -> None:
+    field = _make_field()
+
+    with pytest.raises(SchemaValidationError):
+        subsample_time(field, stride=stride)  # type: ignore[arg-type]
+    with pytest.raises(SchemaValidationError):
+        subsample_x(field, stride=stride)  # type: ignore[arg-type]
+
+
+def test_split_batch_train_heldout_is_deterministic_and_preserves_original_order() -> None:
+    field = _make_field(batch_size=5)
+
+    train, heldout = split_batch_train_heldout(field, train_size=2, seed=13)
+
+    permutation = np.random.default_rng(13).permutation(5)
+    expected_train = sorted(int(index) for index in permutation[:2])
+    expected_heldout = sorted(int(index) for index in permutation[2:])
+    np.testing.assert_allclose(train.values, field.values[expected_train])
+    np.testing.assert_allclose(heldout.values, field.values[expected_heldout])
+    assert train.preprocess_log[-1]["parameters"]["selected_batch_indices"] == expected_train
+    assert heldout.preprocess_log[-1]["parameters"]["selected_batch_indices"] == expected_heldout
+
+
+@pytest.mark.parametrize("train_size", [0, 5, True, 1.5])
+def test_split_batch_train_heldout_rejects_invalid_train_size(train_size: object) -> None:
+    field = _make_field(batch_size=5)
+
+    with pytest.raises((SchemaValidationError, ScopeValidationError)):
+        split_batch_train_heldout(field, train_size=train_size, seed=7)  # type: ignore[arg-type]
+
+
+def test_split_batch_train_heldout_rejects_missing_batch_and_too_small_batch() -> None:
+    field = _make_field(batch_size=1)
+
+    with pytest.raises(SchemaValidationError, match="at least two batch items"):
+        split_batch_train_heldout(field, train_size=1, seed=2)
+    with pytest.raises(ScopeValidationError, match="'batch'"):
+        split_batch_train_heldout(_make_reduced_field_without_batch(_make_field()), train_size=1, seed=2)
+
+
+def test_field_returning_utilities_deep_copy_metadata_and_preprocess_log() -> None:
+    field = _make_field()
+
+    noisy = add_gaussian_noise(field, std_fraction=0.0, seed=1)
+    reduced = subsample_time(field, stride=2)
+    train, _ = split_batch_train_heldout(field, train_size=2, seed=5)
+
+    noisy.metadata["boundary_conditions"]["x"] = "changed"
+    reduced.preprocess_log[0]["parameters"]["nested"]["level"] = 99
+    train.metadata["parameter_tags"]["nested"]["tag"] = "changed"
+
+    assert field.metadata["boundary_conditions"]["x"] == "periodic"
+    assert field.preprocess_log[0]["parameters"]["nested"]["level"] == 1
+    assert field.metadata["parameter_tags"]["nested"]["tag"] == "source"
+
+
+def test_field_returning_utilities_work_with_mask_none_and_nontrivial_masks() -> None:
+    unmasked = _make_field(mask=None)
+    masked = _make_field(mask=np.zeros((4, 5, 4, 1), dtype=bool))
+    masked.mask[0, 0, 0, 0] = True
+
+    assert add_gaussian_noise(unmasked, std_fraction=0.0, seed=1).mask is None
+    assert subsample_time(unmasked, stride=2).mask is None
+    assert split_batch_train_heldout(unmasked, train_size=2, seed=1)[0].mask is None
+    assert add_gaussian_noise(masked, std_fraction=0.0, seed=1).mask is not None
+    assert subsample_x(masked, stride=2).mask is not None
+    assert split_batch_train_heldout(masked, train_size=2, seed=1)[1].mask is not None
+
+
+def test_summarize_recovery_grid_groups_rows_and_sorts_with_typed_keys() -> None:
+    records = [
+        {
+            "conditions": {"mode": 1},
+            "recovery": _make_recovery(classification="partial", residuals={"heldout_residual_l2": 0.3}),
+        },
+        {
+            "conditions": {"mode": True},
+            "recovery": _make_recovery(classification="exact", residuals={"heldout_residual_l2": 0.1}),
+        },
+        {
+            "conditions": {"mode": 1},
+            "recovery": _make_recovery(classification="failed", residuals={"heldout_residual_l2": 0.5}),
+        },
+    ]
+
+    rows = summarize_recovery_grid(records)
+
+    assert [row["conditions"] for row in rows] == [{"mode": True}, {"mode": 1}]
+    assert rows[1]["num_records"] == 2
+    assert rows[1]["partial_count"] == 1
+    assert rows[1]["failed_count"] == 1
+    assert rows[1]["mean_heldout_residual_l2"] == pytest.approx(0.4)
+
+
+def test_summarize_recovery_grid_computes_counts_rates_and_optional_residual_means() -> None:
+    records = [
+        {
+            "conditions": {"noise_std_fraction": 0.1, "sample_count": 4},
+            "recovery": _make_recovery(
+                classification="exact",
+                residuals={"train_residual_l2": 0.2, "heldout_residual_l2": 0.4, "heldout_residual_rms": 0.1},
+            ),
+        },
+        {
+            "conditions": {"sample_count": 4, "noise_std_fraction": 0.1},
+            "recovery": _make_recovery(
+                classification="partial",
+                residuals={"train_residual_l2": 0.4, "heldout_residual_l2": 0.6, "heldout_residual_rms": 0.2},
+            ),
+        },
+    ]
+
+    row = summarize_recovery_grid(records)[0]
+
+    assert row["exact_count"] == 1
+    assert row["partial_count"] == 1
+    assert row["failed_count"] == 0
+    assert row["exact_rate"] == pytest.approx(0.5)
+    assert row["partial_rate"] == pytest.approx(0.5)
+    assert row["failed_rate"] == pytest.approx(0.0)
+    assert row["mean_support_precision"] == pytest.approx(1.0)
+    assert row["mean_train_residual_l2"] == pytest.approx(0.3)
+    assert row["mean_heldout_residual_l2"] == pytest.approx(0.5)
+    assert row["mean_heldout_residual_rms"] == pytest.approx(0.15)
+
+
+def test_summarize_recovery_grid_omits_optional_residual_means_when_not_universal() -> None:
+    records = [
+        {"conditions": {"noise": 0.1}, "recovery": _make_recovery(classification="exact")},
+        {
+            "conditions": {"noise": 0.1},
+            "recovery": _make_recovery(classification="failed", residuals={"heldout_residual_l2": 0.7}),
+        },
+    ]
+
+    row = summarize_recovery_grid(records)[0]
+
+    assert "mean_heldout_residual_l2" not in row
+
+
+@pytest.mark.parametrize(
+    "records",
+    [
+        [{"conditions": {"noise": np.nan}, "recovery": _make_recovery()}],
+        [{"conditions": {"noise": 0.1}, "recovery": {**_make_recovery(), "classification": "bad"}}],
+        [{"conditions": {"noise": 0.1}, "recovery": {**_make_recovery(), "support_precision": np.inf}}],
+        [{"conditions": {"noise": [1, 2]}, "recovery": _make_recovery()}],
+        [{"recovery": _make_recovery()}],
+    ],
+)
+def test_summarize_recovery_grid_rejects_invalid_records(records: list[dict[str, object]]) -> None:
+    with pytest.raises(SchemaValidationError):
+        summarize_recovery_grid(records)
+
+
+def test_summarize_recovery_grid_returns_empty_list_for_empty_input() -> None:
+    assert summarize_recovery_grid([]) == []


### PR DESCRIPTION
## Summary

Implements `v0.6` Milestone 4 as a small robustness-utility layer for the current canonical Heat/Burgers discovery regime.

This PR adds:
- four public `FieldBatch` robustness helpers under `pdelie.data`
- one grouped recovery-grid summarizer under `pdelie.discovery`
- focused M4 tests
- M4 doc freeze updates in the planning and API-stability docs

This milestone stays narrow:
- no new canonical object
- no root exports
- no dataframe / plotting / report layer
- no new numerical regime
- no manuscript-table or artifact schema

## New Runtime APIs

Added under `pdelie.data`:
- `add_gaussian_noise(field, *, std_fraction, seed) -> FieldBatch`
- `subsample_time(field, *, stride) -> FieldBatch`
- `subsample_x(field, *, stride) -> FieldBatch`
- `split_batch_train_heldout(field, *, train_size, seed) -> tuple[FieldBatch, FieldBatch]`

Added under `pdelie.discovery`:
- `summarize_recovery_grid(records) -> list[dict[str, object]]`

No M4 helpers are exported from `pdelie.__init__`.

## Frozen M4 behavior

### FieldBatch helpers
The data-side helpers are deliberately conservative:
- `FieldBatch` in / `FieldBatch` out only
- deterministic behavior for noise, subsampling, and splitting
- coord arrays copied
- metadata deep-copied
- `var_names` copied
- existing preprocess-log entries deep-copied before appending one new entry
- masks preserved and sliced/copied consistently
- existing `NaN` / non-finite values preserved unless explicitly untouched by the operation

### `add_gaussian_noise(...)`
- noise is applied only to finite unmasked values
- noise scale is `std_fraction * RMS(finite_unmasked_values)`
- masked entries remain unchanged
- existing non-finite entries remain unchanged
- no eligible finite unmasked values raises `SchemaValidationError`
- `std_fraction == 0.0` is a no-op on values but still appends preprocess provenance

### `subsample_time(...)` / `subsample_x(...)`
- stride-only subsampling
- `subsample_time` may leave one time point
- `subsample_x` must leave at least two x-points
- missing required dims raise `ScopeValidationError`
- `NaN` and mask structure are preserved by pure slicing

### `split_batch_train_heldout(...)`
- `train_size` is integer-count only
- train membership is deterministic from `seed`
- outputs preserve original batch order within each split
- `1 <= train_size < batch_size`
- missing batch dim or too-small batch size raises typed validation errors

### `summarize_recovery_grid(...)`
- runtime convenience only
- accepts explicit nested records of the form `{"conditions": {...}, "recovery": {...}}`
- validates `classification` strictly against `{"exact", "partial", "failed"}`
- validates all required numeric recovery fields as finite scalars
- validates optional residual fields as finite when present
- groups rows by exact normalized `conditions`
- sorts grouped output deterministically using typed condition sort keys
- returns grouped counts, rates, and means
- not a canonical artifact schema
- not a manuscript-table format

## Tests

Added:
- `tests/test_robustness_utilities.py`

Updated:
- `tests/test_public_api.py`

Coverage includes:
- deterministic noise behavior
- mask / `NaN` preservation
- RMS-based noise scaling
- no-eligible-entry rejection
- stride validation
- one-time-point `subsample_time` behavior
- minimum-two-x-points `subsample_x` rule
- deterministic train/held-out splitting
- original-order preservation within splits
- explicit `bool` rejection for integer-like parameters, including `seed=True`
- deep-copy behavior for metadata and preprocess logs
- `mask=None` and nontrivial-mask cases
- grouped recovery-grid aggregation
- typed condition sorting
- invalid classification rejection
- non-finite required and optional recovery metric rejection
- empty-record behavior
- public package-surface assertions

## Docs

Updated:
- `docs/planning/PLAN.md`
- `docs/planning/V0_6_SCOPE.md`
- `docs/specs/API_STABILITY.md`

These now freeze M4 as the robustness-utility milestone and explicitly document:
- the new public runtime APIs
- the x-axis minimum-length rule
- integer-like parameter policy
- grouped recovery-grid semantics
- runtime-only / non-artifact status of the summarizer