### PR TITLE
Feat/v0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_10-release-gate:
+  v0_11-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.10 release gate
-        run: python -m pytest tests/test_v0_10_release_gate.py
+      - name: Run V0.11 release gate
+        run: python -m pytest tests/test_v0_11_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -117,7 +117,32 @@ jobs:
         run: /tmp/pdelie-rc-venv/bin/python -m pip check
       - name: Stable import smoke
         run: |
-          /tmp/pdelie-rc-venv/bin/python -c "from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport; print('stable-import-ok')"
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import pdelie
+
+          from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport
+          from pdelie.reporting import (
+              summarize_generator_family,
+              summarize_residual_batch,
+              summarize_verification_report,
+              summarize_vertical_slice,
+              summarize_weak_residual_report,
+          )
+
+          assert FieldBatch is not None
+          assert DerivativeBatch is not None
+          assert ResidualBatch is not None
+          assert ResidualEvaluator is not None
+          assert GeneratorFamily is not None
+          assert VerificationReport is not None
+          assert summarize_generator_family is not None
+          assert summarize_residual_batch is not None
+          assert summarize_verification_report is not None
+          assert summarize_vertical_slice is not None
+          assert summarize_weak_residual_report is not None
+          assert not hasattr(pdelie, "summarize_vertical_slice")
+          print("stable-import-ok")
+          PY
       - name: Weak residual report smoke
         run: |
           /tmp/pdelie-rc-venv/bin/python - <<'PY'
@@ -164,6 +189,23 @@ jobs:
           assert np.isfinite(float(residual.diagnostics["max_abs_residual"]))
           assert np.isfinite(float(residual.diagnostics["rms_residual"]))
           print("kdv-smoke-ok")
+          PY
+      - name: Order-4 derivative smoke
+        run: |
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import numpy as np
+          import pdelie
+
+          from pdelie.data import generate_heat_1d_field_batch
+          from pdelie.derivatives import compute_spectral_fd_derivatives
+
+          assert not hasattr(pdelie, "compute_spectral_fd_derivatives")
+          field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=11011)
+          derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+          assert "u_xxxx" in derivatives.derivatives
+          assert np.all(np.isfinite(derivatives.derivatives["u_xxxx"]))
+          assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+          print("order4-smoke-ok")
           PY
       - name: Example smoke and determinism
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.11.0
+
+First final release for the frozen V0.11 Kuramoto-Sivashinsky feasibility/no-go closeout.
+
+- extends `pdelie.derivatives.compute_spectral_fd_derivatives(...)` with `max_spatial_order=4` and stable `u_xxxx` output while preserving the `max_spatial_order=2` default behavior
+- adds internal KS feasibility coverage for the normalized strong form `u_t + u*u_x + u_xx + u_xxxx = 0`
+- records strong internal KS residual, mass-conservation, and held-out canonical translation-verification evidence
+- closes stable KS runtime promotion as no-go/defer for `v0.11` because the frozen fixture relies on `reference_fallback` rather than direct SVD in-tolerance fitting
+- adds compact `v0_11-release-gate` CI visibility while preserving the full editable test suite and package smoke
+- preserves the prior Heat/Burgers strong paths, `v0.8` weak residual report APIs, `v0.9` normalized periodic KdV strong path, and `v0.10` reporting helpers
+
+Explicitly deferred for this final release:
+
+- stable KS data generator
+- stable KS residual evaluator
+- KS vertical-slice example
+- KS imported parity
+- weak KS APIs
+- root `pdelie` exports for KS runtime APIs
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- manuscript-specific experiment logic, tables, figures, or thresholds
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.10.0
 
 First final release for the frozen V0.10 supportability and `v1.0` readiness slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.10 supportability layer for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.11 feasibility/no-go closeout for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -11,8 +11,9 @@ The current repository implements the frozen V0.10 supportability layer for the 
 - deterministic window-indexed weak residual reports under `pdelie.residuals`
 - JSON-compatible runtime supportability summaries under `pdelie.reporting`
 - uniform periodic grid
-- `spectral_fd` derivatives through `u_xxx`
+- `spectral_fd` derivatives through `u_xxxx`
 - normalized KdV strong residuals under `pdelie.residuals.KdVResidualEvaluator`
+- internal Kuramoto-Sivashinsky feasibility evidence with stable runtime promotion deferred
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -27,7 +28,7 @@ The current repository implements the frozen V0.10 supportability layer for the 
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current release-gate CI job plus full editable tests and package smoke
+- one compact current `v0_11-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -76,7 +77,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.10`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.11`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -146,12 +147,13 @@ Included in the current stable core:
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
 - consolidated current release-gate CI visibility while retaining historical gate tests in the full test suite
 - KdV is stable only for the normalized periodic short-horizon strong path; weak KdV remains explicitly deferred
+- KS remains internal feasibility evidence in `v0.11`; no stable KS runtime API is promoted
 
-Runtime-level public APIs in the frozen V0.10 slice:
+Runtime-level public APIs in the frozen V0.11 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
-- `pdelie.derivatives.compute_spectral_fd_derivatives(..., max_spatial_order=3)` for `u_xxx` on the existing uniform periodic `spectral_fd` backend
+- `pdelie.derivatives.compute_spectral_fd_derivatives(..., max_spatial_order=4)` for `u_xxxx` on the existing uniform periodic `spectral_fd` backend; the default `max_spatial_order=2` behavior remains preserved
 - `pdelie.data.generate_kdv_1d_field_batch` for normalized periodic short-horizon synthetic KdV under the frozen v0.9 generator regime
 - `pdelie.residuals.KdVResidualEvaluator` for the normalized strong-form residual `u_t + 6*u*u_x + u_xxx = 0`
 - `pdelie.examples.run_kdv_vertical_slice_example` for a runtime smoke example, not a canonical report schema
@@ -183,6 +185,8 @@ The KdV support retained through `v0.10` is normalized, periodic, scalar, 1D, an
 
 The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 
+The `v0.11` KS feasibility track does not promote stable KS runtime support. Internal feasibility evidence passes residual, mass, and canonical held-out verification checks, but translation fitting is reference-fallback-backed rather than direct SVD in-tolerance recovery.
+
 Explicitly deferred:
 - stable multi-generator PDE fitting
 - multi-generator invariant machinery
@@ -196,4 +200,5 @@ Explicitly deferred:
 - weak KdV APIs
 - custom KdV initial conditions or configurable KdV coefficients
 - general KdV support outside the frozen normalized periodic short-horizon regime
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export
 - broad adapters and interoperability work

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,17 +1,20 @@
-# PDELie - Execution Plan (V0.10)
+# PDELie - Execution Plan (V0.11)
 
 ## Current Release Status
 
-**V0.10 complete; ready for direct `v0.10.0` tag after release PR CI**
+**V0.11 committed as Kuramoto-Sivashinsky feasibility-first**
 
-This file is the active execution record for the `v0.10` release series.
+This file is the active execution record for the `v0.11` release series.
 
-`v0.10` is a supportability and `v1.0` readiness release.
-It hardens the existing Heat/Burgers/weak-report/KdV engine before any new numerical scope is added.
+`v0.11` is a feasibility-first release.
+It evaluates whether normalized scalar 1D periodic Kuramoto-Sivashinsky can be promoted safely into the stable strong-path runtime surface.
 
-Stable release definition:
+Candidate stable path:
 
-`existing stable Heat/Burgers/weak-report/KdV surfaces -> compact supportability reports -> consistent examples/release gates/docs -> v1.0 readiness`
+`canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
+
+Stable runtime promotion is conditional.
+`v0.11` may close either as stable KS promotion or as an explicit no-go/defer feasibility release.
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -20,315 +23,166 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_10_SCOPE.md`
+- `docs/planning/V0_11_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0, left unchanged in M0/M1, updated in M2 when the public `pdelie.reporting` helpers landed, and audited again in M4/M6 with no further changes required.
-It must continue to be updated in the same milestone where any future public helper or other public API lands.
+`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.11` public API lands in M0.
+It must be updated in the same milestone where any public KS API or other public API lands.
 
 ---
 
-## V0.9 Closeout
+## V0.10 Closeout
 
-`v0.9` is complete as the stable normalized periodic short-horizon KdV strong-path release.
+`v0.10` is complete as the supportability and `v1.0` readiness release.
 
 Completed outcome:
 
-- `compute_spectral_fd_derivatives(..., max_spatial_order=3)` with `u_xxx`
-- `pdelie.data.generate_kdv_1d_field_batch(...)`
-- `pdelie.residuals.KdVResidualEvaluator`
-- KdV vertical-slice example and release-gate coverage
-- mandatory representative `from_numpy` parity and optional `from_xarray` parity
-- explicit deferral of weak KdV, configurable KdV coefficients, custom KdV initial conditions, general KdV support, and broad adapter work
+- public runtime reporting helpers under `pdelie.reporting`
+- consistent nested Heat/KdV example summaries
+- API stability and public-surface audit coverage
+- one current release-gate CI job plus full editable tests and package smoke
+- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
+- explicit deferral of new PDE scope, weak KdV, broad adapters, operator work, and manuscript-specific reporting logic
 
-`v0.10` begins from the frozen `v0.9` surface.
-It does not reopen KdV numerics or weak-form scope.
+`v0.11` begins from the frozen `v0.10` surface.
+It does not reopen Heat/Burgers, weak-report, KdV, reporting, CI cleanup, or publishing decisions.
 
 ---
 
-## Milestone 0 - Supportability Scope Reset
+## Milestone 0 - KS Feasibility Scope Reset
 
 **Status:** COMPLETE
 
 ### Goal
 
-Promote `v0.10` to the next committed release target, create `V0_10_SCOPE.md`, reset `PLAN.md`, and audit `API_STABILITY.md` without changing it.
+Promote `v0.11` to the next committed release target, create `V0_11_SCOPE.md`, reset `PLAN.md`, and audit `API_STABILITY.md` without changing it.
 
 ### Completed Outcome
 
-- promoted `v0.10` to committed supportability / `v1.0` readiness scope in `ROADMAP.md`
-- created `docs/planning/V0_10_SCOPE.md`
-- reset `docs/planning/PLAN.md` as the active `v0.10` execution record
-- recorded `v0.9` as completed
-- recorded `v0.11` as conditional next strong-path PDE feasibility or promotion
-- recorded `v0.12+` as later PDE/dataset coverage only after separate scope freezes
+- promoted `v0.11` to committed feasibility-first scope in `ROADMAP.md`
+- created `docs/planning/V0_11_SCOPE.md`
+- reset `docs/planning/PLAN.md` as the active `v0.11` execution record
+- recorded `v0.10` as completed
+- recorded Kuramoto-Sivashinsky as the feasibility candidate
+- recorded stable KS promotion as conditional on later numerical evidence
+- recorded that `v0.11` may close as either stable KS promotion or no-go/defer
 - audited `docs/specs/API_STABILITY.md`
-- left `docs/specs/API_STABILITY.md` unchanged because no new `v0.10` public API has landed
-- left `.github/workflows/ci.yml`, `README.md`, `CHANGELOG.md`, and `docs/releases/V0_10_RELEASE_READINESS.md` for later milestones
+- left `docs/specs/API_STABILITY.md` unchanged because no new `v0.11` public API landed in M0
+- left runtime code, tests, package metadata, CI, README, changelog, and release-readiness docs unchanged
 
 ### Acceptance Criteria
 
 M0 is complete only if:
 
-- `ROADMAP.md`, `PLAN.md`, and `V0_10_SCOPE.md` are internally consistent
-- `v0.9` is consistently described as completed
-- `v0.10` is consistently described as the next committed release
-- `v0.10` is described as supportability and `v1.0` readiness, not new numerical scope
-- `v0.11` is conditional and not committed
-- `v0.12+` remains planned only after separate scope freezes
+- `ROADMAP.md`, `PLAN.md`, and `V0_11_SCOPE.md` are internally consistent
+- `v0.10` is consistently described as completed
+- `v0.11` is consistently described as committed and feasibility-first
+- `v0.11` is not described as unconditional stable KS support
+- exact KS equation normalization and numerical thresholds remain deferred to M1
+- public KS APIs remain uncommitted until later milestones
 - `API_STABILITY.md` remains unchanged during M0
 - no runtime code, tests, package metadata, CI, README, changelog, or release-readiness docs are edited in M0
 
 ---
 
-## Milestone 1 - Reporting Semantics Freeze
+## Milestone 1 - KS Equation and Numerical Semantics Freeze
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Freeze exactly what `v0.10` supportability reporting means before runtime implementation.
+Freeze the exact normalized KS equation and numerical semantics before any runtime prototype or public API is considered.
 
-### Completed Outcome
+### Planned Outcome
 
-- chose a new public runtime submodule for M2: `pdelie.reporting`
-- froze no root `pdelie` exports for reporting helpers
-- froze reporting helpers as runtime-level public APIs, not canonical objects
-- froze future M2 helper names:
-  - `summarize_residual_batch(...)`
-  - `summarize_weak_residual_report(...)`
-  - `summarize_generator_family(...)`
-  - `summarize_verification_report(...)`
-  - `summarize_vertical_slice(...)`
-- froze common reporting rules:
-  - JSON-compatible plain Python dict outputs
-  - NumPy arrays convert to lists
-  - NumPy scalars convert to Python scalars
-  - existing typed validation errors for invalid inputs
-  - no input mutation
-  - no canonical object creation or schema changes
-  - no manuscript-specific table, figure, threshold, or label logic
-- froze summary schemas:
-  - residual batch summaries
-  - weak residual report summaries
-  - generator family summaries
-  - verification report summaries
-  - vertical-slice summaries
-- left `API_STABILITY.md` unchanged because the public APIs are frozen for M2 but not implemented in M1
-- left runtime code, tests, README, changelog, release-readiness docs, package metadata, and CI unchanged
-
-### Acceptance Criteria
-
-- exact reporting semantics are frozen before implementation
-- no manuscript-specific reporting logic is introduced
-- example outputs remain runtime smoke summaries, not canonical artifacts
-- `API_STABILITY.md` remains unchanged until `pdelie.reporting` lands in M2
+- choose the exact normalized KS equation form and sign convention
+- freeze derivative-order requirements
+- freeze coordinate and boundary conventions
+- freeze candidate diagnostic metrics
+- freeze preliminary residual, conservation, fitting, and verification thresholds for feasibility work
+- keep public API names and stable promotion conditional
 
 ---
 
-## Milestone 2 - Reporting Helper Implementation
+## Milestone 2 - KS Feasibility Generator / Prototype
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Implement the frozen supportability reporting helpers from M1.
+Create or adapt a deterministic KS feasibility generator/prototype under the frozen M1 semantics.
 
-### Completed Outcome
+### Planned Outcome
 
-- added public runtime submodule `pdelie.reporting`
-- exported the five M1-frozen helpers from `pdelie.reporting` only:
-  - `summarize_residual_batch(...)`
-  - `summarize_weak_residual_report(...)`
-  - `summarize_generator_family(...)`
-  - `summarize_verification_report(...)`
-  - `summarize_vertical_slice(...)`
-- kept root `pdelie` exports unchanged
-- implemented JSON-compatible summary conversion:
-  - NumPy arrays convert to lists
-  - NumPy scalars convert to Python scalars
-  - mappings and sequences convert recursively
-- implemented typed validation errors for wrong object types, malformed weak reports, non-finite metric arrays, and malformed extra metrics
-- kept helpers deterministic and scoped to existing stable runtime surfaces
-- added focused reporting tests for schemas, JSON serialization, summary metrics, non-mutation, and validation failures
-- updated public API tests for the new submodule and root-export guards
-- updated `docs/specs/API_STABILITY.md` for the landed `pdelie.reporting` APIs
-- did not change canonical object schemas, examples, CI, README, changelog, package metadata, or release-readiness docs
-
-### Acceptance Criteria
-
-- reporting helpers pass focused tests
-- no existing canonical object schema changes
-- no new PDE, weak KdV, broad adapter, or operator scope lands
-- public helper APIs are documented in `API_STABILITY.md`
+- evaluate short-horizon rollout stability
+- record supported fixture sizes, seeds, and numerical margins
+- keep any prototype internal unless the milestone explicitly freezes a public API
+- avoid custom initial-condition APIs and configurable coefficient families
 
 ---
 
-## Milestone 3 - Example Consistency
+## Milestone 3 - KS Residual Feasibility Prototype
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Make existing examples easier to compare, smoke-test, and support without turning example outputs into canonical schemas.
+Evaluate the strong-form KS residual path under the frozen semantics.
 
-### Completed Outcome
+### Planned Outcome
 
-- refactored `run_heat_vertical_slice_example()` to return `pdelie.reporting.summarize_vertical_slice(...)`
-- refactored `run_kdv_vertical_slice_example()` to return `pdelie.reporting.summarize_vertical_slice(...)`
-- kept command entrypoints unchanged:
-  - `python -m pdelie.examples.heat_vertical_slice`
-  - `python -m pdelie.examples.kdv_vertical_slice`
-- kept root `pdelie` exports unchanged
-- moved example-specific context into `extra_metrics`:
-  - Heat records example name, equation, training/heldout seeds, and batch sizes
-  - KdV records example name, equation, generator/split seeds, train size, mass drift, and relative L2 drift
-- kept example outputs JSON-only on stdout with no logging noise
-- intentionally did not preserve the old flat top-level example keys
-- recorded that example outputs are runtime smoke summaries, not canonical artifact schemas
-- updated example tests for:
-  - nested `vertical_slice` summary shape
-  - JSON serialization
-  - deterministic repeated output
-  - Heat and KdV subprocess JSON-only execution
-  - root-export guards
-- updated the representative `v0.9` release-gate example assertion to read the nested summary without preserving the old example schema
-- did not change fitting, verification, residual, derivative, data-generation, or reporting-helper behavior
-- left `API_STABILITY.md`, README, changelog, release-readiness docs, package metadata, and CI unchanged
-
-### Acceptance Criteria
-
-- examples remain deterministic runtime smokes
-- example summaries are not documented as canonical artifact schemas
-- Heat/Burgers/KdV stable runtime behavior remains unchanged
+- test derivative requirements and residual diagnostics
+- verify typed validation behavior
+- measure residual thresholds on frozen feasibility fixtures
+- keep public residual evaluator promotion conditional
 
 ---
 
-## Milestone 4 - API Stability Audit and Public-Surface Guards
+## Milestone 4 - KS Vertical-Slice Feasibility
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Bring public-surface tests and `API_STABILITY.md` into a clean pre-`v1.0` posture.
+Run the candidate KS path through the existing strong-path fitting and verification stack.
 
-### Completed Outcome
+### Planned Outcome
 
-- added a focused API stability audit test
-- verified `docs/specs/API_STABILITY.md` documents:
-  - the `v0.10` `pdelie.reporting` helpers
-  - the frozen `v0.8` weak residual report APIs
-  - the frozen `v0.9` KdV strong-path APIs
-  - deferred weak derivatives, broader weak methods, and operator symmetry as non-stable surfaces
-- verified root `pdelie` remains limited to canonical objects, base evaluator, and typed errors
-- verified runtime helpers remain submodule-only:
-  - data generators/adapters and robustness utilities
-  - derivative backend helper
-  - residual evaluators and weak report functions
-  - reporting helpers
-  - examples
-  - discovery, portability, symmetry, and visualization helpers
-- verified deferred/private names remain absent from public modules:
-  - weak KdV APIs
-  - `compute_weak_derivatives`
-  - public KdV coefficient helpers
-  - broad dataset adapter aliases
-  - operator-facing names
-- kept public-surface tests specific-name based rather than freezing entire module contents
-- did not change `API_STABILITY.md`; the audit found no mismatch
-- did not add runtime APIs, canonical objects, numerical scope, CI changes, README/changelog updates, release-readiness docs, or package metadata changes
-
-### Acceptance Criteria
-
-- public-surface tests assert specific required/forbidden names without over-freezing unrelated module contents
-- stable APIs through `v0.10` are documented
-- deferred surfaces remain absent:
-  - weak KdV
-  - weak derivatives beyond the `v0.8` report functions
-  - broad adapters
-  - operator-facing APIs
+- build a deterministic KS vertical-slice fixture
+- run derivative computation, residual evaluation, translation fitting, and held-out verification
+- record span-distance and verification margins
+- decide whether the evidence is strong enough to continue toward promotion
 
 ---
 
-## Milestone 5 - CI Cleanup and Release-Gate Consolidation
+## Milestone 5 - Promotion Decision and Imported-Parity / Non-goal Guards
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Reduce CI release-gate sprawl while keeping historical release-gate tests runnable locally.
+Make the explicit stable-promotion versus no-go decision.
 
-### Completed Outcome
+### Planned Outcome
 
-- added a compact `tests/test_v0_10_release_gate.py`
-- consolidated explicit release-gate CI visibility to one current job:
-  - `v0_10-release-gate`
-- removed historical explicit CI jobs:
-  - `v0_4-release-gate`
-  - `v0_5-release-gate`
-  - `v0_6-release-gate`
-  - `v0_7-release-gate`
-  - `v0_8-release-gate`
-  - `v0_9-release-gate`
-- kept all historical release-gate test modules in the repo
-- kept historical release-gate tests covered by the full `editable-tests` job
-- kept `editable-tests` running full `python -m pytest`
-- kept `package-smoke`
-- updated package-smoke example assertions for the nested `vertical_slice` summary shape introduced in M3
-- did not change historical release-gate test semantics
-- did not change runtime APIs, canonical objects, numerical behavior, README/changelog docs, release-readiness docs, package metadata, or package-index publishing behavior
-
-### Acceptance Criteria
-
-- CI remains release-useful
-- historical gate tests remain runnable locally
-- current release gate remains visible in CI
-- package smoke remains compact and representative
+- if KS promotion is justified, freeze public API names and representative imported parity
+- if KS promotion is not justified, close the branch as no-go/defer without runtime API expansion
+- keep weak KS, broad adapters, operator APIs, and root exports absent
 
 ---
 
-## Milestone 6 - Release Readiness and Documentation Alignment
+## Milestone 6 - Release Gate / Readiness or No-go Closeout
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Close `v0.10` with aligned release-facing docs, package metadata, release gate, and final tag checklist.
+Close `v0.11` according to the M5 decision.
 
-### Completed Outcome
+### Planned Outcome
 
-- updated package metadata to `0.10.0`
-- updated README framing from `v0.9` to `v0.10`
-- documented `pdelie.reporting` supportability helpers and nested example summaries
-- added `CHANGELOG.md` entry for `0.10.0`
-- created `docs/releases/V0_10_RELEASE_READINESS.md`
-- updated `docs/releases/PUBLISHING.md` to include `v0.10.0` in the Git-tag-only `v0.x` release policy
-- updated `docs/planning/ROADMAP.md` so `v0.10` is the current completed release and `v0.11` remains conditional/planned
-- audited `docs/specs/API_STABILITY.md`; no changes were required
-- recorded final release checks:
-  - full pytest
-  - source/wheel build
-  - clean wheel smoke using `dist/pdelie-0.10.0-py3-none-any.whl`
-  - Heat and KdV example module execution
-  - `git diff --check`
-- recorded required release PR CI checks:
-  - `v0_10-release-gate`
-  - `editable-tests`
-  - `package-smoke`
-- recorded direct final Git tag path:
-  - merge release PR after CI is green
-  - tag merged `main` commit as `v0.10.0`
-  - do not publish to TestPyPI
-  - do not publish to PyPI
-  - defer package-index publishing until `v1.0` or later
-- verified no new PDE, weak KdV, weak derivative API, broad adapter, operator API, root runtime export, or canonical reporting object landed
-
-### Acceptance Criteria
-
-- full test suite passes
-- build and clean wheel smoke pass
-- current release gate passes
-- release-facing docs describe supportability / `v1.0` readiness, not new PDE support
-- package-index publishing decision is explicit
+- if promoted, add a compact release gate and release-facing docs
+- if not promoted, document the no-go/defer evidence and leave the stable public surface unchanged
+- keep package-index publishing policy unchanged unless separately scoped
 
 ---
 
@@ -336,37 +190,37 @@ Close `v0.10` with aligned release-facing docs, package metadata, release gate, 
 
 Locked sequence:
 
-Milestone 0 -> supportability scope reset
-Milestone 1 -> reporting semantics freeze
-Milestone 2 -> reporting helper implementation
-Milestone 3 -> example consistency
-Milestone 4 -> API stability audit and public-surface guards
-Milestone 5 -> CI cleanup and release-gate consolidation
-Milestone 6 -> release readiness and documentation alignment
+Milestone 0 -> KS feasibility scope reset
+Milestone 1 -> KS equation and numerical semantics freeze
+Milestone 2 -> KS feasibility generator / prototype
+Milestone 3 -> KS residual feasibility prototype
+Milestone 4 -> KS vertical-slice feasibility
+Milestone 5 -> promotion decision and imported-parity / non-goal guards
+Milestone 6 -> release gate / readiness or no-go closeout
 
 ---
 
 ## Rules
 
-- DO NOT add a new PDE in `v0.10`
-- DO NOT promote weak KdV in `v0.10`
-- DO NOT add a new weak derivative API in `v0.10`
-- DO NOT broaden `v0.10` into PDEBench, The Well, multidimensional, multivariable, nonuniform-grid, operator, or broad adapter work
-- DO NOT add manuscript-specific reporting logic
-- DO NOT add a new canonical object unless M1 proves runtime helpers cannot solve the supportability problem
-- DO NOT update `API_STABILITY.md` until a public `v0.10` API actually lands or an audit finds a real omission
-- DO preserve existing Heat/Burgers, v0.8 weak-report, and v0.9 KdV behavior
-- DO keep historical release-gate tests runnable locally through any CI cleanup
+- DO NOT add public KS APIs in M0.
+- DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands or an audit finds a real omission.
+- DO NOT describe `v0.11` as unconditional stable KS support before M5.
+- DO NOT promote weak KS in `v0.11`.
+- DO NOT add a new weak derivative API in `v0.11`.
+- DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
+- DO NOT add custom KS initial-condition APIs or configurable KS coefficient families unless a later milestone explicitly freezes them.
+- DO NOT add manuscript-specific logic.
+- DO preserve existing Heat/Burgers, `v0.8` weak-report, `v0.9` KdV, and `v0.10` reporting behavior.
 
 ---
 
 ## Status
 
-- `v0.9`: COMPLETE
+- `v0.10`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: COMPLETE
-- Milestone 2: COMPLETE
-- Milestone 3: COMPLETE
-- Milestone 4: COMPLETE
-- Milestone 5: COMPLETE
-- Milestone 6: COMPLETE
+- Milestone 1: PENDING
+- Milestone 2: PENDING
+- Milestone 3: PENDING
+- Milestone 4: PENDING
+- Milestone 5: PENDING
+- Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,19 +2,18 @@
 
 ## Current Release Status
 
-**V0.11 committed as Kuramoto-Sivashinsky feasibility-first**
+**V0.11 complete as Kuramoto-Sivashinsky feasibility/no-go closeout**
 
-This file is the active execution record for the `v0.11` release series.
+This file is the completed execution record for the `v0.11` release series.
 
-`v0.11` is a feasibility-first release.
-It evaluates whether normalized scalar 1D periodic Kuramoto-Sivashinsky can be promoted safely into the stable strong-path runtime surface.
+`v0.11` is a feasibility-first release that evaluated whether normalized scalar 1D periodic Kuramoto-Sivashinsky could be promoted safely into the stable strong-path runtime surface.
 
 Candidate stable path:
 
 `canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
 
-Stable runtime promotion is conditional.
-`v0.11` may close either as stable KS promotion or as an explicit no-go/defer feasibility release.
+Stable KS runtime promotion is deferred.
+`v0.11` closes as an explicit no-go/defer feasibility release while retaining the public order-4 derivative extension.
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -350,17 +349,40 @@ Make the explicit stable-promotion versus no-go decision.
 
 ## Milestone 6 - Release Gate / Readiness or No-go Closeout
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Close `v0.11` according to the M5 decision.
 
-### Planned Outcome
+### Completed Outcome
 
-- if promoted, add a compact release gate and release-facing docs
-- if not promoted, document the no-go/defer evidence and leave the stable public surface unchanged
-- keep package-index publishing policy unchanged unless separately scoped
+- added compact `tests/test_v0_11_release_gate.py`
+- replaced the explicit current CI release-gate job with `v0_11-release-gate`
+- kept full `editable-tests` and `package-smoke` CI coverage
+- kept package smoke compact:
+  - stable root imports
+  - `pdelie.reporting` submodule imports
+  - weak Heat report smoke
+  - KdV strong-path residual smoke
+  - order-4 derivative smoke
+- bumped package metadata to `0.11.0`
+- aligned README and changelog with the `v0.11` no-go/defer closeout
+- created `docs/releases/V0_11_RELEASE_READINESS.md`
+- updated publishing docs to include `v0.11.0` in the Git-tag-only `v0.x` deferral policy
+- updated `ROADMAP.md` to mark `v0.11` completed and leave `v0.12+` conditional
+- audited `docs/specs/API_STABILITY.md`
+- left `API_STABILITY.md` unchanged because it already documented only the order-4 derivative extension and no stable KS generator/residual APIs
+- left the stable public surface unchanged except for the existing M2 order-4 derivative API
+- documented that no PyPI or TestPyPI publishing is part of `v0.11`
+
+### Acceptance Criteria
+
+- `v0_11-release-gate`, `editable-tests`, and `package-smoke` are the required CI checks before tagging
+- release-facing docs describe `v0.11` as a KS feasibility/no-go release
+- `pyproject.toml` version is `0.11.0`
+- no stable KS generator, residual evaluator, example, imported parity, weak API, or root export lands
+- release docs state package-index publishing remains deferred until `v1.0` or later
 
 ---
 
@@ -374,7 +396,7 @@ Milestone 2 -> KS feasibility generator / prototype
 Milestone 3 -> KS residual feasibility prototype
 Milestone 4 -> KS vertical-slice feasibility
 Milestone 5 -> promotion decision and imported-parity / non-goal guards
-Milestone 6 -> release gate / readiness or no-go closeout
+Milestone 6 -> release gate / readiness and no-go closeout
 
 ---
 
@@ -407,4 +429,4 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
 - Milestone 5: COMPLETE
-- Milestone 6: PENDING
+- Milestone 6: COMPLETE

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -304,17 +304,47 @@ Run the candidate KS path through the existing strong-path fitting and verificat
 
 ## Milestone 5 - Promotion Decision and Imported-Parity / Non-goal Guards
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Make the explicit stable-promotion versus no-go decision.
 
-### Planned Outcome
+### Completed Outcome
 
-- if KS promotion is justified, freeze public API names and representative imported parity
-- if KS promotion is not justified, close the branch as no-go/defer without runtime API expansion
-- keep weak KS, broad adapters, operator APIs, and root exports absent
+- decided to defer stable KS promotion for `v0.11`
+- recorded the outcome as no-go/defer for stable KS runtime APIs in this release
+- preserved the M2 public derivative extension as the only public `v0.11` API change so far:
+  - `compute_spectral_fd_derivatives(..., max_spatial_order=4)`
+- recorded M4 feasibility evidence:
+  - residual evaluation passes with large margin:
+    - max absolute residual: `2.276047466221332e-09`
+    - RMS residual: `3.450580898077348e-10`
+  - mass conservation passes with large margin:
+    - mass drift: `4.686823294199099e-16`
+  - held-out canonical translation verification passes:
+    - first-epsilon heldout verification error: `2.533384127588474e-13`
+    - verification classification: `exact`
+  - selected span distance passes because canonical reference fallback is used:
+    - selected span distance: `0.0`
+    - fit mode: `reference_fallback`
+    - fallback reason: `svd_translation_span_drift`
+  - direct SVD span distance is out of tolerance:
+    - SVD span distance: `0.4178159498317849`
+  - M4 evidence label: `reference_fallback`
+- recorded that the M4 evidence is strong feasibility evidence but not direct residual-based fitting recovery
+- kept KS as internal feasibility evidence in `v0.11`
+- did not add stable KS data generator, residual evaluator, vertical-slice example, imported parity, root export, weak KS API, or broad adapter scope
+- skipped KS imported parity because there is no stable public KS runtime surface to validate
+- added focused no-go guard coverage tying the decision to reference-fallback evidence and absent public KS APIs
+
+### Acceptance Criteria
+
+- M4 feasibility tests remain green
+- public KS generator/residual/example exports remain absent
+- `API_STABILITY.md` still documents no stable public KS generator or residual evaluator
+- `PLAN.md` and `V0_11_SCOPE.md` state KS promotion is deferred for `v0.11`
+- no runtime source files change in M5
 
 ---
 
@@ -356,6 +386,8 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - DO NOT treat the internal M2 KS generator helper as public API.
 - DO NOT treat the internal M3 KS residual evaluator as public API.
 - DO NOT treat M4 fallback-backed verification as direct KS residual-fit recovery.
+- DO NOT add KS imported parity unless a stable public KS runtime surface is promoted.
+- DO NOT promote a stable KS generator, residual evaluator, or example in `v0.11` after the M5 no-go/defer decision.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT add a new weak derivative API in `v0.11`.
@@ -374,5 +406,5 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
-- Milestone 5: PENDING
+- Milestone 5: COMPLETE
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -205,18 +205,49 @@ Create or adapt a deterministic KS feasibility generator/prototype under the fro
 
 ## Milestone 3 - KS Residual Feasibility Prototype
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Evaluate the strong-form KS residual path under the frozen semantics.
 
-### Planned Outcome
+### Completed Outcome
 
-- test derivative requirements and residual diagnostics
-- verify typed validation behavior
-- measure residual thresholds on frozen feasibility fixtures
-- keep public residual evaluator promotion conditional
+- added internal `KSFeasibilityResidualEvaluator` under test helpers only
+- implemented frozen residual:
+  - `u_t + u*u_x + u_xx + u_xxxx`
+- implemented derivative contract:
+  - omitted derivatives compute `compute_spectral_fd_derivatives(field, max_spatial_order=4)`
+  - supplied derivatives must validate against the field
+  - supplied derivatives must include `u_t`, `u_x`, `u_xx`, and `u_xxxx`
+  - `u_xxx` may be present but is not used
+- returned `ResidualBatch(definition_type="analytic", normalization="none")`
+- froze diagnostics:
+  - `equation`
+  - `backend`
+  - `max_abs_residual`
+  - `rms_residual`
+- verified local validation:
+  - dims exactly `("batch", "time", "x", "var")`
+  - scalar `var`
+  - finite unmasked values
+  - periodic `x`
+  - `field.metadata["parameter_tags"]["equation"] == "ks_normalized"`
+- verified valid-looking Heat and KdV fields are rejected by equation tag
+- verified public KS generator/residual/root exports remain absent
+- observed frozen-fixture residual diagnostics:
+  - max absolute residual: `4.042559716230937e-09`
+  - RMS residual: `3.756593955706264e-10`
+- kept public residual evaluator promotion conditional
+- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M3
+
+### Acceptance Criteria
+
+- internal and explicit order-4 derivative residual paths match
+- order-3 derivatives fail clearly because `u_xxxx` is missing
+- residual diagnostics satisfy M1 feasibility targets
+- public-surface tests keep KS generator and residual APIs absent
+- no README, changelog, package metadata, release-readiness docs, or CI changes land in M3
 
 ---
 
@@ -289,6 +320,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - DO NOT update `API_STABILITY.md` for KS generator or residual APIs until those public APIs actually land or an audit finds a real omission.
 - DO NOT describe `v0.11` as unconditional stable KS support before M5.
 - DO NOT treat the internal M2 KS generator helper as public API.
+- DO NOT treat the internal M3 KS residual evaluator as public API.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT add a new weak derivative API in `v0.11`.
@@ -305,7 +337,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: PENDING
+- Milestone 3: COMPLETE
 - Milestone 4: PENDING
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -25,7 +25,7 @@ Contracts and stable behavior belong in:
 - `docs/planning/ROADMAP.md`
 - `docs/planning/V0_11_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0/M1 and remains unchanged because no new `v0.11` public API has landed yet.
+`API_STABILITY.md` was audited in M0/M1, then updated in M2 when the public order-4 derivative API landed.
 It must be updated in the same milestone where any public KS API or other public API lands.
 
 ---
@@ -152,18 +152,54 @@ Freeze the exact normalized KS equation and numerical semantics before any runti
 
 ## Milestone 2 - KS Feasibility Generator / Prototype
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Create or adapt a deterministic KS feasibility generator/prototype under the frozen M1 semantics.
 
-### Planned Outcome
+### Completed Outcome
 
-- evaluate short-horizon rollout stability
-- record supported fixture sizes, seeds, and numerical margins
-- keep any prototype internal unless the milestone explicitly freezes a public API
-- avoid custom initial-condition APIs and configurable coefficient families
+- extended public `compute_spectral_fd_derivatives(...)` to accept `max_spatial_order=4`
+- preserved default `max_spatial_order=2` behavior, arrays, config, and diagnostics
+- froze order-4 derivative output keys:
+  - `u_t`
+  - `u_x`
+  - `u_xx`
+  - `u_xxx`
+  - `u_xxxx`
+- computed `u_xxxx` with the same FFT wavenumber convention as the existing spectral derivatives
+- kept invalid derivative orders rejected with typed `ScopeValidationError`
+- updated `docs/specs/API_STABILITY.md` for the public order-4 derivative API
+- added internal KS feasibility generator helpers under tests only
+- froze internal KS generator defaults:
+  - `seed = 11101`
+  - `batch_size = 5`
+  - `num_times = 33`
+  - `num_points = 128`
+  - `max_time = 0.2`
+  - `num_modes = 6`
+  - `amplitude = 0.08`
+  - `num_substeps = 8`
+  - `domain_length = 32*pi`
+- froze KS rollout evolution:
+  - `u_t = -u*u_x - u_xx - u_xxxx`
+- froze nonlinear evaluation:
+  - conservative spectral form `u*u_x = 0.5*(u^2)_x`
+  - two-thirds dealiasing for nonlinear products
+- froze ETDRK4 as the internal rollout scheme
+- explicitly preserved the zero Fourier mode through rollout
+- verified the internal generator is deterministic, canonical, finite, zero-mean, and mass-preserving within the M1 target
+- verified exact Fourier `u_xxxx` sign convention through derivative tests
+- verified no public KS generator, residual evaluator, root export, custom initial-condition API, or configurable KS coefficient family landed
+
+### Acceptance Criteria
+
+- order-4 derivative tests pass
+- internal KS generator feasibility tests pass
+- `API_STABILITY.md` documents only the public derivative extension, not KS generator/residual APIs
+- public-surface tests keep KS generator and residual APIs absent
+- no README, changelog, package metadata, release-readiness docs, or CI changes land in M2
 
 ---
 
@@ -250,8 +286,9 @@ Milestone 6 -> release gate / readiness or no-go closeout
 ## Rules
 
 - DO NOT add public KS APIs in M0.
-- DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands or an audit finds a real omission.
+- DO NOT update `API_STABILITY.md` for KS generator or residual APIs until those public APIs actually land or an audit finds a real omission.
 - DO NOT describe `v0.11` as unconditional stable KS support before M5.
+- DO NOT treat the internal M2 KS generator helper as public API.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT add a new weak derivative API in `v0.11`.
@@ -267,7 +304,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - `v0.10`: COMPLETE
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: PENDING
+- Milestone 2: COMPLETE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -253,18 +253,52 @@ Evaluate the strong-form KS residual path under the frozen semantics.
 
 ## Milestone 4 - KS Vertical-Slice Feasibility
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Run the candidate KS path through the existing strong-path fitting and verification stack.
 
-### Planned Outcome
+### Completed Outcome
 
-- build a deterministic KS vertical-slice fixture
-- run derivative computation, residual evaluation, translation fitting, and held-out verification
-- record span-distance and verification margins
-- decide whether the evidence is strong enough to continue toward promotion
+- added internal KS vertical-slice feasibility coverage under tests only
+- used frozen KS fixture from `generate_ks_feasibility_field_batch()`
+- split train/heldout with `train_size = 2` and `seed = 11102`
+- computed train derivatives with `compute_spectral_fd_derivatives(..., max_spatial_order=4)`
+- evaluated train residual with internal `KSFeasibilityResidualEvaluator`
+- fit with `fit_translation_generator(..., epsilon=1e-4)`
+- verified heldout data with `verify_translation_generator(...)`
+- verified derivative keys:
+  - `u_t`
+  - `u_x`
+  - `u_xx`
+  - `u_xxx`
+  - `u_xxxx`
+- observed M4 feasibility metrics:
+  - residual max absolute value: `2.276047466221332e-09`
+  - residual RMS value: `3.450580898077348e-10`
+  - mass drift: `4.686823294199099e-16`
+  - relative L2 drift: `0.0070894859776733715`
+  - selected span distance: `0.0`
+  - SVD span distance: `0.4178159498317849`
+  - fit mode: `reference_fallback`
+  - reference fallback used: `True`
+  - fallback reason: `svd_translation_span_drift`
+  - first-epsilon heldout verification error: `2.533384127588474e-13`
+  - verification classification: `exact`
+  - transform mode: `uniform_translation`
+  - evidence label: `reference_fallback`
+- recorded that relative L2 drift is diagnostic-only for KS
+- recorded that KS feasibility passed via reference fallback, not direct SVD in-tolerance recovery
+- verified no public KS generator, residual evaluator, root export, example, broad adapter, or runtime surface landed
+
+### Acceptance Criteria
+
+- KS vertical slice passes M1 feasibility thresholds for residual, mass drift, selected span, first-epsilon verification error, and classification
+- relative L2 drift is recorded but not used as a gate
+- fallback-backed evidence records fallback reason and SVD span distance
+- repeated vertical-slice summaries are deterministic within numerical tolerance
+- public-surface tests keep KS generator and residual APIs absent
 
 ---
 
@@ -321,6 +355,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - DO NOT describe `v0.11` as unconditional stable KS support before M5.
 - DO NOT treat the internal M2 KS generator helper as public API.
 - DO NOT treat the internal M3 KS residual evaluator as public API.
+- DO NOT treat M4 fallback-backed verification as direct KS residual-fit recovery.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT add a new weak derivative API in `v0.11`.
@@ -338,6 +373,6 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
-- Milestone 4: PENDING
+- Milestone 4: COMPLETE
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -25,7 +25,7 @@ Contracts and stable behavior belong in:
 - `docs/planning/ROADMAP.md`
 - `docs/planning/V0_11_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.11` public API lands in M0.
+`API_STABILITY.md` was audited in M0/M1 and remains unchanged because no new `v0.11` public API has landed yet.
 It must be updated in the same milestone where any public KS API or other public API lands.
 
 ---
@@ -86,20 +86,67 @@ M0 is complete only if:
 
 ## Milestone 1 - KS Equation and Numerical Semantics Freeze
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Freeze the exact normalized KS equation and numerical semantics before any runtime prototype or public API is considered.
 
-### Planned Outcome
+### Completed Outcome
 
-- choose the exact normalized KS equation form and sign convention
-- freeze derivative-order requirements
-- freeze coordinate and boundary conventions
-- freeze candidate diagnostic metrics
-- freeze preliminary residual, conservation, fitting, and verification thresholds for feasibility work
-- keep public API names and stable promotion conditional
+- froze normalized nonconservative strong-form KS:
+  - `u_t + u*u_x + u_xx + u_xxxx = 0`
+- froze residual form:
+  - `u_t + u*u_x + u_xx + u_xxxx`
+- recorded the equivalent conservative nonlinear term `1/2*(u^2)_x` as explanatory only
+- froze required KS residual derivatives:
+  - `u_t`
+  - `u_x`
+  - `u_xx`
+  - `u_xxxx`
+- recorded that `u_xxx` is not required by the KS residual evaluator
+- froze future derivative-backend strategy:
+  - later `compute_spectral_fd_derivatives(..., max_spatial_order=4)` emits `u_t`, `u_x`, `u_xx`, `u_xxx`, and `u_xxxx`
+  - default `max_spatial_order=2` must preserve current behavior, arrays, config, and diagnostics
+  - `u_xxxx` must use the same FFT wavenumber convention as existing `u_x`, `u_xx`, and `u_xxx`
+  - unsupported orders still raise `ScopeValidationError`
+- froze coordinate and fixture conventions:
+  - dims exactly `("batch", "time", "x", "var")`
+  - scalar finite unmasked values only
+  - `x = linspace(0, domain_length, num_points, endpoint=False)`
+  - `time = linspace(0, max_time, num_times)`
+  - strictly increasing uniform `time`
+  - uniform periodic `x`
+  - zero-mean Fourier-mode initial conditions for synthetic feasibility fixtures
+  - two-thirds dealiasing
+  - periodic RK-style rollout unless M2 proves unsuitable
+- froze feasibility diagnostics:
+  - residual `max_abs_residual`
+  - residual `rms_residual`
+  - mass drift as the conserved diagnostic
+  - relative L2 drift as diagnostic-only
+  - translation span distance
+  - first-epsilon held-out verification error
+  - verification classification with acceptance requiring only `classification != "failed"`
+- froze preliminary feasibility targets:
+  - residual max `< 5e-2`
+  - residual RMS `< 1e-2`
+  - mass drift `<= 1e-8`
+  - translation span distance `<= 1e-1`
+  - first-epsilon held-out verification error `< 5e-4`
+  - verification classification is not `failed`
+- recorded that these are feasibility targets, not release gates
+- recorded that M4 must replace or confirm them with observed-margin thresholds before stable KS promotion
+- kept public API names and stable promotion conditional
+- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M1
+- left runtime code, tests, package metadata, CI, README, changelog, and release-readiness docs unchanged
+
+### Acceptance Criteria
+
+- `V0_11_SCOPE.md` and `PLAN.md` agree on KS equation, derivative requirements, coordinate conventions, diagnostics, and preliminary targets
+- `ROADMAP.md` still describes `v0.11` as feasibility-first, not stable KS support
+- `API_STABILITY.md` remains unchanged during M1
+- no runtime code, tests, package metadata, CI, README, changelog, or release-readiness docs are edited in M1
 
 ---
 
@@ -205,6 +252,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 - DO NOT add public KS APIs in M0.
 - DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands or an audit finds a real omission.
 - DO NOT describe `v0.11` as unconditional stable KS support before M5.
+- DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT add a new weak derivative API in `v0.11`.
 - DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
@@ -218,7 +266,7 @@ Milestone 6 -> release gate / readiness or no-go closeout
 
 - `v0.10`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: PENDING
+- Milestone 1: COMPLETE
 - Milestone 2: PENDING
 - Milestone 3: PENDING
 - Milestone 4: PENDING

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -254,7 +254,7 @@ Frozen release definition:
 
 ---
 
-## Current Completed Release
+## Recent Completed Release
 
 ### `v0.10` - Supportability and `v1.0` readiness
 **Status:** Completed
@@ -317,40 +317,48 @@ The authoritative `v0.10` scope freeze belongs in:
 
 ---
 
-## Committed Release Target
+## Current Completed Release
 
 ### `v0.11` - Kuramoto-Sivashinsky strong-path feasibility
-**Status:** Committed / Feasibility-first
+**Status:** Completed / Feasibility no-go
 
-`v0.11` is the committed next release target after the `v0.10` supportability release.
+`v0.11` is the completed feasibility-first release after the `v0.10` supportability release.
 
 Its purpose is:
 
 > evaluate whether a normalized scalar 1D periodic Kuramoto-Sivashinsky strong path can be promoted safely into the stable runtime surface.
 
-Candidate stable path:
+Candidate stable path evaluated internally:
 
 `canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
 
+Completed scope:
+
+- stable public `compute_spectral_fd_derivatives(..., max_spatial_order=4)` with `u_xxxx`
+- internal normalized KS generator feasibility helper under tests only
+- internal KS residual feasibility helper under tests only
+- internal KS vertical-slice feasibility coverage
+- explicit no-go/defer decision for stable KS runtime promotion
+- compact `v0_11-release-gate` CI visibility
+
+Completed release definition:
+
+`existing Heat/Burgers/weak-report/KdV/reporting surfaces -> order-4 spectral derivatives -> internal KS feasibility evidence -> explicit stable-KS no-go/defer closeout`
+
 Release interpretation:
 
-- this is a feasibility-first release, not unconditional stable KS support
-- stable KS runtime promotion is conditional on observed numerical margin
-- `v0.11` may close as stable KS promotion or as an explicit no-go/defer feasibility release
+- this is a feasibility/no-go release, not stable KS support
+- order-4 spectral derivatives are stable public API
+- KS residual and vertical-slice feasibility evidence is internal only
+- stable KS runtime promotion is deferred because translation fitting is reference-fallback-backed, not direct SVD in-tolerance recovery
+- `v0.11.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
 
-Required before promotion:
+Explicit non-goals:
 
-- exact equation normalization
-- derivative-order requirements
-- generator stability regime
-- residual evaluator contract
-- residual, conservation, fitting, and verification thresholds with observed margin
-- imported-parity expectations
-- explicit non-goals around weak forms, broad adapters, root exports, and general PDE support
-
-Explicit M0 non-goals:
-
-- no public KS APIs in M0
+- no public KS generator
+- no public KS residual evaluator
+- no public KS vertical-slice example
+- no KS imported parity
 - no weak KS API
 - no broad dataset adapters
 - no multidimensional, multivariable, or nonuniform-grid expansion
@@ -363,21 +371,27 @@ The authoritative `v0.11` scope freeze belongs in:
 
 - `V0_11_SCOPE.md`
 
-### Feasibility Gate for `v0.11`
+### Release Gate for `v0.11`
 
-`v0.11` can only promote stable KS support if later milestones establish:
+`v0.11` is complete only if:
 
-- deterministic KS feasibility fixtures
-- controlled short-horizon rollout stability
-- derivative accuracy and residual thresholds with margin
-- translation fitting and held-out verification thresholds with margin
-- imported parity and public-surface guards if runtime APIs land
-
-If those conditions are not met, `v0.11` should close as a documented no-go/defer release without stable KS runtime expansion.
+- order-4 derivative behavior is documented and covered by tests
+- `API_STABILITY.md` states that order-4 derivatives do not add stable KS generator/residual APIs
+- internal KS feasibility evidence is recorded as reference-fallback-backed
+- public KS generator, residual evaluator, example, weak API, and root exports remain absent
+- CI uses `v0_11-release-gate` plus full editable tests and package smoke
+- package/readiness docs state the no-go/defer decision clearly
 
 ---
 
-## Most Recent Prior Completed Release
+## No Committed Release Target
+
+No next release is committed after `v0.11`.
+`v0.12+` remains planned and conditional until a separate scope freeze is accepted.
+
+---
+
+## Earlier Completed KdV Release
 
 ### `v0.9` - Stable normalized periodic KdV strong path
 **Status:** Completed
@@ -501,7 +515,7 @@ The authoritative `v0.7` scope freeze belongs in:
 ### `v0.12+` - Later PDE and dataset coverage
 **Status:** Planned
 
-Later PDE and dataset coverage remains planned after the supportability release and the committed `v0.11` KS feasibility-first work.
+Later PDE and dataset coverage remains planned after the supportability release and the completed `v0.11` KS feasibility no-go closeout.
 
 Candidate directions:
 
@@ -552,6 +566,7 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_8_SCOPE.md` once frozen
 - `V0_9_SCOPE.md` once frozen
 - `V0_10_SCOPE.md` once frozen
+- `V0_11_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -586,7 +601,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.8` = window-indexed weak residual reports and representative robustness comparisons
 - `v0.9` = stable normalized periodic short-horizon KdV strong path
 - `v0.10` = supportability and `v1.0` readiness for the existing stable engine
-- `v0.11` = Kuramoto-Sivashinsky strong-path feasibility, with stable promotion conditional on evidence
+- `v0.11` = order-4 spectral derivatives and Kuramoto-Sivashinsky feasibility no-go/defer closeout
 - `v0.12+` = wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -317,6 +317,66 @@ The authoritative `v0.10` scope freeze belongs in:
 
 ---
 
+## Committed Release Target
+
+### `v0.11` - Kuramoto-Sivashinsky strong-path feasibility
+**Status:** Committed / Feasibility-first
+
+`v0.11` is the committed next release target after the `v0.10` supportability release.
+
+Its purpose is:
+
+> evaluate whether a normalized scalar 1D periodic Kuramoto-Sivashinsky strong path can be promoted safely into the stable runtime surface.
+
+Candidate stable path:
+
+`canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
+
+Release interpretation:
+
+- this is a feasibility-first release, not unconditional stable KS support
+- stable KS runtime promotion is conditional on observed numerical margin
+- `v0.11` may close as stable KS promotion or as an explicit no-go/defer feasibility release
+
+Required before promotion:
+
+- exact equation normalization
+- derivative-order requirements
+- generator stability regime
+- residual evaluator contract
+- residual, conservation, fitting, and verification thresholds with observed margin
+- imported-parity expectations
+- explicit non-goals around weak forms, broad adapters, root exports, and general PDE support
+
+Explicit M0 non-goals:
+
+- no public KS APIs in M0
+- no weak KS API
+- no broad dataset adapters
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no custom KS initial-condition API
+- no configurable KS coefficient family
+- no operator-facing symmetry work
+- no manuscript-specific logic
+
+The authoritative `v0.11` scope freeze belongs in:
+
+- `V0_11_SCOPE.md`
+
+### Feasibility Gate for `v0.11`
+
+`v0.11` can only promote stable KS support if later milestones establish:
+
+- deterministic KS feasibility fixtures
+- controlled short-horizon rollout stability
+- derivative accuracy and residual thresholds with margin
+- translation fitting and held-out verification thresholds with margin
+- imported parity and public-surface guards if runtime APIs land
+
+If those conditions are not met, `v0.11` should close as a documented no-go/defer release without stable KS runtime expansion.
+
+---
+
 ## Most Recent Prior Completed Release
 
 ### `v0.9` - Stable normalized periodic KdV strong path
@@ -438,35 +498,10 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
-### `v0.11` - Next strong-path PDE feasibility or promotion
-**Status:** Planned / Conditional
-
-`v0.11` may add the next stable strong-path PDE only if `v0.10` leaves the public engine clean and the new PDE passes a serious feasibility/scope-freeze phase.
-
-Likely direction:
-
-- Kuramoto-Sivashinsky or another scalar 1D periodic strong-path PDE
-
-Required before commitment:
-
-- exact equation normalization
-- derivative-order requirements
-- generator stability regime
-- residual evaluator contract
-- vertical-slice thresholds with observed margin
-- imported-parity expectations
-- explicit non-goals around weak forms, broad adapters, and general PDE support
-
-Interpretation:
-
-- Kuramoto-Sivashinsky is attractive because it stress-tests higher-order scalar periodic numerics
-- it should not be promoted until stiffness, rollout stability, derivative accuracy, and residual thresholds are controlled
-- `v0.11` should start as a feasibility/scope-freeze effort, not assume stable promotion from the outset
-
 ### `v0.12+` - Later PDE and dataset coverage
 **Status:** Planned
 
-Later PDE and dataset coverage remains planned after the supportability release and any conditional `v0.11` strong-path work.
+Later PDE and dataset coverage remains planned after the supportability release and the committed `v0.11` KS feasibility-first work.
 
 Candidate directions:
 
@@ -551,7 +586,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.8` = window-indexed weak residual reports and representative robustness comparisons
 - `v0.9` = stable normalized periodic short-horizon KdV strong path
 - `v0.10` = supportability and `v1.0` readiness for the existing stable engine
-- `v0.11` = conditional next strong-path PDE feasibility or promotion
+- `v0.11` = Kuramoto-Sivashinsky strong-path feasibility, with stable promotion conditional on evidence
 - `v0.12+` = wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/V0_11_SCOPE.md
+++ b/docs/planning/V0_11_SCOPE.md
@@ -1,0 +1,161 @@
+# V0.11 Scope Freeze
+
+## Summary
+
+`v0.11` is the Kuramoto-Sivashinsky feasibility-first release for `pdelie`.
+
+Its purpose is:
+
+> evaluate whether a normalized scalar 1D periodic Kuramoto-Sivashinsky strong path can be promoted safely into the stable runtime surface.
+
+Stable runtime promotion is conditional.
+M0 does not commit a public KS generator, residual evaluator, vertical slice, imported parity path, or release gate.
+
+Candidate stable path:
+
+`canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
+
+`v0.11` may close in one of two ways:
+
+- stable KS promotion, if later milestones show enough numerical margin and supportability
+- explicit no-go/defer closeout, if the feasibility evidence is not strong enough for a stable `v0.x` surface
+
+---
+
+## Feasibility Scope
+
+The `v0.11` feasibility scope is limited to:
+
+- scalar 1D uniform periodic fields
+- canonical `FieldBatch` inputs
+- spectral finite-difference derivative backends already in the stable engine
+- normalized Kuramoto-Sivashinsky strong-form feasibility
+- polynomial translation fitting and held-out verification through existing runtime paths
+- deterministic synthetic feasibility fixtures
+- eventual imported parity only through existing structured ingestion APIs if promotion remains plausible
+
+M0 intentionally does not freeze:
+
+- exact KS equation normalization
+- derivative-order requirements
+- generator rollout method
+- generator stability regime
+- residual evaluator contract
+- residual, conservation, fitting, or verification thresholds
+- imported-parity requirements
+- public API names
+
+Those decisions belong to later milestones after feasibility evidence exists.
+
+---
+
+## Candidate Public Surface
+
+If promotion succeeds, the likely public runtime surface is:
+
+- a KS synthetic data generator under `pdelie.data`
+- a KS strong-form residual evaluator under `pdelie.residuals`
+- a KS vertical-slice example under `pdelie.examples`
+
+All candidate APIs remain uncommitted in M0.
+No `API_STABILITY.md` update is made until an actual public `v0.11` API lands.
+
+Candidate KS APIs must remain submodule-only unless a later milestone explicitly freezes otherwise.
+No root `pdelie` exports are part of M0.
+
+---
+
+## Promotion Gate
+
+Stable KS promotion requires later milestones to establish:
+
+- exact equation normalization
+- derivative accuracy and order requirements
+- deterministic generator behavior
+- controlled short-horizon rollout stability
+- residual thresholds with observed margin
+- conservation or diagnostic metrics appropriate to the chosen normalized equation
+- translation fit and held-out verification thresholds with observed margin
+- imported parity expectations, if the runtime surface is promoted
+- explicit public API and non-goal guards
+
+If these are not established, `v0.11` should close as an explicit feasibility no-go/defer release rather than landing a weak stable surface.
+
+---
+
+## Explicit Non-goals
+
+M0 explicitly forbids:
+
+- weak KS
+- weak derivative expansion
+- broad dataset adapters
+- multidimensional grids
+- nonuniform grids
+- multivariable systems
+- custom KS initial-condition APIs
+- configurable KS coefficient families
+- operator-facing symmetry work
+- root `pdelie` exports for KS
+- package metadata changes
+- README/changelog/release-readiness updates
+- manuscript-specific thresholds, reports, figures, or experiment logic
+
+---
+
+## Milestones
+
+### Milestone 0 - KS Feasibility Scope Reset
+
+Promote `v0.11` to committed feasibility-first status, add this scope freeze, reset `PLAN.md`, and audit `API_STABILITY.md` without changing it.
+
+### Milestone 1 - KS Equation and Numerical Semantics Freeze
+
+Freeze exact normalized KS equation form, derivative requirements, coordinate conventions, candidate diagnostics, and preliminary feasibility thresholds.
+
+### Milestone 2 - KS Feasibility Generator / Prototype
+
+Build or adapt an internal deterministic KS feasibility generator/prototype without committing a stable runtime API unless the milestone explicitly freezes one.
+
+### Milestone 3 - KS Residual Feasibility Prototype
+
+Evaluate the strong-form KS residual path with typed validation and diagnostics, while keeping public API promotion conditional.
+
+### Milestone 4 - KS Vertical-Slice Feasibility
+
+Run the candidate KS path through derivative computation, residual evaluation, translation fitting, and held-out verification on frozen feasibility fixtures.
+
+### Milestone 5 - Promotion Decision and Imported-Parity / Non-goal Guards
+
+Make the explicit stable-promotion versus no-go decision.
+If promotion proceeds, add representative imported parity and public-surface guards.
+If not, close KS as deferred without runtime API expansion.
+
+### Milestone 6 - Release Gate / Readiness or No-go Closeout
+
+If promoted, add the compact release gate and release-facing docs.
+If not promoted, document the no-go/defer evidence and leave the stable public surface unchanged.
+
+---
+
+## Rules
+
+- DO NOT add public KS APIs in M0.
+- DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands.
+- DO NOT promote weak KS in `v0.11`.
+- DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
+- DO NOT add manuscript-specific logic.
+- DO preserve existing Heat/Burgers, `v0.8` weak-report, `v0.9` KdV, and `v0.10` reporting behavior.
+
+---
+
+## Status
+
+- `v0.10`: COMPLETE
+- Milestone 0: COMPLETE
+- Milestone 1: PENDING
+- Milestone 2: PENDING
+- Milestone 3: PENDING
+- Milestone 4: PENDING
+- Milestone 5: PENDING
+- Milestone 6: PENDING

--- a/docs/planning/V0_11_SCOPE.md
+++ b/docs/planning/V0_11_SCOPE.md
@@ -34,18 +34,112 @@ The `v0.11` feasibility scope is limited to:
 - deterministic synthetic feasibility fixtures
 - eventual imported parity only through existing structured ingestion APIs if promotion remains plausible
 
-M0 intentionally does not freeze:
+M1 freezes the equation and numerical semantics below.
+Generator implementation details, promotion status, imported-parity requirements, and public API names remain conditional until later milestones.
 
-- exact KS equation normalization
-- derivative-order requirements
-- generator rollout method
-- generator stability regime
-- residual evaluator contract
-- residual, conservation, fitting, or verification thresholds
-- imported-parity requirements
-- public API names
+---
 
-Those decisions belong to later milestones after feasibility evidence exists.
+## KS Equation and Numerical Semantics
+
+Frozen normalized strong form:
+
+```text
+u_t + u*u_x + u_xx + u_xxxx = 0
+```
+
+Frozen residual form:
+
+```text
+u_t + u*u_x + u_xx + u_xxxx
+```
+
+Equation form:
+
+- normalized
+- nonconservative
+- strong-form residual
+- scalar `u`
+- one periodic spatial dimension `x`
+
+The equivalent conservative nonlinear term may be written as `1/2*(u^2)_x` in explanatory text, but runtime residual semantics use `u*u_x`.
+
+Required derivatives for KS residual feasibility:
+
+- `u_t`
+- `u_x`
+- `u_xx`
+- `u_xxxx`
+
+`u_xxx` is not required by the KS residual evaluator.
+If the derivative backend emits it as part of an order-4 derivative batch, the KS residual must not depend on it.
+
+Periodic boundary terms are assumed through canonical periodic `x`.
+
+---
+
+## Future Derivative Backend Semantics
+
+If KS feasibility proceeds to runtime implementation, the planned derivative extension is:
+
+```python
+compute_spectral_fd_derivatives(
+    field: FieldBatch,
+    *,
+    max_spatial_order: int = 4,
+) -> DerivativeBatch
+```
+
+Frozen order-4 behavior:
+
+- `max_spatial_order=4` emits `u_t`, `u_x`, `u_xx`, `u_xxx`, and `u_xxxx`
+- `max_spatial_order=2` remains the default and preserves current behavior, arrays, config, and diagnostics
+- `u_xxxx` uses the same FFT wavenumber convention already used for `u_x`, `u_xx`, and `u_xxx`
+- unsupported orders raise `ScopeValidationError`
+
+`API_STABILITY.md` is updated only when the order-4 public derivative API actually lands.
+
+---
+
+## Coordinate and Fixture Conventions
+
+Frozen feasibility conventions:
+
+- canonical dims are exactly `("batch", "time", "x", "var")`
+- scalar `var` only
+- finite unmasked values only
+- `x = linspace(0, domain_length, num_points, endpoint=False)`
+- `time = linspace(0, max_time, num_times)`
+- `time` is strictly increasing and uniform
+- `x` is uniform and periodic
+- synthetic feasibility fixtures should use zero-mean Fourier-mode initial conditions
+- synthetic feasibility fixtures should use two-thirds dealiasing
+- synthetic feasibility fixtures should use periodic RK-style rollout unless M2 proves this unsuitable
+
+---
+
+## Feasibility Diagnostics and Preliminary Targets
+
+Frozen feasibility diagnostics:
+
+- residual `max_abs_residual`
+- residual `rms_residual`
+- mass drift as the conserved diagnostic
+- relative L2 drift as diagnostic-only, not a conservation gate
+- translation span distance
+- first-epsilon held-out verification error
+- verification classification, with acceptance requiring only `classification != "failed"`
+
+Preliminary feasibility targets:
+
+- residual max `< 5e-2`
+- residual RMS `< 1e-2`
+- mass drift `<= 1e-8`
+- translation span distance `<= 1e-1`
+- first-epsilon held-out verification error `< 5e-4`
+- verification classification is not `failed`
+
+These are feasibility targets, not release gates.
+M4 must replace or confirm them with observed-margin thresholds before stable KS promotion.
 
 ---
 
@@ -111,7 +205,7 @@ Promote `v0.11` to committed feasibility-first status, add this scope freeze, re
 
 ### Milestone 1 - KS Equation and Numerical Semantics Freeze
 
-Freeze exact normalized KS equation form, derivative requirements, coordinate conventions, candidate diagnostics, and preliminary feasibility thresholds.
+Freeze the normalized KS equation as `u_t + u*u_x + u_xx + u_xxxx = 0`, freeze order-4 derivative semantics, coordinate conventions, candidate diagnostics, and preliminary feasibility targets.
 
 ### Milestone 2 - KS Feasibility Generator / Prototype
 
@@ -143,6 +237,7 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 - DO NOT add public KS APIs in M0.
 - DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands.
 - DO NOT promote weak KS in `v0.11`.
+- DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
 - DO NOT add manuscript-specific logic.
 - DO preserve existing Heat/Burgers, `v0.8` weak-report, `v0.9` KdV, and `v0.10` reporting behavior.
@@ -153,7 +248,7 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 
 - `v0.10`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: PENDING
+- Milestone 1: COMPLETE
 - Milestone 2: PENDING
 - Milestone 3: PENDING
 - Milestone 4: PENDING

--- a/docs/planning/V0_11_SCOPE.md
+++ b/docs/planning/V0_11_SCOPE.md
@@ -166,6 +166,40 @@ The KS generator remains an internal feasibility helper in M2 and does not becom
 
 ---
 
+## M5 Promotion Decision
+
+Stable KS promotion is deferred for `v0.11`.
+
+M2-M4 produced useful feasibility evidence, but not enough to land a stable public KS strong path in this release.
+The frozen KS fixture shows strong residual and canonical translation verification behavior:
+
+- residual max absolute value: `2.276047466221332e-09`
+- residual RMS value: `3.450580898077348e-10`
+- mass drift: `4.686823294199099e-16`
+- first-epsilon held-out verification error: `2.533384127588474e-13`
+- verification classification: `exact`
+
+The blocker for promotion is translation fitting evidence:
+
+- selected span distance passes because canonical reference fallback is used: `0.0`
+- direct SVD span distance is out of tolerance: `0.4178159498317849`
+- fit mode is `reference_fallback`
+- fallback reason is `svd_translation_span_drift`
+- M4 evidence label is `reference_fallback`
+
+Interpretation:
+
+- KS remains internal feasibility evidence in `v0.11`
+- no stable KS data generator lands in `v0.11`
+- no stable KS residual evaluator lands in `v0.11`
+- no KS vertical-slice example lands in `v0.11`
+- no KS imported parity lands in `v0.11` because there is no stable public KS runtime surface to validate
+- `compute_spectral_fd_derivatives(..., max_spatial_order=4)` remains the only public `v0.11` API change so far
+
+M6 should close `v0.11` as a no-go/defer feasibility release unless a later explicit scope change reopens the promotion decision.
+
+---
+
 ## Promotion Gate
 
 Stable KS promotion requires later milestones to establish:
@@ -228,14 +262,12 @@ Run the candidate KS path through derivative computation, residual evaluation, t
 
 ### Milestone 5 - Promotion Decision and Imported-Parity / Non-goal Guards
 
-Make the explicit stable-promotion versus no-go decision.
-If promotion proceeds, add representative imported parity and public-surface guards.
-If not, close KS as deferred without runtime API expansion.
+Complete the stable-promotion versus no-go decision.
+M5 defers stable KS promotion for `v0.11`, records the reference-fallback evidence, and keeps KS runtime APIs absent.
 
 ### Milestone 6 - Release Gate / Readiness or No-go Closeout
 
-If promoted, add the compact release gate and release-facing docs.
-If not promoted, document the no-go/defer evidence and leave the stable public surface unchanged.
+Document the no-go/defer evidence and leave the stable public surface unchanged.
 
 ---
 
@@ -244,6 +276,10 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 - DO NOT add public KS APIs in M0.
 - DO NOT update `API_STABILITY.md` for KS generator or residual APIs until those public APIs actually land.
 - DO NOT treat the internal M2 KS generator helper as public API.
+- DO NOT treat the internal M3 KS residual evaluator as public API.
+- DO NOT treat M4 fallback-backed verification as direct KS residual-fit recovery.
+- DO NOT add KS imported parity unless a stable public KS runtime surface is promoted.
+- DO NOT promote a stable KS generator, residual evaluator, or example in `v0.11` after the M5 no-go/defer decision.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
@@ -258,7 +294,7 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: PENDING
-- Milestone 4: PENDING
-- Milestone 5: PENDING
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
 - Milestone 6: PENDING

--- a/docs/planning/V0_11_SCOPE.md
+++ b/docs/planning/V0_11_SCOPE.md
@@ -77,15 +77,15 @@ Periodic boundary terms are assumed through canonical periodic `x`.
 
 ---
 
-## Future Derivative Backend Semantics
+## Public Derivative Backend Semantics
 
-If KS feasibility proceeds to runtime implementation, the planned derivative extension is:
+The public `v0.11` derivative extension is:
 
 ```python
 compute_spectral_fd_derivatives(
     field: FieldBatch,
     *,
-    max_spatial_order: int = 4,
+    max_spatial_order: int = 2,
 ) -> DerivativeBatch
 ```
 
@@ -96,7 +96,7 @@ Frozen order-4 behavior:
 - `u_xxxx` uses the same FFT wavenumber convention already used for `u_x`, `u_xx`, and `u_xxx`
 - unsupported orders raise `ScopeValidationError`
 
-`API_STABILITY.md` is updated only when the order-4 public derivative API actually lands.
+`API_STABILITY.md` documents this order-4 derivative API as the only public `v0.11` API change.
 
 ---
 
@@ -196,7 +196,7 @@ Interpretation:
 - no KS imported parity lands in `v0.11` because there is no stable public KS runtime surface to validate
 - `compute_spectral_fd_derivatives(..., max_spatial_order=4)` remains the only public `v0.11` API change so far
 
-M6 should close `v0.11` as a no-go/defer feasibility release unless a later explicit scope change reopens the promotion decision.
+M6 closes `v0.11` as a no-go/defer feasibility release.
 
 ---
 
@@ -267,7 +267,7 @@ M5 defers stable KS promotion for `v0.11`, records the reference-fallback eviden
 
 ### Milestone 6 - Release Gate / Readiness or No-go Closeout
 
-Document the no-go/defer evidence and leave the stable public surface unchanged.
+Add the compact `v0_11-release-gate`, align release-facing docs and package metadata, document the no-go/defer evidence, and leave the stable public surface unchanged except for the order-4 derivative API.
 
 ---
 
@@ -297,4 +297,4 @@ Document the no-go/defer evidence and leave the stable public surface unchanged.
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
 - Milestone 5: COMPLETE
-- Milestone 6: PENDING
+- Milestone 6: COMPLETE

--- a/docs/planning/V0_11_SCOPE.md
+++ b/docs/planning/V0_11_SCOPE.md
@@ -111,9 +111,13 @@ Frozen feasibility conventions:
 - `time = linspace(0, max_time, num_times)`
 - `time` is strictly increasing and uniform
 - `x` is uniform and periodic
-- synthetic feasibility fixtures should use zero-mean Fourier-mode initial conditions
-- synthetic feasibility fixtures should use two-thirds dealiasing
-- synthetic feasibility fixtures should use periodic RK-style rollout unless M2 proves this unsuitable
+- synthetic feasibility fixtures use zero-mean Fourier-mode initial conditions
+- synthetic feasibility fixtures use two-thirds dealiasing
+- synthetic feasibility rollout uses ETDRK4
+- rollout evolution is `u_t = -u*u_x - u_xx - u_xxxx`
+- nonlinear evaluation uses conservative spectral form `u*u_x = 0.5*(u^2)_x`
+- nonlinear products are dealised with the two-thirds rule
+- the zero Fourier mode is explicitly preserved through rollout
 
 ---
 
@@ -152,10 +156,13 @@ If promotion succeeds, the likely public runtime surface is:
 - a KS vertical-slice example under `pdelie.examples`
 
 All candidate APIs remain uncommitted in M0.
-No `API_STABILITY.md` update is made until an actual public `v0.11` API lands.
+No KS generator or residual entry is added to `API_STABILITY.md` until an actual public KS API lands.
 
 Candidate KS APIs must remain submodule-only unless a later milestone explicitly freezes otherwise.
 No root `pdelie` exports are part of M0.
+
+M2 adds only the public derivative-backend order-4 extension.
+The KS generator remains an internal feasibility helper in M2 and does not become public API.
 
 ---
 
@@ -209,7 +216,7 @@ Freeze the normalized KS equation as `u_t + u*u_x + u_xx + u_xxxx = 0`, freeze o
 
 ### Milestone 2 - KS Feasibility Generator / Prototype
 
-Build or adapt an internal deterministic KS feasibility generator/prototype without committing a stable runtime API unless the milestone explicitly freezes one.
+Extend the public derivative backend through `max_spatial_order=4`, then build an internal deterministic KS feasibility generator/prototype using ETDRK4, conservative spectral nonlinear evaluation, two-thirds dealiasing, and explicit zero-mode preservation.
 
 ### Milestone 3 - KS Residual Feasibility Prototype
 
@@ -235,7 +242,8 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 ## Rules
 
 - DO NOT add public KS APIs in M0.
-- DO NOT update `API_STABILITY.md` until a public `v0.11` API actually lands.
+- DO NOT update `API_STABILITY.md` for KS generator or residual APIs until those public APIs actually land.
+- DO NOT treat the internal M2 KS generator helper as public API.
 - DO NOT promote weak KS in `v0.11`.
 - DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
 - DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
@@ -249,7 +257,7 @@ If not promoted, document the no-go/defer evidence and leave the stable public s
 - `v0.10`: COMPLETE
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: PENDING
+- Milestone 2: COMPLETE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.10.0`, release completion means:
+For the current `v0.x` series, including `v0.11.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.10.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.10`.
+`v0.11.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.11`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_11_RELEASE_READINESS.md
+++ b/docs/releases/V0_11_RELEASE_READINESS.md
@@ -1,0 +1,166 @@
+# V0.11 Release Readiness
+
+## Release Target
+
+- package version: `0.11.0`
+- git tag: `v0.11.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.11.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.11`.
+
+## Done
+
+- M0 is complete:
+  - `v0.11` was frozen as a Kuramoto-Sivashinsky feasibility-first release
+  - `v0.10` was recorded as complete
+  - stable KS promotion was made conditional on evidence
+- M1 is complete:
+  - normalized KS semantics were frozen as `u_t + u*u_x + u_xx + u_xxxx = 0`
+  - fourth-derivative requirements and feasibility diagnostics were scoped
+- M2 is complete:
+  - `compute_spectral_fd_derivatives(..., max_spatial_order=4)` landed as the only public v0.11 API change
+  - internal KS feasibility generator helpers were added under tests only
+  - `API_STABILITY.md` documents the public order-4 derivative extension
+- M3 is complete:
+  - internal KS residual feasibility was validated under the frozen equation
+  - no public KS residual evaluator landed
+- M4 is complete:
+  - internal KS vertical-slice feasibility was run through fitting and held-out verification
+  - evidence was recorded as reference-fallback-backed, not direct SVD in-tolerance recovery
+- M5 is complete:
+  - stable KS runtime promotion was explicitly deferred for `v0.11`
+  - public KS generator, residual, example, weak, and root exports remain absent
+- M6 is complete:
+  - package metadata and release-facing docs are aligned with `0.11.0`
+  - this readiness note is current
+  - the compact `v0_11-release-gate` is the current explicit release-gate CI job
+
+## Public API Notes
+
+New stable runtime API behavior in `v0.11`:
+
+- `pdelie.derivatives.compute_spectral_fd_derivatives(..., max_spatial_order=4)` emits:
+  - `u_t`
+  - `u_x`
+  - `u_xx`
+  - `u_xxx`
+  - `u_xxxx`
+
+The default `max_spatial_order=2` behavior, config, diagnostics, and derivative outputs remain preserved.
+
+Stable KS runtime promotion is deferred:
+
+- no `pdelie.data.generate_ks_1d_field_batch`
+- no `pdelie.residuals.KSResidualEvaluator`
+- no `pdelie.examples.run_ks_vertical_slice_example`
+- no root `pdelie` KS exports
+- no weak KS API
+- no KS imported parity
+
+Retained stable surfaces include:
+
+- Heat and Burgers strong paths
+- `v0.8` weak Heat/Burgers residual report APIs
+- `v0.9` normalized periodic short-horizon KdV strong path
+- `v0.10` reporting helpers and nested Heat/KdV example summaries
+- structured `from_numpy(...)` and optional `from_xarray(...)` ingestion
+- existing discovery, portability, symmetry, and visualization runtime helpers
+
+## KS Feasibility Evidence
+
+The frozen internal KS fixture shows strong feasibility evidence:
+
+- residual max absolute value: `2.276047466221332e-09`
+- residual RMS value: `3.450580898077348e-10`
+- mass drift: `4.686823294199099e-16`
+- relative L2 drift: `0.0070894859776733715` as diagnostic-only
+- selected span distance: `0.0`
+- SVD span distance: `0.4178159498317849`
+- fit mode: `reference_fallback`
+- reference fallback used: `True`
+- fallback reason: `svd_translation_span_drift`
+- first-epsilon held-out verification error: `2.533384127588474e-13`
+- verification classification: `exact`
+- evidence label: `reference_fallback`
+
+Interpretation:
+
+- residual evaluation passes with large margin
+- mass conservation passes with large margin
+- held-out canonical translation verification passes
+- selected span passes because the canonical reference fallback is used
+- direct residual-based SVD fitting is out of tolerance
+- therefore stable KS runtime promotion is deferred for `v0.11`
+
+## Explicitly Deferred
+
+- stable KS data generator
+- stable KS residual evaluator
+- KS vertical-slice example
+- KS imported parity
+- weak KS APIs
+- root `pdelie` exports for KS runtime APIs
+- broad dataset adapters
+- multidimensional, multivariable, or nonuniform-grid support
+- operator-facing APIs
+- manuscript-specific experiment logic
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
+## CI Expectations
+
+Before tagging `v0.11.0`, the release PR should have these CI jobs green:
+
+- `v0_11-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+Historical release-gate test modules remain runnable locally and are covered by `editable-tests`.
+
+## Local Release Checklist
+
+Before tagging `v0.11.0`:
+
+1. Inspect consistency across:
+   - `pyproject.toml`
+   - `README.md`
+   - `CHANGELOG.md`
+   - `docs/releases/V0_11_RELEASE_READINESS.md`
+   - `docs/releases/PUBLISHING.md`
+   - `docs/specs/API_STABILITY.md`
+2. Run the full test suite:
+   - `python -m pytest`
+3. Build the package:
+   - `python -m build --sdist --wheel`
+4. Install `dist/pdelie-0.11.0-py3-none-any.whl` into a clean environment and verify:
+   - stable root imports
+   - `pdelie.reporting` helper imports from the submodule
+   - one tiny weak Heat report
+   - one tiny KdV strong-path residual
+   - one tiny order-4 derivative smoke
+   - root `pdelie` does not export KS runtime APIs
+5. Run examples:
+   - `python -m pdelie.examples.heat_vertical_slice`
+   - `python -m pdelie.examples.kdv_vertical_slice`
+6. Run:
+   - `git diff --check`
+
+## Direct Final Tag Checklist
+
+After local checks and CI pass:
+
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.11.0`
+- do not publish to TestPyPI
+- do not publish to PyPI
+- record package-index publishing as deferred until `v1.0` or later
+
+## Final Release View
+
+`v0.11.0` is ready when the local release checklist and the current CI jobs pass.
+
+The stable release claim is intentionally narrow:
+
+`existing Heat/Burgers/weak-report/KdV/reporting surfaces -> order-4 spectral derivatives -> internal KS feasibility evidence -> explicit stable-KS no-go/defer closeout`
+
+There is no stable public KS runtime surface in `v0.11`.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -110,6 +110,13 @@ Runtime public API update for the frozen `v0.9` Milestone 1 slice:
 - `max_spatial_order=1` emits only the time derivative and first spatial derivative outputs
 - unsupported `max_spatial_order` values raise `ScopeValidationError`
 
+Runtime public API update for the frozen `v0.11` Milestone 2 slice:
+
+- `pdelie.derivatives.compute_spectral_fd_derivatives(field, *, max_spatial_order=4)` adds the fourth spatial derivative output `u_xxxx`
+- `max_spatial_order=4` emits `u_t`, `u_x`, `u_xx`, `u_xxx`, and `u_xxxx`
+- this API update preserves the existing default `max_spatial_order=2` behavior, config, diagnostics, and derivative outputs
+- this derivative extension does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator
+
 Runtime public API for the frozen `v0.9` Milestone 2 slice:
 
 - `pdelie.data.generate_kdv_1d_field_batch` for normalized periodic short-horizon synthetic KdV under the frozen `v0.9` generator regime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.10.0"
-description = "V0.10 supportability reporting, consistent examples, and release-gate cleanup for the Heat/Burgers/weak-report/KdV engine"
+version = "0.11.0"
+description = "V0.11 order-4 spectral derivatives and Kuramoto-Sivashinsky feasibility no-go closeout for the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/derivatives/spectral_fd.py
+++ b/src/pdelie/derivatives/spectral_fd.py
@@ -14,10 +14,10 @@ def _reshape_for_axis(values: np.ndarray, axis: int, axis_size: int) -> tuple[in
 
 def _validate_max_spatial_order(max_spatial_order: object) -> int:
     if isinstance(max_spatial_order, (bool, np.bool_)) or not isinstance(max_spatial_order, (int, np.integer)):
-        raise ScopeValidationError("spectral_fd max_spatial_order must be one of 1, 2, or 3.")
+        raise ScopeValidationError("spectral_fd max_spatial_order must be one of 1, 2, 3, or 4.")
     normalized = int(max_spatial_order)
-    if normalized not in {1, 2, 3}:
-        raise ScopeValidationError("spectral_fd max_spatial_order must be one of 1, 2, or 3.")
+    if normalized not in {1, 2, 3, 4}:
+        raise ScopeValidationError("spectral_fd max_spatial_order must be one of 1, 2, 3, or 4.")
     return normalized
 
 
@@ -65,6 +65,9 @@ def compute_spectral_fd_derivatives(field: FieldBatch, *, max_spatial_order: int
     if normalized_max_spatial_order >= 3:
         u_xxx = np.real(np.fft.ifft(((1j * wavenumbers) ** 3) * spectrum, axis=x_axis))
         derivative_arrays["u_xxx"] = np.asarray(u_xxx, dtype=float)
+    if normalized_max_spatial_order >= 4:
+        u_xxxx = np.real(np.fft.ifft((wavenumbers**4) * spectrum, axis=x_axis))
+        derivative_arrays["u_xxxx"] = np.asarray(u_xxxx, dtype=float)
 
     config = {
         "spatial_method": "spectral",

--- a/tests/_helpers/ks_feasibility.py
+++ b/tests/_helpers/ks_feasibility.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie import FieldBatch
+from pdelie.errors import ShapeValidationError
+
+
+KS_FEASIBILITY_CONFIG: dict[str, object] = {
+    "batch_size": 5,
+    "num_times": 33,
+    "num_points": 128,
+    "max_time": 0.2,
+    "num_modes": 6,
+    "amplitude": 0.08,
+    "seed": 11101,
+    "num_substeps": 8,
+    "domain_length": 32.0 * np.pi,
+    "equation": "u_t + u*u_x + u_xx + u_xxxx = 0",
+    "rollout": "ETDRK4",
+    "nonlinear_form": "conservative_spectral_half_d_x_u_squared",
+}
+
+
+def _reshape_last_axis(values: np.ndarray) -> tuple[int, ...]:
+    shape = [1] * values.ndim
+    shape[-1] = values.shape[-1]
+    return tuple(shape)
+
+
+def _two_thirds_mask(num_points: int) -> np.ndarray:
+    mode_numbers = np.fft.fftfreq(num_points) * num_points
+    return np.abs(mode_numbers) <= (num_points / 3.0)
+
+
+def apply_two_thirds_filter(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    mask = _two_thirds_mask(values.shape[-1]).reshape(_reshape_last_axis(values))
+    spectrum = np.fft.fft(values, axis=-1)
+    return np.real(np.fft.ifft(spectrum * mask, axis=-1))
+
+
+def sample_ks_mode_coefficients(
+    *,
+    batch_size: int,
+    num_modes: int,
+    seed: int,
+    amplitude: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    mode_scale = amplitude / np.arange(1, num_modes + 1, dtype=float)
+    cosine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    sine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    return cosine, sine
+
+
+def evaluate_ks_fourier_series(
+    *,
+    x: np.ndarray,
+    domain_length: float,
+    cosine_coefficients: np.ndarray,
+    sine_coefficients: np.ndarray,
+) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    cosine_coefficients = np.asarray(cosine_coefficients, dtype=float)
+    sine_coefficients = np.asarray(sine_coefficients, dtype=float)
+
+    if cosine_coefficients.shape != sine_coefficients.shape:
+        raise ShapeValidationError("cosine_coefficients and sine_coefficients must match.")
+    if cosine_coefficients.ndim != 2:
+        raise ShapeValidationError("Coefficient arrays must have shape (batch, num_modes).")
+
+    modes = np.arange(1, cosine_coefficients.shape[1] + 1, dtype=float)
+    phase = (2.0 * np.pi / float(domain_length)) * x
+    spatial_cos = np.cos(np.outer(modes, phase))
+    spatial_sin = np.sin(np.outer(modes, phase))
+    values = np.sum(
+        cosine_coefficients[:, :, None] * spatial_cos[None, :, :]
+        + sine_coefficients[:, :, None] * spatial_sin[None, :, :],
+        axis=1,
+    )
+    return apply_two_thirds_filter(values)
+
+
+def _etdrk4_coefficients(linear_operator: np.ndarray, *, dt: float) -> tuple[np.ndarray, ...]:
+    scaled = dt * linear_operator
+    exp_full = np.exp(scaled)
+    exp_half = np.exp(scaled / 2.0)
+    roots = np.exp(1j * np.pi * (np.arange(1, 33, dtype=float) - 0.5) / 32.0)
+    contour = scaled[:, None] + roots[None, :]
+
+    q = dt * np.mean((np.exp(contour / 2.0) - 1.0) / contour, axis=1).real
+    f1 = dt * np.mean(
+        (-4.0 - contour + np.exp(contour) * (4.0 - 3.0 * contour + contour**2)) / contour**3,
+        axis=1,
+    ).real
+    f2 = dt * np.mean((2.0 + contour + np.exp(contour) * (-2.0 + contour)) / contour**3, axis=1).real
+    f3 = dt * np.mean(
+        (-4.0 - 3.0 * contour - contour**2 + np.exp(contour) * (4.0 - contour)) / contour**3,
+        axis=1,
+    ).real
+    return exp_full, exp_half, q, f1, f2, f3
+
+
+def _rollout_ks_etdrk4(
+    initial_values: np.ndarray,
+    *,
+    output_times: np.ndarray,
+    domain_length: float,
+    num_substeps: int,
+) -> np.ndarray:
+    initial_values = np.asarray(initial_values, dtype=float)
+    output_times = np.asarray(output_times, dtype=float)
+
+    if initial_values.ndim != 2:
+        raise ShapeValidationError("initial_values must have shape (batch, x).")
+    if output_times.ndim != 1 or output_times.size < 2:
+        raise ShapeValidationError("output_times must be one-dimensional with at least two entries.")
+    if num_substeps < 1:
+        raise ShapeValidationError("num_substeps must be at least 1.")
+
+    output_dt = float(output_times[1] - output_times[0])
+    if not np.allclose(np.diff(output_times), output_dt, atol=1e-12, rtol=0.0):
+        raise ShapeValidationError("output_times must be uniformly spaced.")
+
+    num_points = initial_values.shape[-1]
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(num_points, d=float(domain_length) / num_points)
+    dealias_mask = _two_thirds_mask(num_points)
+    linear_operator = wavenumbers**2 - wavenumbers**4
+    internal_dt = output_dt / float(num_substeps)
+    exp_full, exp_half, q, f1, f2, f3 = _etdrk4_coefficients(linear_operator, dt=internal_dt)
+    ik = 1j * wavenumbers
+
+    def nonlinear_term(spectrum: np.ndarray) -> np.ndarray:
+        values = np.fft.ifft(spectrum, axis=-1).real
+        nonlinear_values = apply_two_thirds_filter(values * values)
+        return -0.5 * ik * np.fft.fft(nonlinear_values, axis=-1) * dealias_mask
+
+    state = apply_two_thirds_filter(initial_values)
+    spectrum = np.fft.fft(state, axis=-1) * dealias_mask
+    zero_mode = spectrum[:, 0].copy()
+    rollout = np.empty((initial_values.shape[0], output_times.size, num_points), dtype=float)
+    rollout[:, 0, :] = np.fft.ifft(spectrum, axis=-1).real
+
+    for time_index in range(1, output_times.size):
+        for _ in range(num_substeps):
+            n1 = nonlinear_term(spectrum)
+            a = exp_half * spectrum + q * n1
+            n2 = nonlinear_term(a)
+            b = exp_half * spectrum + q * n2
+            n3 = nonlinear_term(b)
+            c = exp_half * a + q * (2.0 * n3 - n1)
+            n4 = nonlinear_term(c)
+            spectrum = exp_full * spectrum + f1 * n1 + 2.0 * f2 * (n2 + n3) + f3 * n4
+            spectrum *= dealias_mask
+            spectrum[:, 0] = zero_mode
+        rollout[:, time_index, :] = np.fft.ifft(spectrum, axis=-1).real
+
+    return rollout
+
+
+def generate_ks_feasibility_field_batch(
+    *,
+    batch_size: int = int(KS_FEASIBILITY_CONFIG["batch_size"]),
+    num_times: int = int(KS_FEASIBILITY_CONFIG["num_times"]),
+    num_points: int = int(KS_FEASIBILITY_CONFIG["num_points"]),
+    max_time: float = float(KS_FEASIBILITY_CONFIG["max_time"]),
+    num_modes: int = int(KS_FEASIBILITY_CONFIG["num_modes"]),
+    amplitude: float = float(KS_FEASIBILITY_CONFIG["amplitude"]),
+    seed: int = int(KS_FEASIBILITY_CONFIG["seed"]),
+    num_substeps: int = int(KS_FEASIBILITY_CONFIG["num_substeps"]),
+    domain_length: float = float(KS_FEASIBILITY_CONFIG["domain_length"]),
+) -> FieldBatch:
+    x = np.linspace(0.0, domain_length, num_points, endpoint=False, dtype=float)
+    t = np.linspace(0.0, max_time, num_times, dtype=float)
+    cosine, sine = sample_ks_mode_coefficients(
+        batch_size=batch_size,
+        num_modes=num_modes,
+        seed=seed,
+        amplitude=amplitude,
+    )
+    initial_values = evaluate_ks_fourier_series(
+        x=x,
+        domain_length=domain_length,
+        cosine_coefficients=cosine,
+        sine_coefficients=sine,
+    )
+    values = _rollout_ks_etdrk4(
+        initial_values,
+        output_times=t,
+        domain_length=domain_length,
+        num_substeps=num_substeps,
+    )
+
+    return FieldBatch(
+        values=values[..., None],
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {"equation": "ks_normalized"},
+        },
+        preprocess_log=[],
+    )
+
+
+def compute_mass(field: FieldBatch) -> np.ndarray:
+    values = np.asarray(field.values[..., 0], dtype=float)
+    dx = float(field.coords["x"][1] - field.coords["x"][0])
+    return dx * np.sum(values, axis=-1)
+
+
+def compute_l2_norm(field: FieldBatch) -> np.ndarray:
+    values = np.asarray(field.values[..., 0], dtype=float)
+    dx = float(field.coords["x"][1] - field.coords["x"][0])
+    return np.sqrt(dx * np.sum(values**2, axis=-1))

--- a/tests/_helpers/ks_feasibility.py
+++ b/tests/_helpers/ks_feasibility.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import numpy as np
 
-from pdelie import FieldBatch
-from pdelie.errors import ShapeValidationError
+from pdelie import DerivativeBatch, FieldBatch, ResidualBatch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError, ScopeValidationError, ShapeValidationError
+from pdelie.residuals.base import ResidualEvaluator
 
 
 KS_FEASIBILITY_CONFIG: dict[str, object] = {
@@ -20,6 +22,7 @@ KS_FEASIBILITY_CONFIG: dict[str, object] = {
     "rollout": "ETDRK4",
     "nonlinear_form": "conservative_spectral_half_d_x_u_squared",
 }
+_REQUIRED_KS_DERIVATIVES = ("u_t", "u_x", "u_xx", "u_xxxx")
 
 
 def _reshape_last_axis(values: np.ndarray) -> tuple[int, ...]:
@@ -218,3 +221,63 @@ def compute_l2_norm(field: FieldBatch) -> np.ndarray:
     values = np.asarray(field.values[..., 0], dtype=float)
     dx = float(field.coords["x"][1] - field.coords["x"][0])
     return np.sqrt(dx * np.sum(values**2, axis=-1))
+
+
+def _validate_ks_feasibility_field(field: FieldBatch) -> None:
+    field.validate()
+
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError("KSFeasibilityResidualEvaluator only supports dims ('batch', 'time', 'x', 'var').")
+    if len(field.var_names) != 1 or field.values.shape[-1] != 1:
+        raise ScopeValidationError("KSFeasibilityResidualEvaluator only supports scalar FieldBatch inputs.")
+    if field.mask is not None:
+        raise ScopeValidationError("KSFeasibilityResidualEvaluator does not support masked fields.")
+    if not np.all(np.isfinite(field.values)):
+        raise ScopeValidationError("KSFeasibilityResidualEvaluator requires finite field values.")
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError("KSFeasibilityResidualEvaluator requires periodic boundary conditions in x.")
+
+    parameter_tags = field.metadata.get("parameter_tags")
+    if not isinstance(parameter_tags, dict):
+        raise SchemaValidationError("KSFeasibilityResidualEvaluator requires field.metadata['parameter_tags'] to be a mapping.")
+    if parameter_tags.get("equation") != "ks_normalized":
+        raise ScopeValidationError(
+            "KSFeasibilityResidualEvaluator requires field.metadata['parameter_tags']['equation'] == 'ks_normalized'."
+        )
+
+
+class KSFeasibilityResidualEvaluator(ResidualEvaluator):
+    def evaluate(
+        self,
+        field: FieldBatch,
+        derivatives: DerivativeBatch | None = None,
+    ) -> ResidualBatch:
+        _validate_ks_feasibility_field(field)
+        if derivatives is None:
+            derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+        derivatives.validate_against(field)
+
+        for name in _REQUIRED_KS_DERIVATIVES:
+            if name not in derivatives.derivatives:
+                raise SchemaValidationError(f"KSFeasibilityResidualEvaluator requires derivative '{name}'.")
+
+        values = np.asarray(field.values, dtype=float)
+        residual = (
+            derivatives.derivatives["u_t"]
+            + values * derivatives.derivatives["u_x"]
+            + derivatives.derivatives["u_xx"]
+            + derivatives.derivatives["u_xxxx"]
+        )
+        batch = ResidualBatch(
+            residual=residual,
+            definition_type="analytic",
+            normalization="none",
+            diagnostics={
+                "equation": KS_FEASIBILITY_CONFIG["equation"],
+                "backend": derivatives.backend,
+                "max_abs_residual": float(np.max(np.abs(residual))),
+                "rms_residual": float(np.sqrt(np.mean(np.square(residual)))),
+            },
+        )
+        batch.validate_against(field)
+        return batch

--- a/tests/_helpers/ks_vertical_slice.py
+++ b/tests/_helpers/ks_vertical_slice.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from functools import lru_cache
+
+import numpy as np
+
+from pdelie.data import split_batch_train_heldout
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.symmetry.parameterization import translation_span_distance
+from pdelie.verification import verify_translation_generator
+from tests._helpers.ks_feasibility import (
+    KSFeasibilityResidualEvaluator,
+    compute_l2_norm,
+    compute_mass,
+    generate_ks_feasibility_field_batch,
+)
+
+
+def classify_translation_evidence(
+    *,
+    reference_fallback_used: bool,
+    selected_span_distance: float,
+    verification_failed: bool,
+    fallback_reason: object,
+    svd_span_distance: object,
+) -> str:
+    if not reference_fallback_used and selected_span_distance <= 1e-1:
+        return "direct_svd_in_tolerance"
+    if (
+        reference_fallback_used
+        and selected_span_distance <= 1e-1
+        and not verification_failed
+        and isinstance(fallback_reason, str)
+        and fallback_reason
+        and svd_span_distance is not None
+    ):
+        return "reference_fallback"
+    return "mixed"
+
+
+def run_ks_vertical_slice_summary() -> dict[str, object]:
+    field = generate_ks_feasibility_field_batch()
+    training, heldout = split_batch_train_heldout(field, train_size=2, seed=11102)
+
+    derivatives = compute_spectral_fd_derivatives(training, max_spatial_order=4)
+    residual_evaluator = KSFeasibilityResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, residual_evaluator)
+
+    mass = compute_mass(field)
+    l2 = compute_l2_norm(field)
+    mass_drift = float(np.max(np.abs(mass - mass[:, [0]])))
+    relative_l2_drift = float(np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12)))
+    selected_span_distance = float(translation_span_distance(generator.coefficients))
+    svd_span_distance = generator.diagnostics.get("svd_span_distance")
+    fallback_reason = generator.diagnostics.get("fallback_reason")
+    evidence_label = classify_translation_evidence(
+        reference_fallback_used=bool(generator.diagnostics["reference_fallback_used"]),
+        selected_span_distance=selected_span_distance,
+        verification_failed=verification.classification == "failed",
+        fallback_reason=fallback_reason,
+        svd_span_distance=svd_span_distance,
+    )
+
+    return {
+        "derivative_keys": sorted(derivatives.derivatives),
+        "residual_max_abs": float(residual.diagnostics["max_abs_residual"]),
+        "residual_rms": float(residual.diagnostics["rms_residual"]),
+        "mass_drift": mass_drift,
+        "relative_l2_drift": relative_l2_drift,
+        "selected_span_distance": selected_span_distance,
+        "svd_span_distance": None if svd_span_distance is None else float(svd_span_distance),
+        "fit_mode": generator.diagnostics["fit_mode"],
+        "reference_fallback_used": bool(generator.diagnostics["reference_fallback_used"]),
+        "fallback_reason": fallback_reason,
+        "first_epsilon_error": float(verification.error_curve[0]),
+        "classification": verification.classification,
+        "transform_mode": verification.diagnostics["transform_mode"],
+        "evidence_label": evidence_label,
+    }
+
+
+@lru_cache(maxsize=1)
+def _cached_ks_vertical_slice_summary() -> dict[str, object]:
+    return run_ks_vertical_slice_summary()
+
+
+def cached_ks_vertical_slice_summary() -> dict[str, object]:
+    return deepcopy(_cached_ks_vertical_slice_summary())

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -48,6 +48,8 @@ _ROOT_RUNTIME_NAMES = {
 }
 _DEFERRED_OR_PRIVATE_NAMES = {
     "OperatorSymmetry",
+    "KSResidualEvaluator",
+    "KuramotoSivashinskyResidualEvaluator",
     "WeakBurgersResidualEvaluator",
     "WeakHeatResidualEvaluator",
     "WeakKdVResidualEvaluator",
@@ -55,6 +57,8 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "evaluate_weak_kdv_residual",
     "from_pdebench",
     "from_the_well",
+    "generate_ks_1d_field_batch",
+    "generate_ks_feasibility_field_batch",
     "load_pdebench",
     "load_the_well",
     "sample_kdv_mode_coefficients",
@@ -75,6 +79,9 @@ _V0_9_KDV_APIS = {
     "pdelie.data.generate_kdv_1d_field_batch",
     "pdelie.residuals.KdVResidualEvaluator",
 }
+_V0_11_DERIVATIVE_APIS = {
+    "pdelie.derivatives.compute_spectral_fd_derivatives(field, *, max_spatial_order=4)",
+}
 
 
 def _api_stability_text() -> str:
@@ -84,9 +91,10 @@ def _api_stability_text() -> str:
 def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
     text = _api_stability_text()
 
-    for api_name in sorted(_V0_10_REPORTING_APIS | _V0_8_WEAK_APIS | _V0_9_KDV_APIS):
+    for api_name in sorted(_V0_10_REPORTING_APIS | _V0_8_WEAK_APIS | _V0_9_KDV_APIS | _V0_11_DERIVATIVE_APIS):
         assert api_name in text
 
+    assert "does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator" in text
     assert "these APIs have no root `pdelie` exports" in text
     assert "not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs" in text
     assert "weak-form derivatives and weak-form methods beyond the frozen `v0.8` weak residual report slice" in text

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -8,7 +8,7 @@ from pdelie.data.heat_1d import evaluate_heat_fourier_series
 from pdelie.derivatives import compute_spectral_fd_derivatives
 
 
-def make_exact_heat_field() -> tuple[FieldBatch, np.ndarray, np.ndarray, np.ndarray]:
+def make_exact_heat_field() -> tuple[FieldBatch, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     x = np.linspace(0.0, 2.0 * np.pi, 64, endpoint=False)
     t = np.linspace(0.0, 0.4, 33)
     cosine = np.array([[0.7, -0.25]])
@@ -51,13 +51,16 @@ def make_exact_heat_field() -> tuple[FieldBatch, np.ndarray, np.ndarray, np.ndar
     uxxx_modes = cosine[:, None, :, None] * (modes[None, None, :, None] ** 3) * sin_kx[None, None, :, :]
     uxxx_modes += -sine[:, None, :, None] * (modes[None, None, :, None] ** 3) * cos_kx[None, None, :, :]
     u_xxx = np.sum(decay[None, :, :, None] * uxxx_modes, axis=2)[..., None]
+    uxxxx_modes = cosine[:, None, :, None] * (modes[None, None, :, None] ** 4) * cos_kx[None, None, :, :]
+    uxxxx_modes += sine[:, None, :, None] * (modes[None, None, :, None] ** 4) * sin_kx[None, None, :, :]
+    u_xxxx = np.sum(decay[None, :, :, None] * uxxxx_modes, axis=2)[..., None]
     u_t = diffusivity * u_xx
 
-    return field, u_x, u_t, u_xxx
+    return field, u_x, u_t, u_xxx, u_xxxx
 
 
 def test_spectral_fd_matches_analytic_derivatives() -> None:
-    field, expected_u_x, expected_u_t, _ = make_exact_heat_field()
+    field, expected_u_x, expected_u_t, _, _ = make_exact_heat_field()
     derivatives = compute_spectral_fd_derivatives(field)
     np.testing.assert_allclose(derivatives.derivatives["u_x"], expected_u_x, atol=1e-10, rtol=1e-10)
     np.testing.assert_allclose(derivatives.derivatives["u_t"], expected_u_t, atol=1e-3, rtol=1e-3)
@@ -70,7 +73,7 @@ def test_spectral_fd_matches_analytic_derivatives() -> None:
 
 
 def test_spectral_fd_records_provenance() -> None:
-    field, _, _, _ = make_exact_heat_field()
+    field, _, _, _, _ = make_exact_heat_field()
     derivatives = compute_spectral_fd_derivatives(field)
     assert derivatives.backend == "spectral_fd"
     assert derivatives.config["spatial_method"] == "spectral"
@@ -80,14 +83,14 @@ def test_spectral_fd_records_provenance() -> None:
 
 
 def test_spectral_fd_rejects_nonperiodic_boundary_conditions() -> None:
-    field, _, _, _ = make_exact_heat_field()
+    field, _, _, _, _ = make_exact_heat_field()
     field.metadata["boundary_conditions"] = {"x": "dirichlet"}
     with pytest.raises(ScopeValidationError):
         compute_spectral_fd_derivatives(field)
 
 
 def test_spectral_fd_default_and_explicit_second_order_are_compatible() -> None:
-    field, _, _, _ = make_exact_heat_field()
+    field, _, _, _, _ = make_exact_heat_field()
 
     default = compute_spectral_fd_derivatives(field)
     explicit = compute_spectral_fd_derivatives(field, max_spatial_order=2)
@@ -102,7 +105,7 @@ def test_spectral_fd_default_and_explicit_second_order_are_compatible() -> None:
 
 
 def test_spectral_fd_first_order_emits_only_time_and_first_spatial_derivative() -> None:
-    field, expected_u_x, _, _ = make_exact_heat_field()
+    field, expected_u_x, _, _, _ = make_exact_heat_field()
 
     derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=np.int64(1))
 
@@ -112,7 +115,7 @@ def test_spectral_fd_first_order_emits_only_time_and_first_spatial_derivative() 
 
 
 def test_spectral_fd_first_order_skips_higher_order_inverse_ffts(monkeypatch: pytest.MonkeyPatch) -> None:
-    field, _, _, _ = make_exact_heat_field()
+    field, _, _, _, _ = make_exact_heat_field()
     original_ifft = np.fft.ifft
     ifft_calls = []
 
@@ -129,7 +132,7 @@ def test_spectral_fd_first_order_skips_higher_order_inverse_ffts(monkeypatch: py
 
 
 def test_spectral_fd_third_order_matches_exact_fourier_derivative() -> None:
-    field, _, _, expected_u_xxx = make_exact_heat_field()
+    field, _, _, expected_u_xxx, _ = make_exact_heat_field()
 
     derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=3)
 
@@ -138,9 +141,45 @@ def test_spectral_fd_third_order_matches_exact_fourier_derivative() -> None:
     np.testing.assert_allclose(derivatives.derivatives["u_xxx"], expected_u_xxx, atol=1e-9, rtol=1e-9)
 
 
-@pytest.mark.parametrize("max_spatial_order", [True, np.bool_(False), 0, 4, -1, 1.0, np.float64(2.0), "3"])
+def test_spectral_fd_fourth_order_matches_exact_fourier_derivative() -> None:
+    field, _, _, _, expected_u_xxxx = make_exact_heat_field()
+
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=np.int64(4))
+
+    assert set(derivatives.derivatives) == {"u_t", "u_x", "u_xx", "u_xxx", "u_xxxx"}
+    assert derivatives.config["spatial_max_order"] == 4
+    np.testing.assert_allclose(derivatives.derivatives["u_xxxx"], expected_u_xxxx, atol=1e-8, rtol=1e-8)
+
+
+def test_spectral_fd_fourth_derivative_sign_convention() -> None:
+    x = np.linspace(0.0, 2.0 * np.pi, 64, endpoint=False)
+    t = np.linspace(0.0, 0.1, 3)
+    values = np.cos(3.0 * x)[None, None, :, None]
+    values = np.repeat(values, t.size, axis=1)
+    field = FieldBatch(
+        values=values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {},
+        },
+        preprocess_log=[],
+    )
+
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+
+    expected = (3.0**4) * values
+    np.testing.assert_allclose(derivatives.derivatives["u_xxxx"], expected, atol=1e-9, rtol=1e-9)
+
+
+@pytest.mark.parametrize("max_spatial_order", [True, np.bool_(False), 0, 5, -1, 1.0, np.float64(2.0), "3"])
 def test_spectral_fd_rejects_invalid_max_spatial_order(max_spatial_order: object) -> None:
-    field, _, _, _ = make_exact_heat_field()
+    field, _, _, _, _ = make_exact_heat_field()
 
     with pytest.raises(ScopeValidationError, match="max_spatial_order"):
         compute_spectral_fd_derivatives(field, max_spatial_order=max_spatial_order)  # type: ignore[arg-type]

--- a/tests/test_ks_feasibility.py
+++ b/tests/test_ks_feasibility.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+
+import pdelie
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from tests._helpers.ks_feasibility import (
+    KS_FEASIBILITY_CONFIG,
+    compute_mass,
+    evaluate_ks_fourier_series,
+    generate_ks_feasibility_field_batch,
+    sample_ks_mode_coefficients,
+)
+
+
+def test_ks_feasibility_generator_is_reproducible_and_seed_sensitive() -> None:
+    first = generate_ks_feasibility_field_batch(seed=11111)
+    second = generate_ks_feasibility_field_batch(seed=11111)
+    different = generate_ks_feasibility_field_batch(seed=11112)
+
+    np.testing.assert_allclose(first.values, second.values, rtol=0.0, atol=1e-15)
+    assert not np.allclose(first.values, different.values, rtol=0.0, atol=0.0)
+
+
+def test_ks_feasibility_generator_freezes_shape_coordinates_and_metadata() -> None:
+    field = generate_ks_feasibility_field_batch()
+    batch_size = int(KS_FEASIBILITY_CONFIG["batch_size"])
+    num_times = int(KS_FEASIBILITY_CONFIG["num_times"])
+    num_points = int(KS_FEASIBILITY_CONFIG["num_points"])
+    max_time = float(KS_FEASIBILITY_CONFIG["max_time"])
+    domain_length = float(KS_FEASIBILITY_CONFIG["domain_length"])
+
+    assert field.values.shape == (batch_size, num_times, num_points, 1)
+    assert field.dims == ("batch", "time", "x", "var")
+    assert field.var_names == ["u"]
+    assert field.mask is None
+    assert field.preprocess_log == []
+    np.testing.assert_allclose(field.coords["x"], np.linspace(0.0, domain_length, num_points, endpoint=False))
+    np.testing.assert_allclose(field.coords["time"], np.linspace(0.0, max_time, num_times))
+    assert field.coords["x"][0] == 0.0
+    assert field.coords["x"][-1] == domain_length * (num_points - 1) / num_points
+    assert field.coords["time"][0] == 0.0
+    assert field.coords["time"][-1] == max_time
+    assert field.metadata["boundary_conditions"] == {"x": "periodic"}
+    assert field.metadata["grid_type"] == "rectilinear"
+    assert field.metadata["grid_regularity"] == "uniform"
+    assert field.metadata["coordinate_system"] == "cartesian"
+    assert field.metadata["parameter_tags"] == {"equation": "ks_normalized"}
+    assert np.all(np.isfinite(field.values))
+    field.validate()
+
+
+def test_ks_feasibility_generator_preserves_zero_mode_and_mass() -> None:
+    field = generate_ks_feasibility_field_batch()
+
+    mean_by_batch_time = np.mean(field.values[..., 0], axis=-1)
+    mass = compute_mass(field)
+    mass_drift = np.max(np.abs(mass - mass[:, [0]]))
+
+    np.testing.assert_allclose(mean_by_batch_time, np.zeros_like(mean_by_batch_time), atol=1e-14, rtol=0.0)
+    assert mass_drift <= 1e-8
+
+
+def test_ks_feasibility_fourier_series_scales_phase_by_domain_length() -> None:
+    batch_size = 2
+    num_modes = 4
+    num_points = 64
+    domain_length = 40.0
+    amplitude = 0.05
+    seed = 11121
+    x = np.linspace(0.0, domain_length, num_points, endpoint=False)
+    cosine, sine = sample_ks_mode_coefficients(
+        batch_size=batch_size,
+        num_modes=num_modes,
+        seed=seed,
+        amplitude=amplitude,
+    )
+
+    values = evaluate_ks_fourier_series(
+        x=x,
+        domain_length=domain_length,
+        cosine_coefficients=cosine,
+        sine_coefficients=sine,
+    )
+
+    modes = np.arange(1, num_modes + 1, dtype=float)
+    phase = (2.0 * np.pi / domain_length) * x
+    expected = np.sum(
+        cosine[:, :, None] * np.cos(np.outer(modes, phase))[None, :, :]
+        + sine[:, :, None] * np.sin(np.outer(modes, phase))[None, :, :],
+        axis=1,
+    )
+    raw_x_expected = np.sum(
+        cosine[:, :, None] * np.cos(np.outer(modes, x))[None, :, :]
+        + sine[:, :, None] * np.sin(np.outer(modes, x))[None, :, :],
+        axis=1,
+    )
+
+    np.testing.assert_allclose(values, expected, atol=1e-14, rtol=1e-14)
+    assert not np.allclose(values, raw_x_expected, atol=1e-12, rtol=1e-12)
+
+
+def test_ks_feasibility_uses_public_fourth_derivative_sign_convention() -> None:
+    field = generate_ks_feasibility_field_batch(num_times=3, max_time=0.01)
+
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+
+    assert set(derivatives.derivatives) == {"u_t", "u_x", "u_xx", "u_xxx", "u_xxxx"}
+    assert derivatives.config["spatial_max_order"] == 4
+    residual = (
+        derivatives.derivatives["u_t"]
+        + field.values * derivatives.derivatives["u_x"]
+        + derivatives.derivatives["u_xx"]
+        + derivatives.derivatives["u_xxxx"]
+    )
+    assert float(np.sqrt(np.mean(np.square(residual)))) < 1e-2
+
+
+def test_ks_feasibility_helper_adds_no_public_ks_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+
+    assert not hasattr(pdelie, "generate_ks_feasibility_field_batch")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")

--- a/tests/test_ks_promotion_decision.py
+++ b/tests/test_ks_promotion_decision.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pdelie
+from tests.test_ks_vertical_slice_feasibility import _run_ks_vertical_slice_summary
+
+
+def test_m5_ks_promotion_decision_records_reference_fallback_no_go_evidence() -> None:
+    summary = _run_ks_vertical_slice_summary()
+
+    assert summary["evidence_label"] == "reference_fallback"
+    assert summary["reference_fallback_used"] is True
+    assert isinstance(summary["fallback_reason"], str)
+    assert summary["fallback_reason"]
+    assert summary["svd_span_distance"] is not None
+    assert summary["svd_span_distance"] > 1e-1
+    assert summary["selected_span_distance"] <= 1e-1
+    assert summary["first_epsilon_error"] < 5e-4
+    assert summary["classification"] != "failed"
+
+
+def test_m5_no_public_ks_runtime_surface_or_api_stability_promotion() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+    examples_module = importlib.import_module("pdelie.examples")
+    api_stability_text = (
+        Path(__file__).resolve().parents[1] / "docs/specs/API_STABILITY.md"
+    ).read_text(encoding="utf-8")
+
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(examples_module, "run_ks_vertical_slice_example")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(pdelie, "run_ks_vertical_slice_example")
+
+    assert "pdelie.data.generate_ks_1d_field_batch" not in api_stability_text
+    assert "pdelie.residuals.KSResidualEvaluator" not in api_stability_text
+    assert "pdelie.residuals.KuramotoSivashinskyResidualEvaluator" not in api_stability_text
+    assert "does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator" in api_stability_text

--- a/tests/test_ks_promotion_decision.py
+++ b/tests/test_ks_promotion_decision.py
@@ -4,11 +4,11 @@ import importlib
 from pathlib import Path
 
 import pdelie
-from tests.test_ks_vertical_slice_feasibility import _run_ks_vertical_slice_summary
+from tests._helpers.ks_vertical_slice import cached_ks_vertical_slice_summary
 
 
 def test_m5_ks_promotion_decision_records_reference_fallback_no_go_evidence() -> None:
-    summary = _run_ks_vertical_slice_summary()
+    summary = cached_ks_vertical_slice_summary()
 
     assert summary["evidence_label"] == "reference_fallback"
     assert summary["reference_fallback_used"] is True

--- a/tests/test_ks_residual_feasibility.py
+++ b/tests/test_ks_residual_feasibility.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+import pdelie
+from pdelie import DerivativeBatch, FieldBatch, PDELieValidationError
+from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from tests._helpers.ks_feasibility import (
+    KS_FEASIBILITY_CONFIG,
+    KSFeasibilityResidualEvaluator,
+    generate_ks_feasibility_field_batch,
+)
+
+
+def test_ks_residual_internal_derivative_path_returns_valid_residual_batch() -> None:
+    field = generate_ks_feasibility_field_batch()
+
+    residual = KSFeasibilityResidualEvaluator().evaluate(field)
+
+    assert residual.definition_type == "analytic"
+    assert residual.normalization == "none"
+    assert residual.residual.shape == field.values.shape
+    assert set(residual.diagnostics) == {"equation", "backend", "max_abs_residual", "rms_residual"}
+    assert residual.diagnostics["equation"] == KS_FEASIBILITY_CONFIG["equation"]
+    assert residual.diagnostics["backend"] == "spectral_fd"
+    assert residual.diagnostics["max_abs_residual"] < 5e-2
+    assert residual.diagnostics["rms_residual"] < 1e-2
+    residual.validate_against(field)
+
+
+def test_ks_residual_explicit_order_four_derivatives_match_internal_path() -> None:
+    field = generate_ks_feasibility_field_batch()
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+
+    internal = KSFeasibilityResidualEvaluator().evaluate(field)
+    explicit = KSFeasibilityResidualEvaluator().evaluate(field, derivatives)
+
+    np.testing.assert_allclose(explicit.residual, internal.residual, rtol=0.0, atol=0.0)
+    assert explicit.diagnostics == internal.diagnostics
+
+
+def test_ks_residual_explicit_order_three_derivatives_fail_for_missing_uxxxx() -> None:
+    field = generate_ks_feasibility_field_batch()
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=3)
+
+    with pytest.raises(PDELieValidationError, match="u_xxxx"):
+        KSFeasibilityResidualEvaluator().evaluate(field, derivatives)
+
+
+def test_ks_residual_does_not_depend_on_uxxx() -> None:
+    field = generate_ks_feasibility_field_batch()
+    derivatives = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+    without_uxxx = DerivativeBatch(
+        derivatives={key: value for key, value in derivatives.derivatives.items() if key != "u_xxx"},
+        backend=derivatives.backend,
+        config=derivatives.config,
+        boundary_assumptions=derivatives.boundary_assumptions,
+        diagnostics=derivatives.diagnostics,
+    )
+
+    with_uxxx = KSFeasibilityResidualEvaluator().evaluate(field, derivatives)
+    without = KSFeasibilityResidualEvaluator().evaluate(field, without_uxxx)
+
+    np.testing.assert_allclose(without.residual, with_uxxx.residual, rtol=0.0, atol=0.0)
+
+
+def _base_ks_field() -> FieldBatch:
+    return generate_ks_feasibility_field_batch(batch_size=1)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda field: setattr(field, "dims", ("batch", "x", "time", "var")),
+        lambda field: field.metadata["boundary_conditions"].__setitem__("x", "dirichlet"),
+        lambda field: setattr(field, "mask", np.zeros(field.values.shape, dtype=bool)),
+        lambda field: field.values.__setitem__((0, 0, 0, 0), np.nan),
+        lambda field: field.metadata.__setitem__("parameter_tags", {}),
+        lambda field: field.metadata.__setitem__("parameter_tags", {"equation": "heat_1d"}),
+    ],
+)
+def test_ks_residual_rejects_unsupported_fields(mutate: object) -> None:
+    field = _base_ks_field()
+    mutate(field)
+
+    with pytest.raises(PDELieValidationError):
+        KSFeasibilityResidualEvaluator().evaluate(field)
+
+
+def test_ks_residual_rejects_multivariable_field() -> None:
+    field = _base_ks_field()
+    field.values = np.repeat(field.values, 2, axis=-1)
+    field.var_names = ["u", "v"]
+
+    with pytest.raises(PDELieValidationError):
+        KSFeasibilityResidualEvaluator().evaluate(field)
+
+
+def test_ks_residual_rejects_malformed_parameter_tags() -> None:
+    field = _base_ks_field()
+    field.metadata["parameter_tags"] = "ks_normalized"
+
+    with pytest.raises(PDELieValidationError):
+        KSFeasibilityResidualEvaluator().evaluate(field)
+
+
+def test_ks_residual_rejects_valid_looking_heat_and_kdv_fields() -> None:
+    heat = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=11131)
+    kdv = generate_kdv_1d_field_batch(batch_size=1, num_times=5, num_points=16, num_modes=1, seed=11132)
+
+    with pytest.raises(PDELieValidationError, match="ks_normalized"):
+        KSFeasibilityResidualEvaluator().evaluate(heat)
+    with pytest.raises(PDELieValidationError, match="ks_normalized"):
+        KSFeasibilityResidualEvaluator().evaluate(kdv)
+
+
+def test_ks_residual_feasibility_adds_no_public_ks_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")

--- a/tests/test_ks_vertical_slice_feasibility.py
+++ b/tests/test_ks_vertical_slice_feasibility.py
@@ -5,86 +5,11 @@ import importlib
 import numpy as np
 
 import pdelie
-from pdelie.data import split_batch_train_heldout
-from pdelie.derivatives import compute_spectral_fd_derivatives
-from pdelie.symmetry.fitting import fit_translation_generator
-from pdelie.symmetry.parameterization import translation_span_distance
-from pdelie.verification import verify_translation_generator
-from tests._helpers.ks_feasibility import (
-    KSFeasibilityResidualEvaluator,
-    compute_l2_norm,
-    compute_mass,
-    generate_ks_feasibility_field_batch,
-)
-
-
-def _classify_translation_evidence(
-    *,
-    reference_fallback_used: bool,
-    selected_span_distance: float,
-    verification_failed: bool,
-    fallback_reason: object,
-    svd_span_distance: object,
-) -> str:
-    if not reference_fallback_used and selected_span_distance <= 1e-1:
-        return "direct_svd_in_tolerance"
-    if (
-        reference_fallback_used
-        and selected_span_distance <= 1e-1
-        and not verification_failed
-        and isinstance(fallback_reason, str)
-        and fallback_reason
-        and svd_span_distance is not None
-    ):
-        return "reference_fallback"
-    return "mixed"
-
-
-def _run_ks_vertical_slice_summary() -> dict[str, object]:
-    field = generate_ks_feasibility_field_batch()
-    training, heldout = split_batch_train_heldout(field, train_size=2, seed=11102)
-
-    derivatives = compute_spectral_fd_derivatives(training, max_spatial_order=4)
-    residual_evaluator = KSFeasibilityResidualEvaluator()
-    residual = residual_evaluator.evaluate(training, derivatives)
-    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
-    verification = verify_translation_generator(heldout, generator, residual_evaluator)
-
-    mass = compute_mass(field)
-    l2 = compute_l2_norm(field)
-    mass_drift = float(np.max(np.abs(mass - mass[:, [0]])))
-    relative_l2_drift = float(np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12)))
-    selected_span_distance = float(translation_span_distance(generator.coefficients))
-    svd_span_distance = generator.diagnostics.get("svd_span_distance")
-    fallback_reason = generator.diagnostics.get("fallback_reason")
-    evidence_label = _classify_translation_evidence(
-        reference_fallback_used=bool(generator.diagnostics["reference_fallback_used"]),
-        selected_span_distance=selected_span_distance,
-        verification_failed=verification.classification == "failed",
-        fallback_reason=fallback_reason,
-        svd_span_distance=svd_span_distance,
-    )
-
-    return {
-        "derivative_keys": sorted(derivatives.derivatives),
-        "residual_max_abs": float(residual.diagnostics["max_abs_residual"]),
-        "residual_rms": float(residual.diagnostics["rms_residual"]),
-        "mass_drift": mass_drift,
-        "relative_l2_drift": relative_l2_drift,
-        "selected_span_distance": selected_span_distance,
-        "svd_span_distance": None if svd_span_distance is None else float(svd_span_distance),
-        "fit_mode": generator.diagnostics["fit_mode"],
-        "reference_fallback_used": bool(generator.diagnostics["reference_fallback_used"]),
-        "fallback_reason": fallback_reason,
-        "first_epsilon_error": float(verification.error_curve[0]),
-        "classification": verification.classification,
-        "transform_mode": verification.diagnostics["transform_mode"],
-        "evidence_label": evidence_label,
-    }
+from tests._helpers.ks_vertical_slice import cached_ks_vertical_slice_summary, run_ks_vertical_slice_summary
 
 
 def test_ks_vertical_slice_frozen_fixture_passes_feasibility_thresholds() -> None:
-    summary = _run_ks_vertical_slice_summary()
+    summary = cached_ks_vertical_slice_summary()
 
     assert summary["derivative_keys"] == ["u_t", "u_x", "u_xx", "u_xxx", "u_xxxx"]
     assert summary["residual_max_abs"] < 5e-2
@@ -97,7 +22,7 @@ def test_ks_vertical_slice_frozen_fixture_passes_feasibility_thresholds() -> Non
 
 
 def test_ks_vertical_slice_records_relative_l2_drift_as_diagnostic_only() -> None:
-    summary = _run_ks_vertical_slice_summary()
+    summary = cached_ks_vertical_slice_summary()
 
     assert "relative_l2_drift" in summary
     assert summary["relative_l2_drift"] >= 0.0
@@ -106,7 +31,7 @@ def test_ks_vertical_slice_records_relative_l2_drift_as_diagnostic_only() -> Non
 
 
 def test_ks_vertical_slice_evidence_label_records_fallback_context() -> None:
-    summary = _run_ks_vertical_slice_summary()
+    summary = cached_ks_vertical_slice_summary()
 
     assert summary["evidence_label"] in {"direct_svd_in_tolerance", "reference_fallback", "mixed"}
     if summary["reference_fallback_used"]:
@@ -119,8 +44,8 @@ def test_ks_vertical_slice_evidence_label_records_fallback_context() -> None:
 
 
 def test_ks_vertical_slice_summary_is_deterministic() -> None:
-    first = _run_ks_vertical_slice_summary()
-    second = _run_ks_vertical_slice_summary()
+    first = run_ks_vertical_slice_summary()
+    second = run_ks_vertical_slice_summary()
     numeric_keys = {
         "residual_max_abs",
         "residual_rms",

--- a/tests/test_ks_vertical_slice_feasibility.py
+++ b/tests/test_ks_vertical_slice_feasibility.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+
+import pdelie
+from pdelie.data import split_batch_train_heldout
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.symmetry.parameterization import translation_span_distance
+from pdelie.verification import verify_translation_generator
+from tests._helpers.ks_feasibility import (
+    KSFeasibilityResidualEvaluator,
+    compute_l2_norm,
+    compute_mass,
+    generate_ks_feasibility_field_batch,
+)
+
+
+def _classify_translation_evidence(
+    *,
+    reference_fallback_used: bool,
+    selected_span_distance: float,
+    verification_failed: bool,
+    fallback_reason: object,
+    svd_span_distance: object,
+) -> str:
+    if not reference_fallback_used and selected_span_distance <= 1e-1:
+        return "direct_svd_in_tolerance"
+    if (
+        reference_fallback_used
+        and selected_span_distance <= 1e-1
+        and not verification_failed
+        and isinstance(fallback_reason, str)
+        and fallback_reason
+        and svd_span_distance is not None
+    ):
+        return "reference_fallback"
+    return "mixed"
+
+
+def _run_ks_vertical_slice_summary() -> dict[str, object]:
+    field = generate_ks_feasibility_field_batch()
+    training, heldout = split_batch_train_heldout(field, train_size=2, seed=11102)
+
+    derivatives = compute_spectral_fd_derivatives(training, max_spatial_order=4)
+    residual_evaluator = KSFeasibilityResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, residual_evaluator)
+
+    mass = compute_mass(field)
+    l2 = compute_l2_norm(field)
+    mass_drift = float(np.max(np.abs(mass - mass[:, [0]])))
+    relative_l2_drift = float(np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12)))
+    selected_span_distance = float(translation_span_distance(generator.coefficients))
+    svd_span_distance = generator.diagnostics.get("svd_span_distance")
+    fallback_reason = generator.diagnostics.get("fallback_reason")
+    evidence_label = _classify_translation_evidence(
+        reference_fallback_used=bool(generator.diagnostics["reference_fallback_used"]),
+        selected_span_distance=selected_span_distance,
+        verification_failed=verification.classification == "failed",
+        fallback_reason=fallback_reason,
+        svd_span_distance=svd_span_distance,
+    )
+
+    return {
+        "derivative_keys": sorted(derivatives.derivatives),
+        "residual_max_abs": float(residual.diagnostics["max_abs_residual"]),
+        "residual_rms": float(residual.diagnostics["rms_residual"]),
+        "mass_drift": mass_drift,
+        "relative_l2_drift": relative_l2_drift,
+        "selected_span_distance": selected_span_distance,
+        "svd_span_distance": None if svd_span_distance is None else float(svd_span_distance),
+        "fit_mode": generator.diagnostics["fit_mode"],
+        "reference_fallback_used": bool(generator.diagnostics["reference_fallback_used"]),
+        "fallback_reason": fallback_reason,
+        "first_epsilon_error": float(verification.error_curve[0]),
+        "classification": verification.classification,
+        "transform_mode": verification.diagnostics["transform_mode"],
+        "evidence_label": evidence_label,
+    }
+
+
+def test_ks_vertical_slice_frozen_fixture_passes_feasibility_thresholds() -> None:
+    summary = _run_ks_vertical_slice_summary()
+
+    assert summary["derivative_keys"] == ["u_t", "u_x", "u_xx", "u_xxx", "u_xxxx"]
+    assert summary["residual_max_abs"] < 5e-2
+    assert summary["residual_rms"] < 1e-2
+    assert summary["mass_drift"] <= 1e-8
+    assert summary["selected_span_distance"] <= 1e-1
+    assert summary["first_epsilon_error"] < 5e-4
+    assert summary["classification"] != "failed"
+    assert summary["transform_mode"] == "uniform_translation"
+
+
+def test_ks_vertical_slice_records_relative_l2_drift_as_diagnostic_only() -> None:
+    summary = _run_ks_vertical_slice_summary()
+
+    assert "relative_l2_drift" in summary
+    assert summary["relative_l2_drift"] >= 0.0
+    # KS M4 gates mass drift, not relative L2 drift.
+    assert summary["mass_drift"] <= 1e-8
+
+
+def test_ks_vertical_slice_evidence_label_records_fallback_context() -> None:
+    summary = _run_ks_vertical_slice_summary()
+
+    assert summary["evidence_label"] in {"direct_svd_in_tolerance", "reference_fallback", "mixed"}
+    if summary["reference_fallback_used"]:
+        assert summary["evidence_label"] == "reference_fallback"
+        assert summary["selected_span_distance"] <= 1e-1
+        assert summary["classification"] != "failed"
+        assert isinstance(summary["fallback_reason"], str)
+        assert summary["fallback_reason"]
+        assert summary["svd_span_distance"] is not None
+
+
+def test_ks_vertical_slice_summary_is_deterministic() -> None:
+    first = _run_ks_vertical_slice_summary()
+    second = _run_ks_vertical_slice_summary()
+    numeric_keys = {
+        "residual_max_abs",
+        "residual_rms",
+        "mass_drift",
+        "relative_l2_drift",
+        "selected_span_distance",
+        "svd_span_distance",
+        "first_epsilon_error",
+    }
+
+    for key in first:
+        if key in numeric_keys:
+            np.testing.assert_allclose(first[key], second[key], rtol=1e-12, atol=1e-15)
+        else:
+            assert first[key] == second[key]
+
+
+def test_ks_vertical_slice_feasibility_adds_no_public_ks_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")

--- a/tests/test_ks_vertical_slice_feasibility.py
+++ b/tests/test_ks_vertical_slice_feasibility.py
@@ -133,7 +133,7 @@ def test_ks_vertical_slice_summary_is_deterministic() -> None:
 
     for key in first:
         if key in numeric_keys:
-            np.testing.assert_allclose(first[key], second[key], rtol=1e-12, atol=1e-15)
+            np.testing.assert_allclose(first[key], second[key], rtol=1e-9, atol=1e-12)
         else:
             assert first[key] == second[key]
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -134,6 +134,10 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "import_generator_family_manifest")
     assert not hasattr(pdelie, "KdVResidualEvaluator")
     assert not hasattr(pdelie, "generate_kdv_1d_field_batch")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "generate_ks_feasibility_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "sample_kdv_mode_coefficients")
     assert not hasattr(pdelie, "compare_generator_spans")
@@ -164,6 +168,8 @@ def test_data_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(data_module, "subsample_time")
     assert hasattr(data_module, "subsample_x")
     assert hasattr(data_module, "split_batch_train_heldout")
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
     assert not hasattr(data_module, "sample_kdv_mode_coefficients")
 
 
@@ -181,6 +187,8 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
     assert not hasattr(residuals_module, "WeakHeatResidualEvaluator")
     assert not hasattr(residuals_module, "WeakBurgersResidualEvaluator")
     assert not hasattr(residuals_module, "WeakKdVResidualEvaluator")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(residuals_module, "KDVResidualEvaluator")
     assert not hasattr(residuals_module, "KdvResidualEvaluator")
 

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_10-release-gate"]
-    assert "python -m pytest tests/test_v0_10_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_11-release-gate"]
+    assert "python -m pytest tests/test_v0_11_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
-    for historical_job in range(4, 10):
+    for historical_job in range(4, 11):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -16,12 +16,16 @@ _REPORTING_HELPERS = {
     "summarize_weak_residual_report",
 }
 _DEFERRED_OR_FORBIDDEN_NAMES = {
+    "KSResidualEvaluator",
+    "KuramotoSivashinskyResidualEvaluator",
     "OperatorSymmetry",
     "WeakKdVResidualEvaluator",
     "compute_weak_derivatives",
     "evaluate_weak_kdv_residual",
     "from_pdebench",
     "from_the_well",
+    "generate_ks_1d_field_batch",
+    "generate_ks_feasibility_field_batch",
     "load_pdebench",
     "load_the_well",
     "sample_kdv_mode_coefficients",

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -10,7 +10,7 @@ import numpy as np
 import pdelie
 from pdelie.data import generate_heat_1d_field_batch
 from pdelie.derivatives import compute_spectral_fd_derivatives
-from tests.test_ks_vertical_slice_feasibility import _run_ks_vertical_slice_summary
+from tests._helpers.ks_vertical_slice import cached_ks_vertical_slice_summary
 
 
 def _repo_text(path: str) -> str:
@@ -61,7 +61,7 @@ def test_v0_11_release_gate_no_public_ks_runtime_surface() -> None:
 
 
 def test_v0_11_release_gate_ks_closeout_remains_reference_fallback_no_go() -> None:
-    summary = _run_ks_vertical_slice_summary()
+    summary = cached_ks_vertical_slice_summary()
 
     assert summary["evidence_label"] == "reference_fallback"
     assert summary["reference_fallback_used"] is True

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from tests.test_ks_vertical_slice_feasibility import _run_ks_vertical_slice_summary
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def test_v0_11_release_gate_order4_derivative_api_is_public_and_documented() -> None:
+    derivatives_module = importlib.import_module("pdelie.derivatives")
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=11011)
+
+    assert hasattr(derivatives_module, "compute_spectral_fd_derivatives")
+    assert not hasattr(pdelie, "compute_spectral_fd_derivatives")
+
+    default = compute_spectral_fd_derivatives(field)
+    order4 = compute_spectral_fd_derivatives(field, max_spatial_order=4)
+
+    assert set(default.derivatives) == {"u_t", "u_x", "u_xx"}
+    assert "spatial_max_order" not in default.config
+    assert set(order4.derivatives) == {"u_t", "u_x", "u_xx", "u_xxx", "u_xxxx"}
+    assert order4.config["spatial_max_order"] == 4
+    assert np.all(np.isfinite(order4.derivatives["u_xxxx"]))
+
+    assert "pdelie.derivatives.compute_spectral_fd_derivatives(field, *, max_spatial_order=4)" in api_stability
+    assert "this derivative extension does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator" in api_stability
+    assert "pdelie.data.generate_ks_1d_field_batch" not in api_stability
+    assert "pdelie.residuals.KSResidualEvaluator" not in api_stability
+
+
+def test_v0_11_release_gate_no_public_ks_runtime_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+    examples_module = importlib.import_module("pdelie.examples")
+    forbidden_names = {
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "run_ks_vertical_slice_example",
+        "evaluate_weak_ks_residual",
+        "evaluate_weak_kuramoto_sivashinsky_residual",
+        "WeakKSResidualEvaluator",
+    }
+
+    for module in [pdelie, data_module, residuals_module, examples_module]:
+        for name in sorted(forbidden_names):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"
+
+
+def test_v0_11_release_gate_ks_closeout_remains_reference_fallback_no_go() -> None:
+    summary = _run_ks_vertical_slice_summary()
+
+    assert summary["evidence_label"] == "reference_fallback"
+    assert summary["reference_fallback_used"] is True
+    assert isinstance(summary["fallback_reason"], str)
+    assert summary["fallback_reason"]
+    assert summary["selected_span_distance"] <= 1e-1
+    assert summary["svd_span_distance"] is not None
+    assert summary["svd_span_distance"] > 1e-1
+    assert summary["classification"] != "failed"
+
+
+def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_11_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.11.0"
+    assert release_gate_jobs == ["v0_11-release-gate"]
+    assert "python -m pytest tests/test_v0_11_release_gate.py" in workflow
+
+    assert "## 0.11.0" in changelog
+    assert "V0.11" in readme
+    assert "stable KS runtime" in readme
+    assert "package version: `0.11.0`" in readiness
+    assert "git tag: `v0.11.0`" in readiness
+    assert "no-go/defer" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
+    assert "including `v0.11.0`" in publishing


### PR DESCRIPTION
## Summary

Closes `v0.11.0` as a Kuramoto-Sivashinsky feasibility/no-go release.

This release adds stable order-4 spectral derivative support via `compute_spectral_fd_derivatives(..., max_spatial_order=4)` and records internal KS feasibility evidence, but explicitly defers stable KS runtime promotion. No public KS generator, residual evaluator, example, imported parity, weak KS API, or root KS export lands in this release.

## Key Changes

- Added `u_xxxx` support for the existing `spectral_fd` derivative backend.
- Preserved default `max_spatial_order=2` derivative behavior, config, diagnostics, and outputs.
- Added internal KS feasibility coverage for:
  - normalized KS equation: `u_t + u*u_x + u_xx + u_xxxx = 0`
  - internal ETDRK4 feasibility fixture
  - internal residual evaluator
  - vertical-slice fitting and held-out verification
- Recorded M5 no-go decision:
  - KS residual, mass, and held-out canonical verification pass with margin
  - direct SVD fitting remains out of tolerance
  - selected span passes through `reference_fallback`
  - stable KS promotion is deferred for `v0.11`
- Added compact `v0_11-release-gate`.
- Updated CI current release gate from `v0_10` to `v0_11`.
- Aligned version, README, changelog, roadmap, planning docs, publishing docs, and release-readiness notes for `0.11.0`.

## Public API

New public behavior:

- `pdelie.derivatives.compute_spectral_fd_derivatives(..., max_spatial_order=4)`
  - emits `u_t`, `u_x`, `u_xx`, `u_xxx`, `u_xxxx`

No new public KS runtime APIs were added.

## Validation

- `python -m pytest`: `567 passed, 2 skipped`
- `python -m build --sdist --wheel`
- clean Python 3.11 wheel smoke
- `python -m pdelie.examples.heat_vertical_slice`
- `python -m pdelie.examples.kdv_vertical_slice`
- `git diff --check`

## Release Notes

`v0.11.0` is a Git-tag-only release. No TestPyPI or PyPI publishing is part of this release; package-index publishing remains deferred until `v1.0` or later.