### PR TITLE
Feat/v0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_4-release-gate:
+  v0_10-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,153 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.4 release gate
-        run: python -m pytest tests/test_v0_4_release_gate.py
-  v0_5-release-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package and test dependencies
-        shell: bash
-        run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local count=1
-            until "$@"; do
-              if [ "${count}" -ge "${attempts}" ]; then
-                return 1
-              fi
-              count=$((count + 1))
-              echo "Retrying (${count}/${attempts}): $*"
-              sleep 5
-            done
-          }
-          retry 3 python -m pip install --upgrade pip
-          retry 3 python -m pip install -e .[test]
-      - name: Check dependencies
-        run: python -m pip check
-      - name: Run V0.5 release gate
-        run: python -m pytest tests/test_v0_5_release_gate.py
-  v0_6-release-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package and test dependencies
-        shell: bash
-        run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local count=1
-            until "$@"; do
-              if [ "${count}" -ge "${attempts}" ]; then
-                return 1
-              fi
-              count=$((count + 1))
-              echo "Retrying (${count}/${attempts}): $*"
-              sleep 5
-            done
-          }
-          retry 3 python -m pip install --upgrade pip
-          retry 3 python -m pip install -e .[test]
-      - name: Check dependencies
-        run: python -m pip check
-      - name: Run V0.6 release gate
-        run: python -m pytest tests/test_v0_6_release_gate.py
-  v0_7-release-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package and test dependencies
-        shell: bash
-        run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local count=1
-            until "$@"; do
-              if [ "${count}" -ge "${attempts}" ]; then
-                return 1
-              fi
-              count=$((count + 1))
-              echo "Retrying (${count}/${attempts}): $*"
-              sleep 5
-            done
-          }
-          retry 3 python -m pip install --upgrade pip
-          retry 3 python -m pip install -e .[test]
-      - name: Check dependencies
-        run: python -m pip check
-      - name: Run V0.7 release gate
-        run: python -m pytest tests/test_v0_7_release_gate.py
-  v0_8-release-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package and test dependencies
-        shell: bash
-        run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local count=1
-            until "$@"; do
-              if [ "${count}" -ge "${attempts}" ]; then
-                return 1
-              fi
-              count=$((count + 1))
-              echo "Retrying (${count}/${attempts}): $*"
-              sleep 5
-            done
-          }
-          retry 3 python -m pip install --upgrade pip
-          retry 3 python -m pip install -e .[test]
-      - name: Check dependencies
-        run: python -m pip check
-      - name: Run V0.8 release gate
-        run: python -m pytest tests/test_v0_8_release_gate.py
-  v0_9-release-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install package and test dependencies
-        shell: bash
-        run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local count=1
-            until "$@"; do
-              if [ "${count}" -ge "${attempts}" ]; then
-                return 1
-              fi
-              count=$((count + 1))
-              echo "Retrying (${count}/${attempts}): $*"
-              sleep 5
-            done
-          }
-          retry 3 python -m pip install --upgrade pip
-          retry 3 python -m pip install -e .[test]
-      - name: Check dependencies
-        run: python -m pip check
-      - name: Run V0.9 release gate
-        run: python -m pytest tests/test_v0_9_release_gate.py
+      - name: Run V0.10 release gate
+        run: python -m pytest tests/test_v0_10_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -328,6 +183,8 @@ jobs:
           first = run_example()
           second = run_example()
           assert first == second, "example output is not deterministic across repeated runs"
-          assert first["verification_classification"] == "exact"
+          assert first["summary_type"] == "vertical_slice"
+          assert first["derivative_backend"] == "spectral_fd"
+          assert first["verification"]["classification"] == "exact"
           print("example-smoke-ok")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.10.0
+
+First final release for the frozen V0.10 supportability and `v1.0` readiness slice.
+
+- adds public runtime supportability helpers under `pdelie.reporting` for JSON-compatible summaries of residual batches, weak residual reports, generator families, verification reports, and vertical slices
+- refactors Heat and KdV vertical-slice examples to emit the shared nested `vertical_slice` summary shape while keeping their command entrypoints unchanged
+- adds focused API stability audit coverage and public-surface guards for stable submodule APIs, root-export boundaries, and explicitly deferred surfaces
+- consolidates CI release-gate visibility to a single current `v0_10-release-gate` job while keeping historical release-gate tests runnable locally and covered by full editable tests
+- preserves the prior Heat/Burgers strong paths, `v0.8` weak residual report APIs, `v0.9` normalized periodic KdV strong path, structured ingestion, and symmetry/discovery utilities
+
+Explicitly deferred for this final release:
+
+- new PDE support
+- weak KdV APIs
+- weak derivative APIs or broader weak-form expansion
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- manuscript-specific reporting logic, tables, figures, or thresholds
+- new canonical reporting objects
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.9.0
 
 First final release for the frozen V0.9 normalized periodic KdV strong path.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.9 normalized periodic KdV strong path, while retaining the V0.8 weak residual reports plus structured-ingestion and symmetry/discovery utilities core:
+The current repository implements the frozen V0.10 supportability layer for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
 - synthetic normalized periodic short-horizon KdV
 - strict external structured ingestion into canonical `FieldBatch`
 - deterministic window-indexed weak residual reports under `pdelie.residuals`
+- JSON-compatible runtime supportability summaries under `pdelie.reporting`
 - uniform periodic grid
 - `spectral_fd` derivatives through `u_xxx`
 - normalized KdV strong residuals under `pdelie.residuals.KdVResidualEvaluator`
@@ -26,6 +27,7 @@ The current repository implements the frozen V0.9 normalized periodic KdV strong
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
+- one compact current release-gate CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -74,7 +76,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.9`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.10`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -114,13 +116,14 @@ The KdV example demonstrates the frozen normalized periodic short-horizon KdV st
 4. evaluate the normalized KdV residual
 5. fit and verify the polynomial spatial-translation baseline
 
-You can also call the example programmatically:
+You can also call the examples programmatically.
+They return nested `pdelie.reporting.summarize_vertical_slice(...)` runtime summaries, not canonical artifact schemas:
 
 ```python
 from pdelie.examples import run_heat_vertical_slice_example, run_kdv_vertical_slice_example
 
 result = run_kdv_vertical_slice_example()
-print(result["verification_classification"])
+print(result["verification"]["classification"])
 ```
 
 ## Current Scope
@@ -132,6 +135,7 @@ Included in the current stable core:
 - strict structured external-data ingestion into canonical `FieldBatch` via `from_numpy(...)` and `from_xarray(...)`
 - stable weak residual report APIs under `pdelie.residuals` for Heat and Burgers
 - stable normalized KdV strong residual evaluator under `pdelie.residuals`
+- stable supportability reporting helpers under `pdelie.reporting`
 - polynomial translation baseline for the stable PDE slice
 - finite-transform verification for the stable PDE slice
 - family-shaped `GeneratorFamily` serialization and narrow translation compatibility migration
@@ -140,9 +144,10 @@ Included in the current stable core:
 - single-generator invariant map support
 - runtime-only discovery recovery metrics, backend-native PySINDy discovery fits, translation-canonical discovery inputs, robustness utilities, and structured-ingestion parity coverage for the current Heat/Burgers slice
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
+- consolidated current release-gate CI visibility while retaining historical gate tests in the full test suite
 - KdV is stable only for the normalized periodic short-horizon strong path; weak KdV remains explicitly deferred
 
-Runtime-level public APIs in the frozen V0.9 slice:
+Runtime-level public APIs in the frozen V0.10 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -152,6 +157,11 @@ Runtime-level public APIs in the frozen V0.9 slice:
 - `pdelie.examples.run_kdv_vertical_slice_example` for a runtime smoke example, not a canonical report schema
 - `pdelie.residuals.evaluate_weak_heat_residual` for deterministic window-indexed weak residual report dicts over canonical scalar 1D uniform periodic Heat `FieldBatch` data
 - `pdelie.residuals.evaluate_weak_burgers_residual` for deterministic window-indexed weak residual report dicts over canonical scalar 1D uniform periodic Burgers `FieldBatch` data
+- `pdelie.reporting.summarize_residual_batch` for JSON-compatible runtime summaries of `ResidualBatch` outputs
+- `pdelie.reporting.summarize_weak_residual_report` for JSON-compatible summaries of frozen weak residual report dicts
+- `pdelie.reporting.summarize_generator_family` for JSON-compatible summaries of `GeneratorFamily` coefficients and diagnostics
+- `pdelie.reporting.summarize_verification_report` for JSON-compatible summaries of finite-transform verification sweeps
+- `pdelie.reporting.summarize_vertical_slice` for nested derivative/residual/generator/verification runtime summaries
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
 - `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support/coefficient recovery metrics over caller-supplied canonical term strings
@@ -169,7 +179,9 @@ Runtime-level public APIs in the frozen V0.9 slice:
 
 The degraded weak-path release wins in `v0.8` are frozen as representative contract-stability signals. They are fallback-backed release checks, not a general weak-superiority claim.
 
-The KdV support in `v0.9` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+The KdV support retained through `v0.10` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+
+The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 
 Explicitly deferred:
 - stable multi-generator PDE fitting

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 2 complete**
+**V0.10 active; Milestone 3 complete**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -165,18 +165,35 @@ Implement the frozen supportability reporting helpers from M1.
 
 ## Milestone 3 - Example Consistency
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Make existing examples easier to compare, smoke-test, and support without turning example outputs into canonical schemas.
 
-### Planned Scope
+### Completed Outcome
 
-- align Heat and KdV example summary style where useful
-- keep example outputs JSON-serializable
-- preserve existing example behavior unless a supportability issue requires a narrow change
-- add or adjust tests for determinism and subprocess JSON output
+- refactored `run_heat_vertical_slice_example()` to return `pdelie.reporting.summarize_vertical_slice(...)`
+- refactored `run_kdv_vertical_slice_example()` to return `pdelie.reporting.summarize_vertical_slice(...)`
+- kept command entrypoints unchanged:
+  - `python -m pdelie.examples.heat_vertical_slice`
+  - `python -m pdelie.examples.kdv_vertical_slice`
+- kept root `pdelie` exports unchanged
+- moved example-specific context into `extra_metrics`:
+  - Heat records example name, equation, training/heldout seeds, and batch sizes
+  - KdV records example name, equation, generator/split seeds, train size, mass drift, and relative L2 drift
+- kept example outputs JSON-only on stdout with no logging noise
+- intentionally did not preserve the old flat top-level example keys
+- recorded that example outputs are runtime smoke summaries, not canonical artifact schemas
+- updated example tests for:
+  - nested `vertical_slice` summary shape
+  - JSON serialization
+  - deterministic repeated output
+  - Heat and KdV subprocess JSON-only execution
+  - root-export guards
+- updated the representative `v0.9` release-gate example assertion to read the nested summary without preserving the old example schema
+- did not change fitting, verification, residual, derivative, data-generation, or reporting-helper behavior
+- left `API_STABILITY.md`, README, changelog, release-readiness docs, package metadata, and CI unchanged
 
 ### Acceptance Criteria
 
@@ -301,7 +318,7 @@ Milestone 6 -> release readiness and documentation alignment
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: PENDING
+- Milestone 3: COMPLETE
 - Milestone 4: PENDING
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -22,8 +22,8 @@ Contracts and stable behavior belong in:
 - `docs/planning/ROADMAP.md`
 - `docs/planning/V0_10_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.10` public API has landed yet.
-It must be updated in the same milestone where any public reporting helper or other public API lands.
+`API_STABILITY.md` was audited in M0, left unchanged in M0/M1, updated in M2 when the public `pdelie.reporting` helpers landed, and audited again in M4/M6 with no further changes required.
+It must continue to be updated in the same milestone where any future public helper or other public API lands.
 
 ---
 

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 1 complete**
+**V0.10 active; Milestone 2 complete**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -127,26 +127,39 @@ Freeze exactly what `v0.10` supportability reporting means before runtime implem
 
 ## Milestone 2 - Reporting Helper Implementation
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Implement the frozen supportability reporting helpers from M1.
 
-### Planned Scope
+### Completed Outcome
 
-- implement only the helpers frozen in M1
-- keep helpers deterministic over frozen representative inputs
-- keep helpers scoped to existing stable runtime surfaces
-- add focused tests for structure, determinism, and numerical tolerance
-- update `API_STABILITY.md` if any helper is public
+- added public runtime submodule `pdelie.reporting`
+- exported the five M1-frozen helpers from `pdelie.reporting` only:
+  - `summarize_residual_batch(...)`
+  - `summarize_weak_residual_report(...)`
+  - `summarize_generator_family(...)`
+  - `summarize_verification_report(...)`
+  - `summarize_vertical_slice(...)`
+- kept root `pdelie` exports unchanged
+- implemented JSON-compatible summary conversion:
+  - NumPy arrays convert to lists
+  - NumPy scalars convert to Python scalars
+  - mappings and sequences convert recursively
+- implemented typed validation errors for wrong object types, malformed weak reports, non-finite metric arrays, and malformed extra metrics
+- kept helpers deterministic and scoped to existing stable runtime surfaces
+- added focused reporting tests for schemas, JSON serialization, summary metrics, non-mutation, and validation failures
+- updated public API tests for the new submodule and root-export guards
+- updated `docs/specs/API_STABILITY.md` for the landed `pdelie.reporting` APIs
+- did not change canonical object schemas, examples, CI, README, changelog, package metadata, or release-readiness docs
 
 ### Acceptance Criteria
 
 - reporting helpers pass focused tests
 - no existing canonical object schema changes
 - no new PDE, weak KdV, broad adapter, or operator scope lands
-- public helper APIs are documented in `API_STABILITY.md` if they land
+- public helper APIs are documented in `API_STABILITY.md`
 
 ---
 
@@ -287,7 +300,7 @@ Milestone 6 -> release readiness and documentation alignment
 - `v0.9`: COMPLETE
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: PENDING
+- Milestone 2: COMPLETE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 4 complete**
+**V0.10 active; Milestone 5 complete**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -251,20 +251,31 @@ Bring public-surface tests and `API_STABILITY.md` into a clean pre-`v1.0` postur
 
 ## Milestone 5 - CI Cleanup and Release-Gate Consolidation
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Reduce CI release-gate sprawl while keeping historical release-gate tests runnable locally.
 
-### Planned Scope
+### Completed Outcome
 
-- keep full editable tests
-- keep package smoke
-- keep one current release-gate CI job
-- keep historical release-gate test modules in the repo
-- remove redundant historical release-gate CI jobs only after confirming equivalent coverage remains available locally
-- avoid changing test semantics just for CI speed
+- added a compact `tests/test_v0_10_release_gate.py`
+- consolidated explicit release-gate CI visibility to one current job:
+  - `v0_10-release-gate`
+- removed historical explicit CI jobs:
+  - `v0_4-release-gate`
+  - `v0_5-release-gate`
+  - `v0_6-release-gate`
+  - `v0_7-release-gate`
+  - `v0_8-release-gate`
+  - `v0_9-release-gate`
+- kept all historical release-gate test modules in the repo
+- kept historical release-gate tests covered by the full `editable-tests` job
+- kept `editable-tests` running full `python -m pytest`
+- kept `package-smoke`
+- updated package-smoke example assertions for the nested `vertical_slice` summary shape introduced in M3
+- did not change historical release-gate test semantics
+- did not change runtime APIs, canonical objects, numerical behavior, README/changelog docs, release-readiness docs, package metadata, or package-index publishing behavior
 
 ### Acceptance Criteria
 
@@ -337,5 +348,5 @@ Milestone 6 -> release readiness and documentation alignment
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
-- Milestone 5: PENDING
+- Milestone 5: COMPLETE
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,16 +1,17 @@
-# PDELie - Execution Plan (V0.9)
+# PDELie - Execution Plan (V0.10)
 
 ## Current Release Status
 
-**V0.9 complete; Milestone 6 complete**
+**V0.10 active; Milestone 0 complete**
 
-This file is the active execution record for the `v0.9` release series.
+This file is the active execution record for the `v0.10` release series.
 
-`v0.9` promotes the existing tests-first KdV feasibility slice into a narrow stable normalized periodic short-horizon KdV strong path.
+`v0.10` is a supportability and `v1.0` readiness release.
+It hardens the existing Heat/Burgers/weak-report/KdV engine before any new numerical scope is added.
 
 Stable release definition:
 
-`canonical scalar 1D uniform periodic FieldBatch -> spectral_fd with u_xxx -> normalized KdV residual evaluator -> translation fit/verification`
+`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -19,324 +20,223 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_9_SCOPE.md`
+- `docs/planning/V0_10_SCOPE.md`
 
-`API_STABILITY.md` remains unchanged in M0.
-It is updated in the milestone where each public runtime API actually lands.
+`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.10` public API has landed yet.
+It must be updated in the same milestone where any public reporting helper or other public API lands.
 
 ---
 
-## V0.8 Closeout
+## V0.9 Closeout
 
-`v0.8` is complete as the window-indexed weak residual report release.
+`v0.9` is complete as the stable normalized periodic short-horizon KdV strong-path release.
 
 Completed outcome:
 
-- stable `pdelie.residuals.evaluate_weak_heat_residual(...)`
-- stable `pdelie.residuals.evaluate_weak_burgers_residual(...)`
-- deterministic window-indexed weak residual reports for scalar 1D Heat/Burgers
-- fallback-backed representative robustness comparisons against the existing strong path
-- compact `v0_8-release-gate`
-- explicit deferral of weak derivatives, weak `ResidualBatch` integration, and stable KdV runtime promotion
+- `compute_spectral_fd_derivatives(..., max_spatial_order=3)` with `u_xxx`
+- `pdelie.data.generate_kdv_1d_field_batch(...)`
+- `pdelie.residuals.KdVResidualEvaluator`
+- KdV vertical-slice example and release-gate coverage
+- mandatory representative `from_numpy` parity and optional `from_xarray` parity
+- explicit deferral of weak KdV, configurable KdV coefficients, custom KdV initial conditions, general KdV support, and broad adapter work
 
-`v0.9` begins from the frozen `v0.8` surface.
-It does not reopen weak-form numerics.
+`v0.10` begins from the frozen `v0.9` surface.
+It does not reopen KdV numerics or weak-form scope.
 
 ---
 
-## Milestone 0 - KdV Strong-Path Scope Freeze
+## Milestone 0 - Supportability Scope Reset
 
 **Status:** COMPLETE
 
 ### Goal
 
-Promote `v0.9` to the next committed release target, create `V0_9_SCOPE.md`, reset `PLAN.md`, and keep `API_STABILITY.md` unchanged.
+Promote `v0.10` to the next committed release target, create `V0_10_SCOPE.md`, reset `PLAN.md`, and audit `API_STABILITY.md` without changing it.
 
 ### Completed Outcome
 
-- promoted `v0.9` to committed KdV strong-path scope in `ROADMAP.md`
-- created `docs/planning/V0_9_SCOPE.md`
-- reset `docs/planning/PLAN.md` as the active `v0.9` execution record
-- froze exact planned public API signatures
-- froze derivative order behavior for `max_spatial_order`
-- froze KdV generator validation and release-guaranteed parameter regime
-- froze KdV residual evaluator semantics
-- froze KdV vertical-slice fixture and release-gate thresholds
-- left `docs/specs/API_STABILITY.md` unchanged
+- promoted `v0.10` to committed supportability / `v1.0` readiness scope in `ROADMAP.md`
+- created `docs/planning/V0_10_SCOPE.md`
+- reset `docs/planning/PLAN.md` as the active `v0.10` execution record
+- recorded `v0.9` as completed
+- recorded `v0.11` as conditional next strong-path PDE feasibility or promotion
+- recorded `v0.12+` as later PDE/dataset coverage only after separate scope freezes
+- audited `docs/specs/API_STABILITY.md`
+- left `docs/specs/API_STABILITY.md` unchanged because no new `v0.10` public API has landed
+- left `.github/workflows/ci.yml`, `README.md`, `CHANGELOG.md`, and `docs/releases/V0_10_RELEASE_READINESS.md` for later milestones
 
 ### Acceptance Criteria
 
 M0 is complete only if:
 
-- `ROADMAP.md`, `PLAN.md`, and `V0_9_SCOPE.md` are internally consistent
-- `v0.8` is consistently described as completed
-- `v0.9` is consistently described as the next committed release
-- `v0.9` is described as stable normalized periodic short-horizon KdV, not general KdV support
+- `ROADMAP.md`, `PLAN.md`, and `V0_10_SCOPE.md` are internally consistent
+- `v0.9` is consistently described as completed
+- `v0.10` is consistently described as the next committed release
+- `v0.10` is described as supportability and `v1.0` readiness, not new numerical scope
+- `v0.11` is conditional and not committed
+- `v0.12+` remains planned only after separate scope freezes
 - `API_STABILITY.md` remains unchanged during M0
-- no runtime code, tests, or package metadata are edited
+- no runtime code, tests, package metadata, CI, README, changelog, or release-readiness docs are edited in M0
 
 ---
 
-## Milestone 1 - Spectral `u_xxx`
+## Milestone 1 - Reporting Semantics Freeze
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Extend the existing `spectral_fd` derivative backend through third spatial order without breaking default Heat/Burgers behavior.
+Freeze exactly what `v0.10` supportability reporting means before runtime implementation.
 
-### Completed Outcome
+### Planned Scope
 
-- implemented `compute_spectral_fd_derivatives(field, *, max_spatial_order: int = 2)`
-- froze derivative key behavior:
-  - `1` -> `u_t`, `u_x`
-  - `2` -> `u_t`, `u_x`, `u_xx`
-  - `3` -> `u_t`, `u_x`, `u_xx`, `u_xxx`
-- accepted Python integer and NumPy integer scalar orders while rejecting bools and unsupported values
-- preserved default `max_spatial_order=2` derivative arrays, derivative-key set, config, and diagnostics
-- kept `spatial_max_order` out of the default config and recorded it only for non-default orders
-- computed `u_xxx` using the same spectral wavenumber convention as `u_x` and `u_xx`
-- added exact Fourier `u_xxx` accuracy tests
-- added default-regression tests proving existing default derivative arrays and metadata remain behavior-compatible
-- updated `API_STABILITY.md` for the derivative API change
+- choose exact reporting helper names and import paths, if public helpers are justified
+- freeze return types and JSON-compatibility expectations
+- freeze which existing surfaces may be summarized:
+  - residual diagnostics
+  - generator fitting diagnostics
+  - verification reports
+  - vertical-slice summaries
+  - release-gate support summaries
+- define deterministic representative inputs for reporting tests
+- explicitly decide whether helpers are public runtime APIs or internal helpers
+- explicitly avoid new canonical objects unless a repeated supportability problem proves they are necessary
 
 ### Acceptance Criteria
 
-- Heat/Burgers derivative tests pass under default `max_spatial_order=2`
-- `u_xxx` matches exact Fourier fixtures within frozen tolerance
-- invalid derivative orders raise typed errors
-- `API_STABILITY.md` documents the landed derivative API change
+- exact reporting semantics are frozen before implementation
+- no manuscript-specific reporting logic is introduced
+- example outputs remain runtime smoke summaries, not canonical artifacts
+- `API_STABILITY.md` is still unchanged unless public reporting APIs land in this milestone
 
 ---
 
-## Milestone 2 - KdV Generator
+## Milestone 2 - Reporting Helper Implementation
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Promote the tests-first KdV synthetic data generator into runtime as a narrow stable short-horizon normalized periodic generator.
+Implement the frozen supportability reporting helpers from M1.
 
-### Completed Outcome
+### Planned Scope
 
-- implemented `pdelie.data.generate_kdv_1d_field_batch(...)`
-- kept the exact M0 signature and defaults:
-  - `batch_size=2`
-  - `num_times=17`
-  - `num_points=64`
-  - `max_time=0.03`
-  - `num_modes=3`
-  - `amplitude=0.08`
-  - `seed=0`
-  - `num_substeps=8`
-  - `domain_length=DEFAULT_DOMAIN_LENGTH`
-- kept no `dtype` parameter and no custom initial-condition API
-- froze coordinate conventions:
-  - `x = np.linspace(0.0, domain_length, num_points, endpoint=False)`
-  - `x` spans `[0, domain_length)`
-  - `time = np.linspace(0.0, max_time, num_times)`
-  - `time` spans `[0, max_time]`
-  - values shape is `(batch_size, num_times, num_points, 1)`
-- preserved canonical metadata:
-  - `boundary_conditions["x"] == "periodic"`
-  - `grid_type == "rectilinear"`
-  - `grid_regularity == "uniform"`
-  - `coordinate_system == "cartesian"`
-  - `parameter_tags == {"equation": "kdv_normalized"}`
-- validated:
-  - positive integer `batch_size`
-  - `num_times >= 3`
-  - `num_points >= 16`
-  - finite positive `max_time`
-  - integer `num_modes >= 1`
-  - `num_modes <= floor(num_points / 3)`
-  - finite nonnegative `amplitude`
-  - integer `seed`
-  - positive integer `num_substeps`
-  - finite positive `domain_length`
-- accepted Python integer and NumPy integer scalar parameters while rejecting bools
-- accepted `amplitude=0.0` as a valid zero-field case without using it for relative-L2 release assertions
-- refactored the test-only KdV feasibility helper to call the runtime generator while keeping residual/derivative feasibility helpers test-only
-- updated public-surface guards so `pdelie.data.generate_kdv_1d_field_batch` is public, root KdV exports remain absent, public coefficient-sampling helpers remain absent, and `KdVResidualEvaluator` remains pending for M3
-- updated `API_STABILITY.md` for the generator API
+- implement only the helpers frozen in M1
+- keep helpers deterministic over frozen representative inputs
+- keep helpers scoped to existing stable runtime surfaces
+- add focused tests for structure, determinism, and numerical tolerance
+- update `API_STABILITY.md` if any helper is public
 
 ### Acceptance Criteria
 
-- generated KdV fields are reproducible
-- generated fields validate as canonical `FieldBatch`
-- default fixture mass drift is `<= 1e-8`
-- default fixture relative L2 drift is `<= 5e-3`
-- invalid generator parameters raise typed errors
-- `API_STABILITY.md` documents the landed generator API
+- reporting helpers pass focused tests
+- no existing canonical object schema changes
+- no new PDE, weak KdV, broad adapter, or operator scope lands
+- public helper APIs are documented in `API_STABILITY.md` if they land
 
 ---
 
-## Milestone 3 - KdV Residual Evaluator
+## Milestone 3 - Example Consistency
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Promote normalized KdV strong-form residual evaluation into runtime.
+Make existing examples easier to compare, smoke-test, and support without turning example outputs into canonical schemas.
 
-### Completed Outcome
+### Planned Scope
 
-- implemented `pdelie.residuals.KdVResidualEvaluator`
-- froze the normalized KdV strong-form equation `u_t + 6*u*u_x + u_xxx = 0`
-- compute derivatives internally with `compute_spectral_fd_derivatives(field, max_spatial_order=3)` when derivatives are omitted
-- require supplied derivatives to validate against the field and include `u_t`, `u_x`, and `u_xxx`
-- reject missing `u_xxx` with a typed validation error before residual construction
-- keep supplied derivative backend compatibility field-based rather than requiring `backend == "spectral_fd"`
-- validate the normalized KdV stable scope:
-  - canonical dims `("batch", "time", "x", "var")`
-  - scalar `var`
-  - periodic `x`
-  - finite, unmasked values
-  - `field.metadata["parameter_tags"]["equation"] == "kdv_normalized"`
-- return `ResidualBatch(definition_type="analytic", normalization="none")`
-- include diagnostics:
-  - `equation`
-  - `backend`
-  - `max_abs_residual`
-  - `rms_residual`
-- expose the evaluator only from `pdelie.residuals`, not root `pdelie`
-- keep weak KdV and configurable KdV coefficients absent
-- updated `API_STABILITY.md` for the residual evaluator API
+- align Heat and KdV example summary style where useful
+- keep example outputs JSON-serializable
+- preserve existing example behavior unless a supportability issue requires a narrow change
+- add or adjust tests for determinism and subprocess JSON output
 
 ### Acceptance Criteria
 
-- clean default KdV residual max absolute value is `< 1e-2`
-- clean default KdV residual RMS value is `< 2e-3`
-- missing required derivatives raise typed errors
-- unsupported fields raise typed errors
-- non-periodic or non-canonical inputs are rejected
-- `API_STABILITY.md` documents the landed residual evaluator API
+- examples remain deterministic runtime smokes
+- example summaries are not documented as canonical artifact schemas
+- Heat/Burgers/KdV stable runtime behavior remains unchanged
 
 ---
 
-## Milestone 4 - KdV Vertical Slice
+## Milestone 4 - API Stability Audit and Public-Surface Guards
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Prove KdV works through the existing translation fitting and held-out verification stack.
+Bring public-surface tests and `API_STABILITY.md` into a clean pre-`v1.0` posture.
 
-### Completed Outcome
+### Planned Scope
 
-- added KdV fit/verification coverage using the frozen fixture:
-  - generator seed `9001`
-  - `batch_size = 5`
-  - `train_size = 2`
-  - split seed `9002`
-  - all other generator settings default
-- added `python -m pdelie.examples.kdv_vertical_slice`
-- added lazy `pdelie.examples.run_kdv_vertical_slice_example`
-- kept root `pdelie` exports unchanged
-- kept the vertical slice on the normalized periodic short-horizon strong path only
-- computed conservation diagnostics on the full generated fixture before train/heldout splitting
-- kept the example output as a JSON-serializable runtime smoke summary, not a stable canonical artifact schema
-- observed frozen-fixture values:
-  - max absolute residual: `0.0029755398453998883`
-  - RMS residual: `0.0005530662104030956`
-  - mass drift: `1.529348589458863e-16`
-  - relative L2 drift: `4.353026792731057e-14`
-  - translation span distance: `0.007441277120177836`
-  - first-epsilon held-out verification error: `3.7632323492784305e-06`
-  - verification classification: `approximate`
-  - fit mode: `svd`
-  - reference fallback used: `False`
+- audit root exports
+- audit submodule exports
+- audit runtime-only APIs
+- audit experimental/deferred surfaces
+- add targeted guards against accidental exports
+- update `API_STABILITY.md` only for actual public API changes or omissions
 
 ### Acceptance Criteria
 
-- translation span distance is `<= 5e-2`
-- first-epsilon held-out verification error is `< 1e-4`
-- verification classification is not `failed`
-- observed `approximate` classification is acceptable because the M4 gate requires only non-failed verification
-- example smoke runs without changing the existing Heat example
+- public-surface tests assert specific required/forbidden names without over-freezing unrelated module contents
+- stable APIs through `v0.10` are documented
+- deferred surfaces remain absent:
+  - weak KdV
+  - weak derivatives beyond the `v0.8` report functions
+  - broad adapters
+  - operator-facing APIs
 
 ---
 
-## Milestone 5 - Imported Parity and Non-goal Guards
+## Milestone 5 - CI Cleanup and Release-Gate Consolidation
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Prove KdV remains compatible with the existing structured-ingestion path while protecting v0.9 scope boundaries.
+Reduce CI release-gate sprawl while keeping historical release-gate tests runnable locally.
 
-### Completed Outcome
+### Planned Scope
 
-- added mandatory `from_numpy` parity for representative KdV train and heldout data
-- added optional `from_xarray` parity with `pytest.importorskip`
-- used the frozen M4 fixture:
-  - generator seed `9001`
-  - `batch_size = 5`
-  - `train_size = 2`
-  - split seed `9002`
-- verified imported train and heldout fields preserve:
-  - canonical dims, values, coordinates, and variable names
-  - `parameter_tags == {"equation": "kdv_normalized"}`
-  - mask state
-  - native preprocess-log prefix plus exactly one importer entry
-- compared native and imported KdV strong paths with tolerances:
-  - `compute_spectral_fd_derivatives(..., max_spatial_order=3)`
-  - `KdVResidualEvaluator`
-  - `fit_translation_generator`
-  - `verify_translation_generator`
-- compared stable summary fields only and avoided full diagnostic-dict equality for floating or implementation-specific diagnostics
-- observed mandatory `from_numpy` parity passed
-- observed optional `from_xarray` parity skipped cleanly because xarray is unavailable in the local test environment
-- asserted no weak KdV API
-- asserted no root `pdelie` exports for KdV runtime APIs or KdV example helpers
-- asserted v0.8 weak report APIs remain stable
-- did not add runtime APIs, KdV-specific importers, generic adapter helpers, or broad adapter expansion
+- keep full editable tests
+- keep package smoke
+- keep one current release-gate CI job
+- keep historical release-gate test modules in the repo
+- remove redundant historical release-gate CI jobs only after confirming equivalent coverage remains available locally
+- avoid changing test semantics just for CI speed
 
 ### Acceptance Criteria
 
-- native and imported KdV paths agree within frozen tolerances
-- optional xarray parity skips cleanly when xarray is unavailable
-- weak KdV remains absent
-- root exports remain unchanged
-- v0.8 weak report API tests remain green
+- CI remains release-useful
+- historical gate tests remain runnable locally
+- current release gate remains visible in CI
+- package smoke remains compact and representative
 
 ---
 
-## Milestone 6 - Release Gate and Release Readiness
+## Milestone 6 - Release Readiness and Documentation Alignment
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Add the compact `v0_9-release-gate`, align release-facing docs, and document the direct `0.9.0` Git tag path.
+Close `v0.10` with aligned release-facing docs, package metadata, release gate, and final tag checklist.
 
-### Completed Outcome
+### Planned Scope
 
-- added compact `tests/test_v0_9_release_gate.py`
-- added `v0_9-release-gate` CI visibility job
-- kept historical release-gate CI jobs unchanged
-- added KdV editable-install example smoke beside the Heat example smoke
-- added tiny KdV strong-path wheel smoke after build
-- updated README, changelog, release readiness, package version, roadmap, and publishing docs
-- aligned release docs around a direct Git tag release path
-- recorded that `v0.9.0` is Git-tag-only:
-  - no `v0.9.0rc1`
-  - no TestPyPI run
-  - no PyPI run
-  - package-index publishing deferred to `v1.0` or later
-- kept `API_STABILITY.md` unchanged after audit because the landed v0.9 APIs were already documented
-- recorded post-`v0.9` CI job consolidation as a follow-up, not part of M6
+- update README, changelog, and release-readiness docs
+- update package version for the `v0.10` release
+- record the `v1.0` package-index publishing decision
+- document final local validation requirements
+- verify no new numerical scope landed
 
 ### Acceptance Criteria
 
-- historical release gates remain green
-- `v0_9-release-gate` is green
 - full test suite passes
-- source and wheel build passes
-- clean wheel smoke passes
-- KdV vertical slice passes
-- release-facing docs describe stable short-horizon normalized periodic KdV, not general KdV support
-- release-facing docs do not instruct PyPI or TestPyPI publication for `v0.9`
+- build and clean wheel smoke pass
+- current release gate passes
+- release-facing docs describe supportability / `v1.0` readiness, not new PDE support
+- package-index publishing decision is explicit
 
 ---
 
@@ -344,36 +244,37 @@ Add the compact `v0_9-release-gate`, align release-facing docs, and document the
 
 Locked sequence:
 
-Milestone 0 -> KdV strong-path scope freeze
-Milestone 1 -> spectral `u_xxx`
-Milestone 2 -> KdV generator
-Milestone 3 -> KdV residual evaluator
-Milestone 4 -> KdV vertical slice
-Milestone 5 -> imported parity and non-goal guards
-Milestone 6 -> release gate and release readiness
+Milestone 0 -> supportability scope reset
+Milestone 1 -> reporting semantics freeze
+Milestone 2 -> reporting helper implementation
+Milestone 3 -> example consistency
+Milestone 4 -> API stability audit and public-surface guards
+Milestone 5 -> CI cleanup and release-gate consolidation
+Milestone 6 -> release readiness and documentation alignment
 
 ---
 
 ## Rules
 
-- DO NOT promote weak KdV in `v0.9`
-- DO NOT add root `pdelie` exports for KdV runtime APIs
-- DO NOT add custom KdV initial-condition APIs in `v0.9`
-- DO NOT broaden `v0.9` into general KdV support
-- DO NOT broaden `v0.9` into PDEBench, The Well, multidimensional, multivariable, nonuniform-grid, operator, or broad adapter work
-- DO NOT update `API_STABILITY.md` in M0
-- DO update `API_STABILITY.md` in the same milestone where each public API lands
-- DO preserve existing Heat/Burgers and v0.8 weak-report behavior
+- DO NOT add a new PDE in `v0.10`
+- DO NOT promote weak KdV in `v0.10`
+- DO NOT add a new weak derivative API in `v0.10`
+- DO NOT broaden `v0.10` into PDEBench, The Well, multidimensional, multivariable, nonuniform-grid, operator, or broad adapter work
+- DO NOT add manuscript-specific reporting logic
+- DO NOT add a new canonical object unless M1 proves runtime helpers cannot solve the supportability problem
+- DO NOT update `API_STABILITY.md` until a public `v0.10` API actually lands or an audit finds a real omission
+- DO preserve existing Heat/Burgers, v0.8 weak-report, and v0.9 KdV behavior
+- DO keep historical release-gate tests runnable locally through any CI cleanup
 
 ---
 
 ## Status
 
-- `v0.8`: COMPLETE
+- `v0.9`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: COMPLETE
-- Milestone 2: COMPLETE
-- Milestone 3: COMPLETE
-- Milestone 4: COMPLETE
-- Milestone 5: COMPLETE
-- Milestone 6: COMPLETE
+- Milestone 1: PENDING
+- Milestone 2: PENDING
+- Milestone 3: PENDING
+- Milestone 4: PENDING
+- Milestone 5: PENDING
+- Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 3 complete**
+**V0.10 active; Milestone 4 complete**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -205,20 +205,37 @@ Make existing examples easier to compare, smoke-test, and support without turnin
 
 ## Milestone 4 - API Stability Audit and Public-Surface Guards
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Bring public-surface tests and `API_STABILITY.md` into a clean pre-`v1.0` posture.
 
-### Planned Scope
+### Completed Outcome
 
-- audit root exports
-- audit submodule exports
-- audit runtime-only APIs
-- audit experimental/deferred surfaces
-- add targeted guards against accidental exports
-- update `API_STABILITY.md` only for actual public API changes or omissions
+- added a focused API stability audit test
+- verified `docs/specs/API_STABILITY.md` documents:
+  - the `v0.10` `pdelie.reporting` helpers
+  - the frozen `v0.8` weak residual report APIs
+  - the frozen `v0.9` KdV strong-path APIs
+  - deferred weak derivatives, broader weak methods, and operator symmetry as non-stable surfaces
+- verified root `pdelie` remains limited to canonical objects, base evaluator, and typed errors
+- verified runtime helpers remain submodule-only:
+  - data generators/adapters and robustness utilities
+  - derivative backend helper
+  - residual evaluators and weak report functions
+  - reporting helpers
+  - examples
+  - discovery, portability, symmetry, and visualization helpers
+- verified deferred/private names remain absent from public modules:
+  - weak KdV APIs
+  - `compute_weak_derivatives`
+  - public KdV coefficient helpers
+  - broad dataset adapter aliases
+  - operator-facing names
+- kept public-surface tests specific-name based rather than freezing entire module contents
+- did not change `API_STABILITY.md`; the audit found no mismatch
+- did not add runtime APIs, canonical objects, numerical scope, CI changes, README/changelog updates, release-readiness docs, or package metadata changes
 
 ### Acceptance Criteria
 
@@ -319,6 +336,6 @@ Milestone 6 -> release readiness and documentation alignment
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
-- Milestone 4: PENDING
+- Milestone 4: COMPLETE
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 0 complete**
+**V0.10 active; Milestone 1 complete**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -82,32 +82,46 @@ M0 is complete only if:
 
 ## Milestone 1 - Reporting Semantics Freeze
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Freeze exactly what `v0.10` supportability reporting means before runtime implementation.
 
-### Planned Scope
+### Completed Outcome
 
-- choose exact reporting helper names and import paths, if public helpers are justified
-- freeze return types and JSON-compatibility expectations
-- freeze which existing surfaces may be summarized:
-  - residual diagnostics
-  - generator fitting diagnostics
-  - verification reports
+- chose a new public runtime submodule for M2: `pdelie.reporting`
+- froze no root `pdelie` exports for reporting helpers
+- froze reporting helpers as runtime-level public APIs, not canonical objects
+- froze future M2 helper names:
+  - `summarize_residual_batch(...)`
+  - `summarize_weak_residual_report(...)`
+  - `summarize_generator_family(...)`
+  - `summarize_verification_report(...)`
+  - `summarize_vertical_slice(...)`
+- froze common reporting rules:
+  - JSON-compatible plain Python dict outputs
+  - NumPy arrays convert to lists
+  - NumPy scalars convert to Python scalars
+  - existing typed validation errors for invalid inputs
+  - no input mutation
+  - no canonical object creation or schema changes
+  - no manuscript-specific table, figure, threshold, or label logic
+- froze summary schemas:
+  - residual batch summaries
+  - weak residual report summaries
+  - generator family summaries
+  - verification report summaries
   - vertical-slice summaries
-  - release-gate support summaries
-- define deterministic representative inputs for reporting tests
-- explicitly decide whether helpers are public runtime APIs or internal helpers
-- explicitly avoid new canonical objects unless a repeated supportability problem proves they are necessary
+- left `API_STABILITY.md` unchanged because the public APIs are frozen for M2 but not implemented in M1
+- left runtime code, tests, README, changelog, release-readiness docs, package metadata, and CI unchanged
 
 ### Acceptance Criteria
 
 - exact reporting semantics are frozen before implementation
 - no manuscript-specific reporting logic is introduced
 - example outputs remain runtime smoke summaries, not canonical artifacts
-- `API_STABILITY.md` is still unchanged unless public reporting APIs land in this milestone
+- `API_STABILITY.md` remains unchanged until `pdelie.reporting` lands in M2
 
 ---
 
@@ -272,7 +286,7 @@ Milestone 6 -> release readiness and documentation alignment
 
 - `v0.9`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: PENDING
+- Milestone 1: COMPLETE
 - Milestone 2: PENDING
 - Milestone 3: PENDING
 - Milestone 4: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Current Release Status
 
-**V0.10 active; Milestone 5 complete**
+**V0.10 complete; ready for direct `v0.10.0` tag after release PR CI**
 
 This file is the active execution record for the `v0.10` release series.
 
@@ -288,19 +288,39 @@ Reduce CI release-gate sprawl while keeping historical release-gate tests runnab
 
 ## Milestone 6 - Release Readiness and Documentation Alignment
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Close `v0.10` with aligned release-facing docs, package metadata, release gate, and final tag checklist.
 
-### Planned Scope
+### Completed Outcome
 
-- update README, changelog, and release-readiness docs
-- update package version for the `v0.10` release
-- record the `v1.0` package-index publishing decision
-- document final local validation requirements
-- verify no new numerical scope landed
+- updated package metadata to `0.10.0`
+- updated README framing from `v0.9` to `v0.10`
+- documented `pdelie.reporting` supportability helpers and nested example summaries
+- added `CHANGELOG.md` entry for `0.10.0`
+- created `docs/releases/V0_10_RELEASE_READINESS.md`
+- updated `docs/releases/PUBLISHING.md` to include `v0.10.0` in the Git-tag-only `v0.x` release policy
+- updated `docs/planning/ROADMAP.md` so `v0.10` is the current completed release and `v0.11` remains conditional/planned
+- audited `docs/specs/API_STABILITY.md`; no changes were required
+- recorded final release checks:
+  - full pytest
+  - source/wheel build
+  - clean wheel smoke using `dist/pdelie-0.10.0-py3-none-any.whl`
+  - Heat and KdV example module execution
+  - `git diff --check`
+- recorded required release PR CI checks:
+  - `v0_10-release-gate`
+  - `editable-tests`
+  - `package-smoke`
+- recorded direct final Git tag path:
+  - merge release PR after CI is green
+  - tag merged `main` commit as `v0.10.0`
+  - do not publish to TestPyPI
+  - do not publish to PyPI
+  - defer package-index publishing until `v1.0` or later
+- verified no new PDE, weak KdV, weak derivative API, broad adapter, operator API, root runtime export, or canonical reporting object landed
 
 ### Acceptance Criteria
 
@@ -349,4 +369,4 @@ Milestone 6 -> release readiness and documentation alignment
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
 - Milestone 5: COMPLETE
-- Milestone 6: PENDING
+- Milestone 6: COMPLETE

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -256,6 +256,69 @@ Frozen release definition:
 
 ## Current Completed Release
 
+### `v0.10` - Supportability and `v1.0` readiness
+**Status:** Completed
+
+`v0.10` is the completed supportability release after the `v0.9` normalized periodic KdV strong-path release.
+
+Its purpose is:
+
+> harden the existing Heat/Burgers/weak-report/KdV engine into a more supportable public surface before adding more numerical scope.
+
+Completed stable scope:
+
+- compact runtime reporting helpers under `pdelie.reporting`
+- consistent Heat/KdV example summaries through nested `vertical_slice` reports
+- API stability audit across root exports, submodule exports, runtime-only APIs, and explicitly deferred surfaces
+- accidental-public-surface guards for stable and deferred APIs
+- CI release-gate cleanup:
+  - one current `v0_10-release-gate` CI job
+  - full editable test suite remains in CI
+  - historical release-gate tests remain runnable locally and covered by the full suite
+- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
+
+Completed release definition:
+
+`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
+
+Release interpretation:
+
+- this is a supportability release, not a new numerics release
+- reporting helpers are runtime supportability APIs, not canonical objects or manuscript artifact schemas
+- example outputs are runtime smoke summaries, not stable scientific-result schemas
+- `v0.10.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no new PDE in `v0.10`
+- no weak KdV API
+- no new weak derivative API
+- no broad benchmark adapters
+- no multidimensional or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no manuscript-specific reporting logic
+- no new canonical object
+
+The authoritative `v0.10` scope freeze belongs in:
+
+- `V0_10_SCOPE.md`
+
+### Release Gate for `v0.10`
+
+`v0.10` is complete only if:
+
+- reporting helpers are deterministic and scoped to existing runtime surfaces
+- example outputs remain JSON-serializable runtime smoke summaries, not canonical artifacts
+- API stability docs and public-surface tests agree
+- historical release-gate tests remain runnable locally
+- CI uses one current release-gate job plus full editable tests and package smoke
+- package/readiness docs state the `v1.0` publishing decision clearly
+- no new PDE, weak KdV, broad adapter, or operator scope lands
+
+---
+
+## Most Recent Prior Completed Release
+
 ### `v0.9` - Stable normalized periodic KdV strong path
 **Status:** Completed
 
@@ -316,62 +379,7 @@ The authoritative `v0.9` scope freeze belongs in:
 
 ---
 
-## Next Committed Release
-
-### `v0.10` - Supportability and `v1.0` readiness
-**Status:** Committed
-
-`v0.10` is the next committed release after the `v0.9` normalized periodic KdV strong-path release.
-
-Its purpose is:
-
-> harden the existing Heat/Burgers/weak-report/KdV engine into a more supportable public surface before adding more numerical scope.
-
-Committed stable direction:
-
-- compact runtime reporting helpers for existing residual, fit, verification, and vertical-slice outputs
-- consistent Heat/KdV example summaries where useful, without making example output a canonical artifact schema
-- API stability audit across root exports, submodule exports, runtime-only APIs, and explicitly experimental surfaces
-- accidental-public-surface guards for stable and deferred APIs
-- CI cleanup around release gates:
-  - keep historical gate tests runnable locally
-  - prefer one current-release-gate CI job instead of historical job sprawl
-- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
-- explicit decision record for whether package-index publishing resumes at `v1.0`
-
-Release definition:
-
-`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
-
-Explicit non-goals:
-
-- no new PDE in `v0.10`
-- no weak KdV API
-- no new weak derivative API
-- no broad benchmark adapters
-- no multidimensional or nonuniform-grid expansion
-- no operator-facing symmetry work
-- no new canonical object unless a repeated supportability problem proves one is necessary
-
-The authoritative `v0.10` scope freeze belongs in:
-
-- `V0_10_SCOPE.md` once frozen
-
-### Release Gate for `v0.10`
-
-`v0.10` is complete only if:
-
-- reporting helpers are deterministic and scoped to existing runtime surfaces
-- example outputs remain JSON-serializable runtime smoke summaries, not canonical artifacts
-- API stability docs and public-surface tests agree
-- historical release-gate tests remain runnable locally
-- CI no longer depends on redundant historical release-gate jobs unless intentionally retained
-- package/readiness docs state the `v1.0` publishing decision clearly
-- no new PDE, weak KdV, broad adapter, or operator scope lands
-
----
-
-## Most Recent Prior Completed Release
+## Earlier Completed Release
 
 ### `v0.8` — Window-indexed weak residuals
 **Status:** Completed

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -316,6 +316,61 @@ The authoritative `v0.9` scope freeze belongs in:
 
 ---
 
+## Next Committed Release
+
+### `v0.10` - Supportability and `v1.0` readiness
+**Status:** Committed
+
+`v0.10` is the next committed release after the `v0.9` normalized periodic KdV strong-path release.
+
+Its purpose is:
+
+> harden the existing Heat/Burgers/weak-report/KdV engine into a more supportable public surface before adding more numerical scope.
+
+Committed stable direction:
+
+- compact runtime reporting helpers for existing residual, fit, verification, and vertical-slice outputs
+- consistent Heat/KdV example summaries where useful, without making example output a canonical artifact schema
+- API stability audit across root exports, submodule exports, runtime-only APIs, and explicitly experimental surfaces
+- accidental-public-surface guards for stable and deferred APIs
+- CI cleanup around release gates:
+  - keep historical gate tests runnable locally
+  - prefer one current-release-gate CI job instead of historical job sprawl
+- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
+- explicit decision record for whether package-index publishing resumes at `v1.0`
+
+Release definition:
+
+`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
+
+Explicit non-goals:
+
+- no new PDE in `v0.10`
+- no weak KdV API
+- no new weak derivative API
+- no broad benchmark adapters
+- no multidimensional or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no new canonical object unless a repeated supportability problem proves one is necessary
+
+The authoritative `v0.10` scope freeze belongs in:
+
+- `V0_10_SCOPE.md` once frozen
+
+### Release Gate for `v0.10`
+
+`v0.10` is complete only if:
+
+- reporting helpers are deterministic and scoped to existing runtime surfaces
+- example outputs remain JSON-serializable runtime smoke summaries, not canonical artifacts
+- API stability docs and public-surface tests agree
+- historical release-gate tests remain runnable locally
+- CI no longer depends on redundant historical release-gate jobs unless intentionally retained
+- package/readiness docs state the `v1.0` publishing decision clearly
+- no new PDE, weak KdV, broad adapter, or operator scope lands
+
+---
+
 ## Most Recent Prior Completed Release
 
 ### `v0.8` — Window-indexed weak residuals
@@ -375,6 +430,45 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
+### `v0.11` - Next strong-path PDE feasibility or promotion
+**Status:** Planned / Conditional
+
+`v0.11` may add the next stable strong-path PDE only if `v0.10` leaves the public engine clean and the new PDE passes a serious feasibility/scope-freeze phase.
+
+Likely direction:
+
+- Kuramoto-Sivashinsky or another scalar 1D periodic strong-path PDE
+
+Required before commitment:
+
+- exact equation normalization
+- derivative-order requirements
+- generator stability regime
+- residual evaluator contract
+- vertical-slice thresholds with observed margin
+- imported-parity expectations
+- explicit non-goals around weak forms, broad adapters, and general PDE support
+
+Interpretation:
+
+- Kuramoto-Sivashinsky is attractive because it stress-tests higher-order scalar periodic numerics
+- it should not be promoted until stiffness, rollout stability, derivative accuracy, and residual thresholds are controlled
+- `v0.11` should start as a feasibility/scope-freeze effort, not assume stable promotion from the outset
+
+### `v0.12+` - Later PDE and dataset coverage
+**Status:** Planned
+
+Later PDE and dataset coverage remains planned after the supportability release and any conditional `v0.11` strong-path work.
+
+Candidate directions:
+
+- wave equation only after second-time-derivative semantics are frozen
+- reaction-diffusion systems after multivariable semantics are explicitly scoped
+- PDEBench / The Well adapters after generic ingestion and provenance policies are proven
+- multidimensional structured grids only after the 1D path is stable and supportable
+
+Each of these requires its own scope freeze before implementation.
+
 ### `v1.0` - Stable public engine
 **Status:** Deferred
 
@@ -389,19 +483,6 @@ The authoritative `v0.7` scope freeze belongs in:
 - selected stable strong-form PDE paths
 
 `v1.0` should be a stabilization milestone, not a scope-expansion milestone.
-
-### Later / Planned - Additional PDE and dataset coverage
-**Status:** Planned
-
-Additional PDE and dataset coverage remains planned after the stable KdV strong path.
-
-Candidate directions:
-
-- wave equation after second-time-derivative semantics are clarified
-- reaction-diffusion systems
-- Kuramoto-Sivashinsky as a harder high-derivative stress test
-- PDEBench / The Well adapters after generic ingestion is proven
-- multidimensional structured grids if the 1D path is stable
 
 ### Later / Experimental - Operator-facing symmetry discovery
 **Status:** Experimental / Deferred
@@ -427,6 +508,7 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_7_SCOPE.md` once frozen
 - `V0_8_SCOPE.md` once frozen
 - `V0_9_SCOPE.md` once frozen
+- `V0_10_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -460,5 +542,8 @@ It should **not** be edited every time a new idea appears.
 - `v0.7` = structured external data ingestion into canonical `FieldBatch`
 - `v0.8` = window-indexed weak residual reports and representative robustness comparisons
 - `v0.9` = stable normalized periodic short-horizon KdV strong path
+- `v0.10` = supportability and `v1.0` readiness for the existing stable engine
+- `v0.11` = conditional next strong-path PDE feasibility or promotion
+- `v0.12+` = wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/V0_10_SCOPE.md
+++ b/docs/planning/V0_10_SCOPE.md
@@ -41,34 +41,147 @@ Committed supportability directions:
 
 ## Public API Policy
 
-No new `v0.10` public API is frozen in M0.
+M1 freezes a new runtime-level public helper surface for M2:
 
-If `v0.10` adds reporting helpers, M1 must freeze their exact names, import paths, return shape, and non-goals before implementation.
+- `pdelie.reporting`
 
-Any new `v0.10` reporting helper must be:
+This is a public runtime submodule.
+It is not a canonical object system.
+It has no root `pdelie` exports.
+
+Frozen M2 public APIs:
+
+```python
+summarize_residual_batch(residual: ResidualBatch) -> dict[str, Any]
+summarize_weak_residual_report(report: Mapping[str, Any]) -> dict[str, Any]
+summarize_generator_family(generator: GeneratorFamily) -> dict[str, Any]
+summarize_verification_report(report: VerificationReport) -> dict[str, Any]
+summarize_vertical_slice(
+    *,
+    derivatives: DerivativeBatch,
+    residual: ResidualBatch,
+    generator: GeneratorFamily,
+    verification: VerificationReport,
+    extra_metrics: Mapping[str, Any] | None = None,
+) -> dict[str, Any]
+```
+
+Frozen common reporting rules:
 
 - runtime-level, not a canonical object
-- deterministic for frozen representative inputs
-- JSON-compatible or explicitly documented as runtime-only if NumPy arrays are returned
+- deterministic for identical inputs
+- JSON-compatible plain Python dict outputs
+- NumPy arrays become lists
+- NumPy scalar values become Python scalar values
+- input object types and required report keys are validated
+- validation failures use existing typed validation errors
 - scoped to existing stable surfaces
-- documented in `API_STABILITY.md` in the same milestone where the public API lands
-
-No root `pdelie` export should be added for new `v0.10` helper APIs unless the scope freeze explicitly justifies it.
+- no helper mutates its inputs
+- no helper creates or changes canonical objects
+- no manuscript-specific table, figure, threshold, or label logic
+- no root `pdelie` exports
+- `API_STABILITY.md` is updated in M2 when these APIs land
 
 ---
 
-## Reporting Helper Direction
+## Reporting Helper Schemas
 
-`v0.10` may add compact reporting helpers for supportability.
-Exact helper names and schemas are deferred to M1.
+Every reporting helper returns a dict containing:
 
-Candidate reporting targets:
+- `summary_schema_version = "0.1"`
+- `summary_type`
 
-- residual diagnostics summaries
-- generator fitting summaries
-- verification report summaries
-- vertical-slice summaries
-- release-gate support summaries
+### ResidualBatch Summary
+
+`summarize_residual_batch(...)` freezes these keys:
+
+- `summary_schema_version`
+- `summary_type = "residual_batch"`
+- `residual_shape`
+- `definition_type`
+- `normalization`
+- `max_abs_residual`
+- `rms_residual`
+- `diagnostics`
+
+`max_abs_residual` and `rms_residual` are computed from `residual.residual`.
+The original diagnostics are preserved after JSON-safe conversion.
+
+### Weak Residual Report Summary
+
+`summarize_weak_residual_report(...)` freezes these keys:
+
+- `summary_schema_version`
+- `summary_type = "weak_residual_report"`
+- `equation`
+- `equation_form`
+- `method_family`
+- `normalization`
+- `window_residual_shape`
+- `max_abs_residual`
+- `l2_residual`
+- `diagnostics`
+
+The helper supports the frozen `v0.8` weak report shape only.
+It validates that the input mapping contains the frozen weak report keys before summarizing.
+
+### GeneratorFamily Summary
+
+`summarize_generator_family(...)` freezes these keys:
+
+- `summary_schema_version`
+- `summary_type = "generator_family"`
+- `parameterization`
+- `normalization`
+- `coefficient_shape`
+- `coefficients`
+- `generator_names`
+- `translation_span_distance`
+- `fit_mode`
+- `reference_fallback_used`
+- `fallback_reason`
+- `diagnostics`
+
+`translation_span_distance` is populated only for `polynomial_translation_affine`.
+For other parameterizations, it is `None`.
+Fit and fallback fields are read from diagnostics when present and otherwise reported as `None`.
+
+### VerificationReport Summary
+
+`summarize_verification_report(...)` freezes these keys:
+
+- `summary_schema_version`
+- `summary_type = "verification_report"`
+- `norm`
+- `classification`
+- `epsilon_values`
+- `error_curve`
+- `first_epsilon`
+- `first_error`
+- `max_error`
+- `diagnostics`
+
+`first_epsilon` and `first_error` are the first entries of the verification sweep.
+`max_error` is computed from `error_curve`.
+
+### Vertical Slice Summary
+
+`summarize_vertical_slice(...)` freezes these keys:
+
+- `summary_schema_version`
+- `summary_type = "vertical_slice"`
+- `derivative_backend`
+- `derivative_keys`
+- `derivative_config`
+- `derivative_diagnostics`
+- `residual`
+- `generator`
+- `verification`
+- `extra_metrics`
+
+The nested `residual`, `generator`, and `verification` values are produced by the corresponding summary helpers.
+`extra_metrics` is optional and JSON-safe converted when provided.
+It must not be used to smuggle manuscript-specific reporting logic into the runtime API.
 
 Reporting helpers must not:
 
@@ -99,12 +212,19 @@ Expected properties:
 ## API Stability Audit
 
 M0 audits `docs/specs/API_STABILITY.md` only.
+M1 freezes future public reporting APIs in planning docs only.
 
 Audit result for M0:
 
 - all public APIs through `v0.9` remain documented
 - no `v0.10` public API has landed yet
 - `API_STABILITY.md` should remain unchanged until reporting helpers or other public APIs actually land
+
+M1 audit result:
+
+- `pdelie.reporting` APIs are frozen for M2 but not implemented yet
+- `API_STABILITY.md` remains unchanged in M1
+- M2 must update `API_STABILITY.md` when `pdelie.reporting` lands
 
 Future `v0.10` milestones must update `API_STABILITY.md` in the same milestone where any public API is added or changed.
 
@@ -188,6 +308,6 @@ Planned `v0.10` sequence:
 `API_STABILITY.md` is updated only when public APIs land:
 
 - M0 audits it but leaves it unchanged
-- M1 may freeze proposed public reporting contracts in planning docs only
-- M2 updates it if public reporting helpers land
+- M1 freezes public reporting contracts in planning docs only
+- M2 updates it when public reporting helpers land
 - later milestones update it only if they add or change public APIs

--- a/docs/planning/V0_10_SCOPE.md
+++ b/docs/planning/V0_10_SCOPE.md
@@ -1,0 +1,193 @@
+# V0.10 Scope Freeze
+
+## Summary
+
+`v0.10` is the supportability and `v1.0` readiness release for `pdelie`.
+
+Its purpose is:
+
+> harden the existing Heat/Burgers/weak-report/KdV engine into a more supportable public surface before adding more numerical scope.
+
+Stable release definition:
+
+`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
+
+`v0.10` is not a new numerics release.
+It does not add another PDE, weak KdV, broad adapters, multidimensional grids, or operator-facing work.
+
+---
+
+## Stable Scope
+
+Stable `v0.10` scope is limited to supportability work around the surfaces already stable through `v0.9`:
+
+- canonical Heat/Burgers strong paths
+- window-indexed weak Heat/Burgers report APIs
+- structured `from_numpy(...)` and `from_xarray(...)` ingestion
+- normalized periodic short-horizon KdV strong path
+- polynomial translation fitting and held-out verification
+- existing examples and release gates
+- package, publishing, and release-readiness documentation
+
+Committed supportability directions:
+
+- compact runtime reporting helpers over existing residual, fit, verification, and vertical-slice outputs
+- consistent example summaries where useful
+- API stability audit and accidental-public-surface guards
+- CI release-gate cleanup
+- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
+
+---
+
+## Public API Policy
+
+No new `v0.10` public API is frozen in M0.
+
+If `v0.10` adds reporting helpers, M1 must freeze their exact names, import paths, return shape, and non-goals before implementation.
+
+Any new `v0.10` reporting helper must be:
+
+- runtime-level, not a canonical object
+- deterministic for frozen representative inputs
+- JSON-compatible or explicitly documented as runtime-only if NumPy arrays are returned
+- scoped to existing stable surfaces
+- documented in `API_STABILITY.md` in the same milestone where the public API lands
+
+No root `pdelie` export should be added for new `v0.10` helper APIs unless the scope freeze explicitly justifies it.
+
+---
+
+## Reporting Helper Direction
+
+`v0.10` may add compact reporting helpers for supportability.
+Exact helper names and schemas are deferred to M1.
+
+Candidate reporting targets:
+
+- residual diagnostics summaries
+- generator fitting summaries
+- verification report summaries
+- vertical-slice summaries
+- release-gate support summaries
+
+Reporting helpers must not:
+
+- redefine canonical object meaning
+- make example outputs canonical artifacts
+- encode manuscript-specific tables or figures
+- hide backend-specific caveats
+- broaden numerical scope
+
+---
+
+## Example Consistency
+
+Heat and KdV examples should be made more consistent where that improves supportability.
+
+Example outputs remain runtime smoke summaries.
+They are not stable canonical artifact schemas.
+
+Expected properties:
+
+- JSON-serializable plain Python values
+- deterministic for frozen example inputs
+- compact enough for command-line smoke checks
+- explicit about backend and verification classification
+
+---
+
+## API Stability Audit
+
+M0 audits `docs/specs/API_STABILITY.md` only.
+
+Audit result for M0:
+
+- all public APIs through `v0.9` remain documented
+- no `v0.10` public API has landed yet
+- `API_STABILITY.md` should remain unchanged until reporting helpers or other public APIs actually land
+
+Future `v0.10` milestones must update `API_STABILITY.md` in the same milestone where any public API is added or changed.
+
+---
+
+## CI Cleanup Direction
+
+`v0.10` should reduce release-gate CI sprawl without deleting useful historical tests.
+
+Target direction:
+
+- keep historical release-gate test modules runnable locally
+- keep the current release gate visible in CI
+- avoid redundant historical release-gate CI jobs unless intentionally retained
+- keep full editable tests and package smoke as required release checks
+- do not change test semantics just to make CI faster
+
+Exact workflow edits are deferred until the CI cleanup milestone.
+
+---
+
+## Package and Publishing Readiness
+
+`v0.10` should prepare the project for the `v1.0` publishing decision.
+
+Required decision record:
+
+- whether package-index publishing resumes at `v1.0`
+- whether `v0.10` remains Git-tag-only
+- what local build and wheel-smoke checks are required before any future publishable release
+- what CI jobs are required before tagging
+
+No PyPI or TestPyPI publication is added by this scope freeze.
+
+---
+
+## Scope Limits
+
+Stable `v0.10` scope is limited to:
+
+- supportability helpers around existing stable runtime surfaces
+- existing canonical objects
+- existing scalar 1D uniform rectilinear / periodic regimes
+- existing Heat, Burgers, weak Heat/Burgers report, and KdV strong-path surfaces
+- documentation and CI release-process cleanup
+
+---
+
+## Explicit Non-goals
+
+Out of stable `v0.10` scope:
+
+- no new PDE
+- no weak KdV API
+- no new weak derivative API
+- no KdV weak residual report
+- no broad benchmark adapters
+- no PDEBench or The Well adapter work
+- no multidimensional grids
+- no multivariable systems
+- no nonuniform-grid expansion
+- no operator-method expansion
+- no neural generators
+- no manuscript-specific reporting logic
+- no new canonical object unless M1 proves a repeated supportability problem cannot be solved with runtime helpers
+
+---
+
+## Milestones
+
+Planned `v0.10` sequence:
+
+- Milestone 0 - supportability scope reset
+- Milestone 1 - reporting semantics freeze
+- Milestone 2 - reporting helper implementation
+- Milestone 3 - example consistency
+- Milestone 4 - API stability audit and public-surface guards
+- Milestone 5 - CI cleanup and release-gate consolidation
+- Milestone 6 - release readiness and documentation alignment
+
+`API_STABILITY.md` is updated only when public APIs land:
+
+- M0 audits it but leaves it unchanged
+- M1 may freeze proposed public reporting contracts in planning docs only
+- M2 updates it if public reporting helpers land
+- later milestones update it only if they add or change public APIs

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.9.0`, release completion means:
+For the current `v0.x` series, including `v0.10.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.9.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.9`.
+`v0.10.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.10`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_10_RELEASE_READINESS.md
+++ b/docs/releases/V0_10_RELEASE_READINESS.md
@@ -1,0 +1,141 @@
+# V0.10 Release Readiness
+
+## Release Target
+
+- package version: `0.10.0`
+- git tag: `v0.10.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.10.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.10`.
+
+## Done
+
+- M0 is complete:
+  - `v0.10` was frozen as a supportability and `v1.0` readiness release
+  - `v0.9` was recorded as complete
+  - `v0.11` remains conditional, not committed
+- M1 is complete:
+  - `pdelie.reporting` was chosen as a public runtime submodule
+  - reporting helpers were frozen as JSON-compatible supportability summaries, not canonical objects
+- M2 is complete:
+  - `pdelie.reporting.summarize_residual_batch(...)` is implemented
+  - `pdelie.reporting.summarize_weak_residual_report(...)` is implemented
+  - `pdelie.reporting.summarize_generator_family(...)` is implemented
+  - `pdelie.reporting.summarize_verification_report(...)` is implemented
+  - `pdelie.reporting.summarize_vertical_slice(...)` is implemented
+  - `API_STABILITY.md` documents the new runtime public APIs
+- M3 is complete:
+  - Heat and KdV vertical-slice examples return nested `vertical_slice` summaries
+  - example command entrypoints remain unchanged
+  - example outputs remain runtime smoke summaries, not canonical artifact schemas
+- M4 is complete:
+  - API stability audit coverage was added
+  - root exports, submodule APIs, and deferred surfaces are guarded by tests
+  - `API_STABILITY.md` needed no further changes
+- M5 is complete:
+  - CI release-gate visibility was consolidated to one current `v0_10-release-gate` job
+  - historical release-gate test modules remain in the repo
+  - historical gates remain covered by full editable tests
+- M6 is complete:
+  - package metadata and release-facing docs are aligned with `0.10.0`
+  - this readiness note is current
+  - final release checks are documented for local execution and release PR CI
+
+## Public API Notes
+
+New stable runtime APIs in `v0.10`:
+
+- `pdelie.reporting.summarize_residual_batch`
+- `pdelie.reporting.summarize_weak_residual_report`
+- `pdelie.reporting.summarize_generator_family`
+- `pdelie.reporting.summarize_verification_report`
+- `pdelie.reporting.summarize_vertical_slice`
+
+These helpers:
+
+- are exported from `pdelie.reporting` only
+- have no root `pdelie` exports
+- return JSON-compatible runtime dicts
+- are supportability helpers, not canonical objects
+- do not define manuscript tables, figures, labels, or artifact schemas
+
+Retained stable surfaces include:
+
+- Heat and Burgers strong paths
+- `v0.8` weak Heat/Burgers residual report APIs
+- `v0.9` normalized periodic short-horizon KdV strong path
+- structured `from_numpy(...)` and optional `from_xarray(...)` ingestion
+- polynomial translation fitting and held-out verification
+- existing discovery, portability, symmetry, and visualization runtime helpers
+
+## Explicitly Deferred
+
+- new PDE support
+- weak KdV APIs
+- weak derivative APIs or broader weak-form expansion
+- PDEBench, The Well, or other broad dataset adapters
+- multidimensional, multivariable, or nonuniform-grid support
+- operator-facing APIs
+- manuscript-specific reporting logic
+- new canonical reporting objects
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
+## CI Expectations
+
+Before tagging `v0.10.0`, the release PR should have these CI jobs green:
+
+- `v0_10-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+Historical release-gate test modules remain runnable locally and are covered by `editable-tests`.
+They are no longer separate named CI jobs in `v0.10`.
+
+## Local Release Checklist
+
+Before tagging `v0.10.0`:
+
+1. Inspect consistency across:
+   - `pyproject.toml`
+   - `README.md`
+   - `CHANGELOG.md`
+   - `docs/releases/V0_10_RELEASE_READINESS.md`
+   - `docs/releases/PUBLISHING.md`
+   - `docs/specs/API_STABILITY.md`
+2. Run the full test suite:
+   - `python -m pytest`
+3. Build the package:
+   - `python -m build --sdist --wheel`
+4. Install `dist/pdelie-0.10.0-py3-none-any.whl` into a clean environment and verify:
+   - stable root imports
+   - `pdelie.reporting` helper imports from the submodule
+   - root `pdelie` does not export reporting helpers
+   - one tiny weak Heat report
+   - one tiny KdV strong-path residual
+   - one nested `vertical_slice` example summary shape check
+5. Run examples:
+   - `python -m pdelie.examples.heat_vertical_slice`
+   - `python -m pdelie.examples.kdv_vertical_slice`
+6. Run:
+   - `git diff --check`
+
+## Direct Final Tag Checklist
+
+After local checks and CI pass:
+
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.10.0`
+- do not publish to TestPyPI
+- do not publish to PyPI
+- record package-index publishing as deferred until `v1.0` or later
+
+## Final Release View
+
+`v0.10.0` is ready when the local release checklist and the current CI jobs pass.
+
+The stable release claim is intentionally narrow:
+
+`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
+
+There are no new numerical claims in `v0.10`.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -127,6 +127,16 @@ Runtime public API for the frozen `v0.9` Milestone 3 slice:
 - this API has no root `pdelie` export
 - this API does not expose configurable KdV coefficients or weak KdV behavior in `v0.9`
 
+Runtime public API for the frozen `v0.10` Milestone 2 slice:
+
+- `pdelie.reporting.summarize_residual_batch` for JSON-compatible runtime summaries of `ResidualBatch` residual shape, definition type, normalization, residual norms, and diagnostics
+- `pdelie.reporting.summarize_weak_residual_report` for JSON-compatible runtime summaries of frozen `v0.8` weak residual report mappings
+- `pdelie.reporting.summarize_generator_family` for JSON-compatible runtime summaries of `GeneratorFamily` coefficients, parameterization, normalization, translation span distance when applicable, and fitting diagnostics
+- `pdelie.reporting.summarize_verification_report` for JSON-compatible runtime summaries of `VerificationReport` epsilon sweeps, classification, first-error metrics, and diagnostics
+- `pdelie.reporting.summarize_vertical_slice` for JSON-compatible runtime summaries that combine derivative metadata plus residual, generator, verification, and optional extra metrics summaries
+- these APIs are runtime supportability helpers, not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.9.0"
-description = "V0.9 normalized periodic KdV strong path with weak residual reports, structured ingestion, and symmetry/discovery utilities"
+version = "0.10.0"
+description = "V0.10 supportability reporting, consistent examples, and release-gate cleanup for the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/examples/heat_vertical_slice.py
+++ b/src/pdelie/examples/heat_vertical_slice.py
@@ -4,15 +4,31 @@ import json
 
 from pdelie.data import generate_heat_1d_field_batch
 from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.reporting import summarize_vertical_slice
 from pdelie.residuals import HeatResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
-from pdelie.symmetry.parameterization import translation_span_distance
 from pdelie.verification import verify_translation_generator
 
 
+_TRAINING_SEED = 100
+_HELDOUT_SEED = 101
+_TRAINING_BATCH_SIZE = 4
+_HELDOUT_BATCH_SIZE = 3
+
+
 def run_heat_vertical_slice_example() -> dict[str, object]:
-    training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=100)
-    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=101)
+    training = generate_heat_1d_field_batch(
+        batch_size=_TRAINING_BATCH_SIZE,
+        num_times=33,
+        num_points=64,
+        seed=_TRAINING_SEED,
+    )
+    heldout = generate_heat_1d_field_batch(
+        batch_size=_HELDOUT_BATCH_SIZE,
+        num_times=33,
+        num_points=64,
+        seed=_HELDOUT_SEED,
+    )
 
     derivatives = compute_spectral_fd_derivatives(training)
     residual_evaluator = HeatResidualEvaluator()
@@ -20,16 +36,20 @@ def run_heat_vertical_slice_example() -> dict[str, object]:
     generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
     report = verify_translation_generator(heldout, generator, residual_evaluator)
 
-    return {
-        "backend": derivatives.backend,
-        "max_abs_residual": residual.diagnostics["max_abs_residual"],
-        "parameterization": generator.parameterization,
-        "coefficients": generator.coefficients.tolist(),
-        "span_distance": translation_span_distance(generator.coefficients),
-        "verification_classification": report.classification,
-        "epsilon_values": report.epsilon_values.tolist(),
-        "error_curve": report.error_curve.tolist(),
-    }
+    return summarize_vertical_slice(
+        derivatives=derivatives,
+        residual=residual,
+        generator=generator,
+        verification=report,
+        extra_metrics={
+            "example_name": "heat_vertical_slice",
+            "equation": "heat_1d",
+            "training_seed": _TRAINING_SEED,
+            "heldout_seed": _HELDOUT_SEED,
+            "training_batch_size": _TRAINING_BATCH_SIZE,
+            "heldout_batch_size": _HELDOUT_BATCH_SIZE,
+        },
+    )
 
 
 def main() -> None:

--- a/src/pdelie/examples/kdv_vertical_slice.py
+++ b/src/pdelie/examples/kdv_vertical_slice.py
@@ -6,10 +6,16 @@ import numpy as np
 
 from pdelie.data import generate_kdv_1d_field_batch, split_batch_train_heldout
 from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.reporting import summarize_vertical_slice
 from pdelie.residuals import KdVResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
-from pdelie.symmetry.parameterization import translation_span_distance
 from pdelie.verification import verify_translation_generator
+
+
+_GENERATOR_SEED = 9001
+_BATCH_SIZE = 5
+_TRAIN_SIZE = 2
+_SPLIT_SEED = 9002
 
 
 def _mass_and_l2_drift(values: np.ndarray, *, dx: float) -> tuple[float, float]:
@@ -22,10 +28,10 @@ def _mass_and_l2_drift(values: np.ndarray, *, dx: float) -> tuple[float, float]:
 
 
 def run_kdv_vertical_slice_example() -> dict[str, object]:
-    field = generate_kdv_1d_field_batch(batch_size=5, seed=9001)
+    field = generate_kdv_1d_field_batch(batch_size=_BATCH_SIZE, seed=_GENERATOR_SEED)
     dx = float(field.coords["x"][1] - field.coords["x"][0])
     mass_drift, relative_l2_drift = _mass_and_l2_drift(field.values, dx=dx)
-    training, heldout = split_batch_train_heldout(field, train_size=2, seed=9002)
+    training, heldout = split_batch_train_heldout(field, train_size=_TRAIN_SIZE, seed=_SPLIT_SEED)
 
     derivatives = compute_spectral_fd_derivatives(training, max_spatial_order=3)
     residual_evaluator = KdVResidualEvaluator()
@@ -33,21 +39,22 @@ def run_kdv_vertical_slice_example() -> dict[str, object]:
     generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
     report = verify_translation_generator(heldout, generator, residual_evaluator)
 
-    return {
-        "backend": str(derivatives.backend),
-        "max_abs_residual": float(residual.diagnostics["max_abs_residual"]),
-        "rms_residual": float(residual.diagnostics["rms_residual"]),
-        "mass_drift": mass_drift,
-        "relative_l2_drift": relative_l2_drift,
-        "parameterization": str(generator.parameterization),
-        "coefficients": generator.coefficients.tolist(),
-        "fit_mode": str(generator.diagnostics["fit_mode"]),
-        "reference_fallback_used": bool(generator.diagnostics["reference_fallback_used"]),
-        "span_distance": float(translation_span_distance(generator.coefficients)),
-        "verification_classification": str(report.classification),
-        "epsilon_values": report.epsilon_values.tolist(),
-        "error_curve": report.error_curve.tolist(),
-    }
+    return summarize_vertical_slice(
+        derivatives=derivatives,
+        residual=residual,
+        generator=generator,
+        verification=report,
+        extra_metrics={
+            "example_name": "kdv_vertical_slice",
+            "equation": "kdv_normalized",
+            "generator_seed": _GENERATOR_SEED,
+            "batch_size": _BATCH_SIZE,
+            "split_seed": _SPLIT_SEED,
+            "train_size": _TRAIN_SIZE,
+            "mass_drift": mass_drift,
+            "relative_l2_drift": relative_l2_drift,
+        },
+    )
 
 
 def main() -> None:

--- a/src/pdelie/reporting/__init__.py
+++ b/src/pdelie/reporting/__init__.py
@@ -1,0 +1,15 @@
+from pdelie.reporting.summaries import (
+    summarize_generator_family,
+    summarize_residual_batch,
+    summarize_verification_report,
+    summarize_vertical_slice,
+    summarize_weak_residual_report,
+)
+
+__all__ = [
+    "summarize_generator_family",
+    "summarize_residual_batch",
+    "summarize_verification_report",
+    "summarize_vertical_slice",
+    "summarize_weak_residual_report",
+]

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from pdelie.contracts import DerivativeBatch, GeneratorFamily, ResidualBatch, VerificationReport
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.symmetry.parameterization import translation_span_distance
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_WEAK_REPORT_KEYS = frozenset(
+    {
+        "equation",
+        "equation_form",
+        "method_family",
+        "window_residuals",
+        "time_window_centers",
+        "x_window_centers",
+        "normalization",
+        "diagnostics",
+    }
+)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _validate_json_compatible(value: Any, *, name: str) -> Any:
+    safe_value = _json_safe(value)
+    try:
+        json.dumps(safe_value)
+    except TypeError as exc:
+        raise SchemaValidationError(f"{name} must be JSON-compatible after reporting conversion.") from exc
+    return safe_value
+
+
+def _require_finite(array: np.ndarray, *, name: str) -> np.ndarray:
+    normalized = np.asarray(array, dtype=float)
+    if not np.all(np.isfinite(normalized)):
+        raise ScopeValidationError(f"{name} must contain finite values.")
+    return normalized
+
+
+def _require_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _summary_payload(summary_type: str, **items: Any) -> dict[str, Any]:
+    payload = {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": summary_type,
+        **items,
+    }
+    return _validate_json_compatible(payload, name=f"{summary_type} summary")
+
+
+def summarize_residual_batch(residual: ResidualBatch) -> dict[str, Any]:
+    if not isinstance(residual, ResidualBatch):
+        raise SchemaValidationError("summarize_residual_batch requires a ResidualBatch.")
+
+    residual_values = _require_finite(residual.residual, name="ResidualBatch.residual")
+    return _summary_payload(
+        "residual_batch",
+        residual_shape=list(residual_values.shape),
+        definition_type=residual.definition_type,
+        normalization=residual.normalization,
+        max_abs_residual=float(np.max(np.abs(residual_values))),
+        rms_residual=float(np.sqrt(np.mean(np.square(residual_values)))),
+        diagnostics=residual.diagnostics,
+    )
+
+
+def summarize_weak_residual_report(report: Mapping[str, Any]) -> dict[str, Any]:
+    report_mapping = _require_mapping(report, name="weak residual report")
+    missing = sorted(_WEAK_REPORT_KEYS.difference(report_mapping))
+    if missing:
+        raise SchemaValidationError(f"weak residual report is missing required fields: {missing}.")
+
+    diagnostics = _require_mapping(report_mapping["diagnostics"], name="weak residual report diagnostics")
+    window_residuals = _require_finite(
+        np.asarray(report_mapping["window_residuals"], dtype=float),
+        name="weak residual report window_residuals",
+    )
+    if window_residuals.ndim != 4 or window_residuals.shape[-1] != 1:
+        raise SchemaValidationError(
+            "weak residual report window_residuals must have shape (batch, time_window, x_window, 1)."
+        )
+
+    return _summary_payload(
+        "weak_residual_report",
+        equation=str(report_mapping["equation"]),
+        equation_form=str(report_mapping["equation_form"]),
+        method_family=str(report_mapping["method_family"]),
+        normalization=str(report_mapping["normalization"]),
+        window_residual_shape=list(window_residuals.shape),
+        max_abs_residual=float(np.max(np.abs(window_residuals))),
+        l2_residual=float(np.linalg.norm(window_residuals.ravel(), ord=2)),
+        diagnostics=diagnostics,
+    )
+
+
+def summarize_generator_family(generator: GeneratorFamily) -> dict[str, Any]:
+    if not isinstance(generator, GeneratorFamily):
+        raise SchemaValidationError("summarize_generator_family requires a GeneratorFamily.")
+
+    coefficients = _require_finite(generator.coefficients, name="GeneratorFamily.coefficients")
+    translation_distance = (
+        float(translation_span_distance(coefficients))
+        if generator.parameterization == "polynomial_translation_affine"
+        else None
+    )
+    diagnostics = dict(generator.diagnostics)
+
+    return _summary_payload(
+        "generator_family",
+        parameterization=generator.parameterization,
+        normalization=generator.normalization,
+        coefficient_shape=list(coefficients.shape),
+        coefficients=coefficients,
+        generator_names=generator.generator_names,
+        translation_span_distance=translation_distance,
+        fit_mode=diagnostics.get("fit_mode"),
+        reference_fallback_used=diagnostics.get("reference_fallback_used"),
+        fallback_reason=diagnostics.get("fallback_reason"),
+        diagnostics=diagnostics,
+    )
+
+
+def summarize_verification_report(report: VerificationReport) -> dict[str, Any]:
+    if not isinstance(report, VerificationReport):
+        raise SchemaValidationError("summarize_verification_report requires a VerificationReport.")
+
+    epsilon_values = _require_finite(report.epsilon_values, name="VerificationReport.epsilon_values")
+    error_curve = _require_finite(report.error_curve, name="VerificationReport.error_curve")
+
+    return _summary_payload(
+        "verification_report",
+        norm=report.norm,
+        classification=report.classification,
+        epsilon_values=epsilon_values,
+        error_curve=error_curve,
+        first_epsilon=float(epsilon_values[0]),
+        first_error=float(error_curve[0]),
+        max_error=float(np.max(error_curve)),
+        diagnostics=report.diagnostics,
+    )
+
+
+def summarize_vertical_slice(
+    *,
+    derivatives: DerivativeBatch,
+    residual: ResidualBatch,
+    generator: GeneratorFamily,
+    verification: VerificationReport,
+    extra_metrics: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(derivatives, DerivativeBatch):
+        raise SchemaValidationError("summarize_vertical_slice requires derivatives to be a DerivativeBatch.")
+    if extra_metrics is None:
+        normalized_extra_metrics: Mapping[str, Any] = {}
+    else:
+        normalized_extra_metrics = _require_mapping(extra_metrics, name="extra_metrics")
+
+    return _summary_payload(
+        "vertical_slice",
+        derivative_backend=derivatives.backend,
+        derivative_keys=sorted(str(name) for name in derivatives.derivatives),
+        derivative_config=derivatives.config,
+        derivative_diagnostics=derivatives.diagnostics,
+        residual=summarize_residual_batch(residual),
+        generator=summarize_generator_family(generator),
+        verification=summarize_verification_report(verification),
+        extra_metrics=normalized_extra_metrics,
+    )

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pdelie
+
+
+_ROOT_RUNTIME_NAMES = {
+    "InvariantApplier",
+    "add_gaussian_noise",
+    "build_translation_canonical_discovery_inputs",
+    "coerce_generator_family",
+    "compare_generator_spans",
+    "compute_spectral_fd_derivatives",
+    "diagnose_generator_family_closure",
+    "evaluate_discovery_recovery",
+    "evaluate_weak_burgers_residual",
+    "evaluate_weak_heat_residual",
+    "export_generator_family_manifest",
+    "fit_pysindy_discovery",
+    "fit_translation_generator",
+    "from_numpy",
+    "from_xarray",
+    "generate_burgers_1d_field_batch",
+    "generate_heat_1d_field_batch",
+    "generate_kdv_1d_field_batch",
+    "import_generator_family_manifest",
+    "plot_closure_diagnostics",
+    "plot_generator_coefficients",
+    "plot_generator_symbolic_summary",
+    "plot_span_diagnostics",
+    "plot_verification_curve",
+    "render_generator_family",
+    "run_heat_vertical_slice_example",
+    "run_kdv_vertical_slice_example",
+    "split_batch_train_heldout",
+    "subsample_time",
+    "subsample_x",
+    "summarize_generator_family",
+    "summarize_recovery_grid",
+    "summarize_residual_batch",
+    "summarize_verification_report",
+    "summarize_vertical_slice",
+    "summarize_weak_residual_report",
+    "to_pysindy_trajectories",
+    "to_sympy_component_expressions",
+}
+_DEFERRED_OR_PRIVATE_NAMES = {
+    "OperatorSymmetry",
+    "WeakBurgersResidualEvaluator",
+    "WeakHeatResidualEvaluator",
+    "WeakKdVResidualEvaluator",
+    "compute_weak_derivatives",
+    "evaluate_weak_kdv_residual",
+    "from_pdebench",
+    "from_the_well",
+    "load_pdebench",
+    "load_the_well",
+    "sample_kdv_mode_coefficients",
+}
+_V0_10_REPORTING_APIS = {
+    "pdelie.reporting.summarize_residual_batch",
+    "pdelie.reporting.summarize_weak_residual_report",
+    "pdelie.reporting.summarize_generator_family",
+    "pdelie.reporting.summarize_verification_report",
+    "pdelie.reporting.summarize_vertical_slice",
+}
+_V0_8_WEAK_APIS = {
+    "pdelie.residuals.evaluate_weak_heat_residual",
+    "pdelie.residuals.evaluate_weak_burgers_residual",
+}
+_V0_9_KDV_APIS = {
+    "pdelie.derivatives.compute_spectral_fd_derivatives(field, *, max_spatial_order=2)",
+    "pdelie.data.generate_kdv_1d_field_batch",
+    "pdelie.residuals.KdVResidualEvaluator",
+}
+
+
+def _api_stability_text() -> str:
+    return (Path(__file__).resolve().parents[1] / "docs/specs/API_STABILITY.md").read_text(encoding="utf-8")
+
+
+def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
+    text = _api_stability_text()
+
+    for api_name in sorted(_V0_10_REPORTING_APIS | _V0_8_WEAK_APIS | _V0_9_KDV_APIS):
+        assert api_name in text
+
+    assert "these APIs have no root `pdelie` exports" in text
+    assert "not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs" in text
+    assert "weak-form derivatives and weak-form methods beyond the frozen `v0.8` weak residual report slice" in text
+    assert "operator symmetry" in text
+
+
+def test_root_package_still_exposes_only_stable_canonical_surface() -> None:
+    for name in sorted(_ROOT_RUNTIME_NAMES | _DEFERRED_OR_PRIVATE_NAMES):
+        assert not hasattr(pdelie, name), name
+
+
+def test_required_runtime_submodule_apis_remain_importable() -> None:
+    required_by_module = {
+        "pdelie.data": {
+            "add_gaussian_noise",
+            "from_numpy",
+            "from_xarray",
+            "generate_burgers_1d_field_batch",
+            "generate_heat_1d_field_batch",
+            "generate_kdv_1d_field_batch",
+            "split_batch_train_heldout",
+            "subsample_time",
+            "subsample_x",
+        },
+        "pdelie.derivatives": {"compute_spectral_fd_derivatives"},
+        "pdelie.discovery": {
+            "build_translation_canonical_discovery_inputs",
+            "evaluate_discovery_recovery",
+            "fit_pysindy_discovery",
+            "summarize_recovery_grid",
+            "to_pysindy_trajectories",
+        },
+        "pdelie.examples": {"run_heat_vertical_slice_example", "run_kdv_vertical_slice_example"},
+        "pdelie.invariants": {"InvariantApplier"},
+        "pdelie.portability": {
+            "coerce_generator_family",
+            "export_generator_family_manifest",
+            "import_generator_family_manifest",
+        },
+        "pdelie.reporting": {
+            "summarize_generator_family",
+            "summarize_residual_batch",
+            "summarize_verification_report",
+            "summarize_vertical_slice",
+            "summarize_weak_residual_report",
+        },
+        "pdelie.residuals": {
+            "BurgersResidualEvaluator",
+            "HeatResidualEvaluator",
+            "KdVResidualEvaluator",
+            "ResidualEvaluator",
+            "evaluate_weak_burgers_residual",
+            "evaluate_weak_heat_residual",
+        },
+        "pdelie.symmetry": {
+            "compare_generator_spans",
+            "diagnose_generator_family_closure",
+            "fit_translation_generator",
+            "render_generator_family",
+            "to_sympy_component_expressions",
+        },
+        "pdelie.viz": {
+            "plot_closure_diagnostics",
+            "plot_generator_coefficients",
+            "plot_generator_symbolic_summary",
+            "plot_span_diagnostics",
+            "plot_verification_curve",
+        },
+    }
+
+    for module_name, names in required_by_module.items():
+        module = importlib.import_module(module_name)
+        for name in sorted(names):
+            assert hasattr(module, name), f"{module_name}.{name}"
+
+
+def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
+    modules = [
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.derivatives"),
+        importlib.import_module("pdelie.discovery"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.symmetry"),
+    ]
+
+    for module in modules:
+        for name in sorted(_DEFERRED_OR_PRIVATE_NAMES):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,39 +10,102 @@ import pdelie
 from pdelie.examples import run_heat_vertical_slice_example, run_kdv_vertical_slice_example
 
 
+def _assert_vertical_slice_summary(result: dict[str, object]) -> None:
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "vertical_slice"
+    assert result["derivative_backend"] == "spectral_fd"
+    assert result["residual"]["summary_type"] == "residual_batch"
+    assert result["generator"]["summary_type"] == "generator_family"
+    assert result["verification"]["summary_type"] == "verification_report"
+
+
+def _assert_repeated_summary_matches(first: dict[str, object], second: dict[str, object]) -> None:
+    for key in (
+        "summary_schema_version",
+        "summary_type",
+        "derivative_backend",
+        "derivative_keys",
+        "derivative_config",
+        "derivative_diagnostics",
+        "extra_metrics",
+    ):
+        assert first[key] == second[key]
+
+    for section in ("residual", "generator", "verification"):
+        for key, first_value in first[section].items():
+            second_value = second[section][key]
+            if key in {"coefficients", "epsilon_values", "error_curve"}:
+                np.testing.assert_allclose(np.asarray(first_value, dtype=float), np.asarray(second_value, dtype=float))
+            elif key in {
+                "max_abs_residual",
+                "rms_residual",
+                "translation_span_distance",
+                "first_epsilon",
+                "first_error",
+                "max_error",
+            }:
+                np.testing.assert_allclose(float(first_value), float(second_value))
+            else:
+                assert first_value == second_value
+
+
+def _run_module_json(module_name: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, "-m", module_name],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stderr == ""
+    return json.loads(completed.stdout)
+
+
 def test_heat_vertical_slice_example_runs_end_to_end() -> None:
     result = run_heat_vertical_slice_example()
-    assert result["backend"] == "spectral_fd"
-    assert result["parameterization"] == "polynomial_translation_affine"
-    assert result["verification_classification"] == "exact"
+    _assert_vertical_slice_summary(result)
+
+    assert result["extra_metrics"] == {
+        "example_name": "heat_vertical_slice",
+        "equation": "heat_1d",
+        "training_seed": 100,
+        "heldout_seed": 101,
+        "training_batch_size": 4,
+        "heldout_batch_size": 3,
+    }
+    assert result["generator"]["parameterization"] == "polynomial_translation_affine"
+    assert result["verification"]["classification"] == "exact"
+    assert result["verification"]["first_error"] < 1e-6
+    assert not hasattr(pdelie, "run_heat_vertical_slice_example")
 
 
 def test_heat_vertical_slice_example_is_deterministic() -> None:
     first = run_heat_vertical_slice_example()
     second = run_heat_vertical_slice_example()
 
-    assert first["verification_classification"] == second["verification_classification"]
-    assert first["backend"] == second["backend"]
-    assert first["parameterization"] == second["parameterization"]
-    assert first["coefficients"] == second["coefficients"]
-    assert first["error_curve"] == second["error_curve"]
+    _assert_repeated_summary_matches(first, second)
 
 
 def test_kdv_vertical_slice_example_runs_end_to_end_and_is_json_serializable() -> None:
     result = run_kdv_vertical_slice_example()
+    _assert_vertical_slice_summary(result)
 
-    assert json.loads(json.dumps(result)) == result
-    assert result["backend"] == "spectral_fd"
-    assert result["parameterization"] == "polynomial_translation_affine"
-    assert result["fit_mode"] == "svd"
-    assert result["reference_fallback_used"] is False
-    assert result["verification_classification"] != "failed"
-    assert result["max_abs_residual"] < 1e-2
-    assert result["rms_residual"] < 2e-3
-    assert result["mass_drift"] <= 1e-8
-    assert result["relative_l2_drift"] <= 5e-3
-    assert result["span_distance"] <= 5e-2
-    assert result["error_curve"][0] < 1e-4
+    assert result["extra_metrics"]["example_name"] == "kdv_vertical_slice"
+    assert result["extra_metrics"]["equation"] == "kdv_normalized"
+    assert result["extra_metrics"]["generator_seed"] == 9001
+    assert result["extra_metrics"]["split_seed"] == 9002
+    assert result["extra_metrics"]["train_size"] == 2
+    assert result["residual"]["max_abs_residual"] < 1e-2
+    assert result["residual"]["rms_residual"] < 2e-3
+    assert result["extra_metrics"]["mass_drift"] <= 1e-8
+    assert result["extra_metrics"]["relative_l2_drift"] <= 5e-3
+    assert result["generator"]["parameterization"] == "polynomial_translation_affine"
+    assert result["generator"]["fit_mode"] == "svd"
+    assert result["generator"]["reference_fallback_used"] is False
+    assert result["generator"]["translation_span_distance"] <= 5e-2
+    assert result["verification"]["classification"] != "failed"
+    assert result["verification"]["first_error"] < 1e-4
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
 
 
@@ -50,36 +113,18 @@ def test_kdv_vertical_slice_example_is_deterministic() -> None:
     first = run_kdv_vertical_slice_example()
     second = run_kdv_vertical_slice_example()
 
-    for key in (
-        "backend",
-        "parameterization",
-        "fit_mode",
-        "reference_fallback_used",
-        "verification_classification",
-    ):
-        assert first[key] == second[key]
-    for key in (
-        "max_abs_residual",
-        "rms_residual",
-        "mass_drift",
-        "relative_l2_drift",
-        "span_distance",
-        "coefficients",
-        "epsilon_values",
-        "error_curve",
-    ):
-        np.testing.assert_allclose(np.asarray(first[key], dtype=float), np.asarray(second[key], dtype=float))
+    _assert_repeated_summary_matches(first, second)
+
+
+def test_heat_vertical_slice_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.heat_vertical_slice")
+
+    _assert_vertical_slice_summary(parsed)
+    assert parsed["verification"]["classification"] == "exact"
 
 
 def test_kdv_vertical_slice_module_prints_json_only() -> None:
-    completed = subprocess.run(
-        [sys.executable, "-m", "pdelie.examples.kdv_vertical_slice"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    parsed = _run_module_json("pdelie.examples.kdv_vertical_slice")
 
-    assert completed.stderr == ""
-    parsed = json.loads(completed.stdout)
-    assert parsed["backend"] == "spectral_fd"
-    assert parsed["verification_classification"] != "failed"
+    _assert_vertical_slice_summary(parsed)
+    assert parsed["verification"]["classification"] != "failed"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -52,6 +52,13 @@ def test_runtime_package_api_is_importable() -> None:
         import_generator_family_manifest,
     )
     from pdelie.residuals import KdVResidualEvaluator, evaluate_weak_burgers_residual, evaluate_weak_heat_residual
+    from pdelie.reporting import (
+        summarize_generator_family,
+        summarize_residual_batch,
+        summarize_verification_report,
+        summarize_vertical_slice,
+        summarize_weak_residual_report,
+    )
     from pdelie.symmetry import (
         compare_generator_spans,
         diagnose_generator_family_closure,
@@ -77,6 +84,11 @@ def test_runtime_package_api_is_importable() -> None:
     assert KdVResidualEvaluator is not None
     assert evaluate_weak_burgers_residual is not None
     assert evaluate_weak_heat_residual is not None
+    assert summarize_generator_family is not None
+    assert summarize_residual_batch is not None
+    assert summarize_verification_report is not None
+    assert summarize_vertical_slice is not None
+    assert summarize_weak_residual_report is not None
     assert build_translation_canonical_discovery_inputs is not None
     assert evaluate_discovery_recovery is not None
     assert fit_pysindy_discovery is not None
@@ -111,6 +123,11 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "subsample_time")
     assert not hasattr(pdelie, "subsample_x")
     assert not hasattr(pdelie, "summarize_recovery_grid")
+    assert not hasattr(pdelie, "summarize_generator_family")
+    assert not hasattr(pdelie, "summarize_residual_batch")
+    assert not hasattr(pdelie, "summarize_verification_report")
+    assert not hasattr(pdelie, "summarize_vertical_slice")
+    assert not hasattr(pdelie, "summarize_weak_residual_report")
     assert not hasattr(pdelie, "to_pysindy_trajectories")
     assert not hasattr(pdelie, "coerce_generator_family")
     assert not hasattr(pdelie, "export_generator_family_manifest")
@@ -166,6 +183,16 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
     assert not hasattr(residuals_module, "WeakKdVResidualEvaluator")
     assert not hasattr(residuals_module, "KDVResidualEvaluator")
     assert not hasattr(residuals_module, "KdvResidualEvaluator")
+
+
+def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
+    reporting_module = importlib.import_module("pdelie.reporting")
+
+    assert hasattr(reporting_module, "summarize_generator_family")
+    assert hasattr(reporting_module, "summarize_residual_batch")
+    assert hasattr(reporting_module, "summarize_verification_report")
+    assert hasattr(reporting_module, "summarize_vertical_slice")
+    assert hasattr(reporting_module, "summarize_weak_residual_report")
 
 
 def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import numpy as np
+import pytest
+
+from pdelie.contracts import ResidualBatch
+from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.reporting import (
+    summarize_generator_family,
+    summarize_residual_batch,
+    summarize_verification_report,
+    summarize_vertical_slice,
+    summarize_weak_residual_report,
+)
+from pdelie.residuals import HeatResidualEvaluator, evaluate_weak_burgers_residual, evaluate_weak_heat_residual
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.symmetry.parameterization import translation_span_distance
+from pdelie.verification import verify_translation_generator
+
+
+_SUMMARY_PREFIX_KEYS = {"summary_schema_version", "summary_type"}
+
+
+@pytest.fixture(scope="module")
+def heat_artifacts() -> dict[str, object]:
+    training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=1010)
+    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=64, seed=1011)
+    derivatives = compute_spectral_fd_derivatives(training)
+    evaluator = HeatResidualEvaluator()
+    residual = evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, evaluator)
+    return {
+        "derivatives": derivatives,
+        "residual": residual,
+        "generator": generator,
+        "verification": verification,
+    }
+
+
+def _assert_json_serializable(payload: dict[str, object]) -> None:
+    assert json.loads(json.dumps(payload)) == payload
+
+
+def test_summarize_residual_batch_returns_frozen_json_summary(heat_artifacts: dict[str, object]) -> None:
+    residual = heat_artifacts["residual"]
+    assert isinstance(residual, ResidualBatch)
+
+    summary = summarize_residual_batch(residual)
+
+    assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+        "residual_shape",
+        "definition_type",
+        "normalization",
+        "max_abs_residual",
+        "rms_residual",
+        "diagnostics",
+    }
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "residual_batch"
+    assert summary["residual_shape"] == list(residual.residual.shape)
+    assert summary["definition_type"] == residual.definition_type
+    assert summary["normalization"] == residual.normalization
+    assert summary["max_abs_residual"] == pytest.approx(float(np.max(np.abs(residual.residual))))
+    assert summary["rms_residual"] == pytest.approx(float(np.sqrt(np.mean(np.square(residual.residual)))))
+    assert summary["diagnostics"] == residual.diagnostics
+    _assert_json_serializable(summary)
+
+
+def test_summarize_weak_residual_report_accepts_frozen_heat_and_burgers_reports() -> None:
+    heat = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=9, seed=1020)
+    burgers = generate_burgers_1d_field_batch(batch_size=1, num_times=5, num_points=9, seed=1021)
+
+    for report in (evaluate_weak_heat_residual(heat), evaluate_weak_burgers_residual(burgers)):
+        summary = summarize_weak_residual_report(report)
+        residuals = np.asarray(report["window_residuals"], dtype=float)
+
+        assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+            "equation",
+            "equation_form",
+            "method_family",
+            "normalization",
+            "window_residual_shape",
+            "max_abs_residual",
+            "l2_residual",
+            "diagnostics",
+        }
+        assert summary["summary_type"] == "weak_residual_report"
+        assert summary["equation"] == report["equation"]
+        assert summary["equation_form"] == report["equation_form"]
+        assert summary["method_family"] == report["method_family"]
+        assert summary["normalization"] == "none"
+        assert summary["window_residual_shape"] == list(residuals.shape)
+        assert summary["max_abs_residual"] == pytest.approx(float(np.max(np.abs(residuals))))
+        assert summary["l2_residual"] == pytest.approx(float(np.linalg.norm(residuals.ravel(), ord=2)))
+        _assert_json_serializable(summary)
+
+
+def test_summarize_generator_family_reports_translation_fit_fields(heat_artifacts: dict[str, object]) -> None:
+    generator = heat_artifacts["generator"]
+
+    summary = summarize_generator_family(generator)
+
+    assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+        "parameterization",
+        "normalization",
+        "coefficient_shape",
+        "coefficients",
+        "generator_names",
+        "translation_span_distance",
+        "fit_mode",
+        "reference_fallback_used",
+        "fallback_reason",
+        "diagnostics",
+    }
+    assert summary["summary_type"] == "generator_family"
+    assert summary["parameterization"] == generator.parameterization
+    assert summary["normalization"] == generator.normalization
+    assert summary["coefficient_shape"] == list(generator.coefficients.shape)
+    assert summary["coefficients"] == generator.coefficients.tolist()
+    assert summary["translation_span_distance"] == pytest.approx(translation_span_distance(generator.coefficients))
+    assert summary["fit_mode"] == generator.diagnostics["fit_mode"]
+    assert summary["reference_fallback_used"] == generator.diagnostics["reference_fallback_used"]
+    assert summary["fallback_reason"] == generator.diagnostics["fallback_reason"]
+    _assert_json_serializable(summary)
+
+
+def test_summarize_verification_report_returns_sweep_metrics(heat_artifacts: dict[str, object]) -> None:
+    report = heat_artifacts["verification"]
+
+    summary = summarize_verification_report(report)
+
+    assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+        "norm",
+        "classification",
+        "epsilon_values",
+        "error_curve",
+        "first_epsilon",
+        "first_error",
+        "max_error",
+        "diagnostics",
+    }
+    assert summary["summary_type"] == "verification_report"
+    assert summary["norm"] == report.norm
+    assert summary["classification"] == report.classification
+    assert summary["epsilon_values"] == report.epsilon_values.tolist()
+    assert summary["error_curve"] == report.error_curve.tolist()
+    assert summary["first_epsilon"] == pytest.approx(float(report.epsilon_values[0]))
+    assert summary["first_error"] == pytest.approx(float(report.error_curve[0]))
+    assert summary["max_error"] == pytest.approx(float(np.max(report.error_curve)))
+    _assert_json_serializable(summary)
+
+
+def test_summarize_vertical_slice_nests_summaries_and_derivative_metadata(heat_artifacts: dict[str, object]) -> None:
+    summary = summarize_vertical_slice(
+        derivatives=heat_artifacts["derivatives"],
+        residual=heat_artifacts["residual"],
+        generator=heat_artifacts["generator"],
+        verification=heat_artifacts["verification"],
+        extra_metrics={"numpy_scalar": np.float64(1.5), "numpy_array": np.asarray([1, 2])},
+    )
+
+    assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+        "derivative_backend",
+        "derivative_keys",
+        "derivative_config",
+        "derivative_diagnostics",
+        "residual",
+        "generator",
+        "verification",
+        "extra_metrics",
+    }
+    assert summary["summary_type"] == "vertical_slice"
+    assert summary["derivative_backend"] == "spectral_fd"
+    assert summary["derivative_keys"] == sorted(heat_artifacts["derivatives"].derivatives)
+    assert summary["residual"]["summary_type"] == "residual_batch"
+    assert summary["generator"]["summary_type"] == "generator_family"
+    assert summary["verification"]["summary_type"] == "verification_report"
+    assert summary["extra_metrics"] == {"numpy_scalar": 1.5, "numpy_array": [1, 2]}
+    _assert_json_serializable(summary)
+
+
+def test_summarize_vertical_slice_defaults_extra_metrics_to_empty_mapping(heat_artifacts: dict[str, object]) -> None:
+    summary = summarize_vertical_slice(
+        derivatives=heat_artifacts["derivatives"],
+        residual=heat_artifacts["residual"],
+        generator=heat_artifacts["generator"],
+        verification=heat_artifacts["verification"],
+    )
+
+    assert summary["extra_metrics"] == {}
+
+
+@pytest.mark.parametrize(
+    ("helper", "argument"),
+    [
+        (summarize_residual_batch, object()),
+        (summarize_generator_family, object()),
+        (summarize_verification_report, object()),
+        (summarize_weak_residual_report, object()),
+    ],
+)
+def test_reporting_helpers_reject_wrong_input_types(helper: object, argument: object) -> None:
+    with pytest.raises(SchemaValidationError):
+        helper(argument)  # type: ignore[misc]
+
+
+def test_summarize_weak_residual_report_rejects_malformed_report() -> None:
+    with pytest.raises(SchemaValidationError, match="missing required fields"):
+        summarize_weak_residual_report({"equation": "heat_1d"})
+
+    report = evaluate_weak_heat_residual(
+        generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=9, seed=1030)
+    )
+    malformed = dict(report)
+    malformed["window_residuals"] = np.asarray(report["window_residuals"], dtype=float)[..., 0]
+
+    with pytest.raises(SchemaValidationError, match="window_residuals"):
+        summarize_weak_residual_report(malformed)
+
+
+def test_reporting_helpers_reject_nonfinite_metric_arrays(
+    heat_artifacts: dict[str, object],
+) -> None:
+    residual = heat_artifacts["residual"]
+    bad_residual = ResidualBatch(
+        residual=np.full_like(residual.residual, np.nan),
+        definition_type=residual.definition_type,
+        normalization=residual.normalization,
+        diagnostics=residual.diagnostics,
+    )
+
+    with pytest.raises(ScopeValidationError, match="finite"):
+        summarize_residual_batch(bad_residual)
+
+    report = evaluate_weak_heat_residual(
+        generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=9, seed=1040)
+    )
+    bad_report = dict(report)
+    bad_window_residuals = np.asarray(report["window_residuals"], dtype=float).copy()
+    bad_window_residuals[0, 0, 0, 0] = np.nan
+    bad_report["window_residuals"] = bad_window_residuals
+
+    with pytest.raises(ScopeValidationError, match="finite"):
+        summarize_weak_residual_report(bad_report)
+
+
+def test_summarize_vertical_slice_rejects_malformed_extra_metrics(heat_artifacts: dict[str, object]) -> None:
+    with pytest.raises(SchemaValidationError, match="extra_metrics"):
+        summarize_vertical_slice(
+            derivatives=heat_artifacts["derivatives"],
+            residual=heat_artifacts["residual"],
+            generator=heat_artifacts["generator"],
+            verification=heat_artifacts["verification"],
+            extra_metrics=["not", "a", "mapping"],  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(SchemaValidationError, match="JSON-compatible"):
+        summarize_vertical_slice(
+            derivatives=heat_artifacts["derivatives"],
+            residual=heat_artifacts["residual"],
+            generator=heat_artifacts["generator"],
+            verification=heat_artifacts["verification"],
+            extra_metrics={"not_json": object()},
+        )
+
+
+def test_reporting_helpers_do_not_mutate_inputs(heat_artifacts: dict[str, object]) -> None:
+    residual = heat_artifacts["residual"]
+    generator = heat_artifacts["generator"]
+    verification = heat_artifacts["verification"]
+    weak_report = evaluate_weak_heat_residual(
+        generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=9, seed=1050)
+    )
+    weak_snapshot = copy.deepcopy(weak_report)
+
+    residual_snapshot = residual.to_dict()
+    generator_snapshot = generator.to_dict()
+    verification_snapshot = verification.to_dict()
+
+    summarize_residual_batch(residual)
+    summarize_generator_family(generator)
+    summarize_verification_report(verification)
+    summarize_weak_residual_report(weak_report)
+    summarize_vertical_slice(
+        derivatives=heat_artifacts["derivatives"],
+        residual=residual,
+        generator=generator,
+        verification=verification,
+        extra_metrics={"nested": {"array": np.asarray([1.0, 2.0])}},
+    )
+
+    assert residual.to_dict() == residual_snapshot
+    assert generator.to_dict() == generator_snapshot
+    assert verification.to_dict() == verification_snapshot
+    for key, expected in weak_snapshot.items():
+        if isinstance(expected, np.ndarray):
+            np.testing.assert_allclose(np.asarray(weak_report[key]), expected, atol=0.0, rtol=0.0)
+        elif isinstance(expected, dict):
+            assert weak_report[key] == expected
+        else:
+            assert weak_report[key] == expected

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pdelie
+from pdelie.examples import run_heat_vertical_slice_example, run_kdv_vertical_slice_example
+
+
+_REPORTING_HELPERS = {
+    "summarize_generator_family",
+    "summarize_residual_batch",
+    "summarize_verification_report",
+    "summarize_vertical_slice",
+    "summarize_weak_residual_report",
+}
+_DEFERRED_OR_FORBIDDEN_NAMES = {
+    "OperatorSymmetry",
+    "WeakKdVResidualEvaluator",
+    "compute_weak_derivatives",
+    "evaluate_weak_kdv_residual",
+    "from_pdebench",
+    "from_the_well",
+    "load_pdebench",
+    "load_the_well",
+    "sample_kdv_mode_coefficients",
+}
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def _assert_vertical_slice_summary(summary: dict[str, object], *, expected_equation: str) -> None:
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "vertical_slice"
+    assert summary["derivative_backend"] == "spectral_fd"
+    assert summary["extra_metrics"]["equation"] == expected_equation
+    assert summary["residual"]["summary_type"] == "residual_batch"
+    assert summary["generator"]["summary_type"] == "generator_family"
+    assert summary["verification"]["summary_type"] == "verification_report"
+
+    assert "verification_classification" not in summary
+    assert "max_abs_residual" not in summary
+
+
+def test_v0_10_release_gate_reporting_surface_and_api_stability_are_aligned() -> None:
+    reporting_module = importlib.import_module("pdelie.reporting")
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+
+    for name in sorted(_REPORTING_HELPERS):
+        assert hasattr(reporting_module, name)
+        assert not hasattr(pdelie, name)
+        assert f"pdelie.reporting.{name}" in api_stability
+
+    assert "pdelie.residuals.evaluate_weak_heat_residual" in api_stability
+    assert "pdelie.residuals.evaluate_weak_burgers_residual" in api_stability
+    assert "pdelie.data.generate_kdv_1d_field_batch" in api_stability
+    assert "pdelie.residuals.KdVResidualEvaluator" in api_stability
+    assert "these APIs have no root `pdelie` exports" in api_stability
+    assert "operator symmetry" in api_stability
+
+
+def test_v0_10_release_gate_examples_emit_nested_reporting_summaries() -> None:
+    heat = run_heat_vertical_slice_example()
+    kdv = run_kdv_vertical_slice_example()
+
+    _assert_vertical_slice_summary(heat, expected_equation="heat_1d")
+    _assert_vertical_slice_summary(kdv, expected_equation="kdv_normalized")
+    assert heat["verification"]["classification"] == "exact"
+    assert kdv["verification"]["classification"] != "failed"
+    assert kdv["residual"]["max_abs_residual"] < 1e-2
+
+
+def test_v0_10_release_gate_no_new_numerical_or_deferred_public_surface() -> None:
+    modules = [
+        pdelie,
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.derivatives"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.reporting"),
+    ]
+
+    for module in modules:
+        for name in sorted(_DEFERRED_OR_FORBIDDEN_NAMES):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"
+
+
+def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
+    workflow = _repo_text(".github/workflows/ci.yml")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert release_gate_jobs == ["v0_10-release-gate"]
+    assert "python -m pytest tests/test_v0_10_release_gate.py" in workflow
+    assert "run: python -m pytest\n" in workflow
+    for historical_job in range(4, 10):
+        assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_9_release_gate.py
+++ b/tests/test_v0_9_release_gate.py
@@ -152,15 +152,16 @@ def test_v0_9_release_gate_runtime_surface_and_api_stability_doc_are_aligned() -
 def test_v0_9_release_gate_representative_kdv_vertical_slice_holds() -> None:
     result = run_kdv_vertical_slice_example()
 
-    assert result["backend"] == "spectral_fd"
-    assert result["max_abs_residual"] < 1e-2
-    assert result["rms_residual"] < 2e-3
-    assert result["mass_drift"] <= 1e-8
-    assert result["relative_l2_drift"] <= 5e-3
-    assert result["parameterization"] == "polynomial_translation_affine"
-    assert result["span_distance"] <= 5e-2
-    assert result["error_curve"][0] < 1e-4
-    assert result["verification_classification"] != "failed"
+    assert result["summary_type"] == "vertical_slice"
+    assert result["derivative_backend"] == "spectral_fd"
+    assert result["residual"]["max_abs_residual"] < 1e-2
+    assert result["residual"]["rms_residual"] < 2e-3
+    assert result["extra_metrics"]["mass_drift"] <= 1e-8
+    assert result["extra_metrics"]["relative_l2_drift"] <= 5e-3
+    assert result["generator"]["parameterization"] == "polynomial_translation_affine"
+    assert result["generator"]["translation_span_distance"] <= 5e-2
+    assert result["verification"]["first_error"] < 1e-4
+    assert result["verification"]["classification"] != "failed"
 
 
 @pytest.mark.parametrize("importer", [_import_from_numpy, _import_from_xarray])


### PR DESCRIPTION
v0.10 Summary

- Added public submodule pdelie.reporting with JSON-compatible supportability summaries.
- Refactored Heat/KdV examples to emit nested vertical_slice summaries.
- Added API stability audit and public-surface guard coverage.
- Consolidated CI release-gate visibility to one current v0_10-release-gate job.
- Updated release metadata/docs for 0.10.0, Git-tag-only, no PyPI/TestPyPI until v1.0+.
- No new PDE, weak KdV, weak derivatives, broad adapters, or canonical objects.