### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.6.0
+
+First final release for the frozen V0.6 symmetry-guided PDE discovery utilities core.
+
+- adds runtime-only discovery recovery metrics under `pdelie.discovery.evaluate_discovery_recovery(...)`
+- adds a thin runtime-only PySINDy backend-fit adapter under `pdelie.discovery.fit_pysindy_discovery(...)`
+- adds runtime-only heuristic translation-canonical discovery inputs under `pdelie.discovery.build_translation_canonical_discovery_inputs(...)`
+- adds deterministic robustness helpers under `pdelie.data` plus grouped recovery-grid summaries under `pdelie.discovery`
+- adds a compact `v0_6-release-gate` CI visibility job and representative release-gate pytest module
+- finalizes the frozen `v0.6` Heat/Burgers discovery-utility surface without promoting KdV
+
+Explicitly deferred for this final release:
+
+- stable KdV API or stable KdV runtime module
+- external structured dataset ingestion
+- weak-form methods
+- operator methods
+- broad discovery adapters or backend frameworks
+- paper-specific experiment logic, figures, or manuscript tables
+
 ## 0.5.0
 
 First final release for the frozen V0.5 portability and external-compatibility core.

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,15 +1,15 @@
 # PDELie — Execution Plan (V0.6)
 
-## Current Active Milestone
+## Current Release Status
 
-**V0.6 Milestone 5 — V0.6 release gate**
+**V0.6 release complete**
 
-This file is the active execution plan for the current `v0.6` release series.
+This file is the execution record for the completed `v0.6` release series.
 
 It should contain:
 
 - a short record of the completed `v0.5` release
-- the frozen plan for the current active milestone
+- the frozen plan for the completed `v0.6` milestone sequence
 - milestone-specific rules and gates
 
 It should not redefine package contracts or roadmap commitments. Those belong in:
@@ -201,7 +201,7 @@ Add plain, deterministic robustness helpers that keep `FieldBatch` semantics int
 
 ## Milestone 5 — V0.6 Release Gate
 
-**Status:** Active
+**Status:** Complete
 
 ### Goal
 
@@ -269,4 +269,4 @@ Hard sequencing rules:
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
-- Milestone 5: ACTIVE
+- Milestone 5: COMPLETE

--- a/docs/planning/V0_6_SCOPE.md
+++ b/docs/planning/V0_6_SCOPE.md
@@ -283,7 +283,7 @@ Frozen preprocess-log policy:
 ---
 
 ## Milestone 5 — V0.6 release gate
-**Status:** Active
+**Status:** Complete
 
 The `v0.6` release gate remains compact and representative only.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.5.0"
-description = "V0.5 generator-family portability and external-family compatibility core with optional algebra diagnostics and visualization for PDE Lie symmetry discovery on synthetic Heat and Burgers data"
+version = "0.6.0"
+description = "V0.6 symmetry-guided PDE discovery utilities core with recovery metrics, a thin PySINDy adapter, translation-canonical discovery inputs, and robustness utilities for synthetic Heat and Burgers data"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",


### PR DESCRIPTION
What changed:

bumped package version to 0.6.0
replaced the old 0.5 portability description with v0.6 discovery-utilities wording
added a 0.6.0 changelog section
marked M5 complete and switched the V0.6 planning docs to release-complete status