### PR TITLE
Feat/v0.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_11-release-gate:
+  v0_12-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.11 release gate
-        run: python -m pytest tests/test_v0_11_release_gate.py
+      - name: Run V0.12 release gate
+        run: python -m pytest tests/test_v0_12_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -122,6 +122,7 @@ jobs:
 
           from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport
           from pdelie.reporting import (
+              summarize_generator_fit_diagnostics,
               summarize_generator_family,
               summarize_residual_batch,
               summarize_verification_report,
@@ -135,13 +136,62 @@ jobs:
           assert ResidualEvaluator is not None
           assert GeneratorFamily is not None
           assert VerificationReport is not None
+          assert summarize_generator_fit_diagnostics is not None
           assert summarize_generator_family is not None
           assert summarize_residual_batch is not None
           assert summarize_verification_report is not None
           assert summarize_vertical_slice is not None
           assert summarize_weak_residual_report is not None
+          assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
           assert not hasattr(pdelie, "summarize_vertical_slice")
           print("stable-import-ok")
+          PY
+      - name: Generator fit diagnostics smoke
+        run: |
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import json
+          import numpy as np
+
+          import pdelie
+          from pdelie import GeneratorFamily
+          from pdelie.contracts import _translation_generator_basis_spec
+          from pdelie.reporting import summarize_generator_fit_diagnostics
+
+          generator = GeneratorFamily(
+              parameterization="polynomial_translation_affine",
+              coefficients=np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+              basis_spec=_translation_generator_basis_spec(),
+              normalization="l2_unit",
+              diagnostics={
+                  "fit_mode": "svd",
+                  "training_epsilon": 1e-4,
+                  "basis": ["1", "t", "x", "u"],
+                  "basis_delta_norms": {"1": 1.0, "t": 2.0, "x": 3.0, "u": 4.0},
+                  "design_column_norms": {"1": 1.0, "t": 2.0, "x": 3.0, "u": 4.0},
+                  "singular_values": [4.0, 2.0, 1.0],
+                  "condition_number": 4.0,
+                  "fit_residual": 1e-8,
+                  "min_delta_basis": "1",
+                  "selected_coefficients": [1.0, 0.0, 0.0, 0.0],
+                  "svd_coefficients": [1.0, 0.0, 0.0, 0.0],
+                  "selected_span_distance": 0.0,
+                  "svd_span_distance": 0.0,
+                  "reference_fallback_used": False,
+                  "fallback_reason": None,
+                  "evidence_label": "direct_svd_in_tolerance",
+              },
+          )
+          summary = summarize_generator_fit_diagnostics(generator)
+          json.dumps(summary)
+          assert summary["summary_type"] == "generator_fit_diagnostics"
+          assert summary["condition_number"] == 4.0
+          assert summary["evidence_label"] == "direct_svd_in_tolerance"
+          assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
+          assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+          assert not hasattr(pdelie, "summarize_orbit_coverage")
+          assert not hasattr(pdelie, "augment_translation_orbit")
+          assert not hasattr(pdelie, "WeakKSResidualEvaluator")
+          print("generator-fit-diagnostics-smoke-ok")
           PY
       - name: Weak residual report smoke
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.12.0
+
+First final release for the frozen V0.12 diagnostics and supportability hardening slice.
+
+- adds `pdelie.reporting.summarize_generator_fit_diagnostics(...)` for JSON-compatible summaries of generator-fit diagnostics, singular values, condition number, selected/SVD span distances, fallback status, and evidence labels
+- enriches `fit_translation_generator(...)` diagnostics without changing coefficient selection or fitting behavior
+- adds internal KS diagnostic sweep evidence showing residuals and verification remain healthy while direct residual-based SVD fitting remains fallback-backed across frozen epsilons and cheap fixture variants
+- adds internal orbit/coverage feasibility diagnostics over stable Heat and KdV fixtures, including periodic-window coverage and uniform-translation consistency checks
+- tightens API stability and public-surface guards so KS, orbit/coverage, augmentation, weak KS, broad adapter, and root runtime exports remain absent
+- updates CI to the compact current `v0_12-release-gate` while preserving full editable tests and package smoke
+- preserves the prior Heat/Burgers strong paths, `v0.8` weak residual report APIs, `v0.9` normalized periodic KdV strong path, `v0.10` reporting helpers, and `v0.11` order-4 derivative API
+
+Explicitly deferred for this final release:
+
+- new PDE support
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak API, or root KS exports
+- public orbit/coverage helpers
+- public augmentation utilities
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- manuscript-specific experiment logic, tables, figures, or thresholds
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.11.0
 
 First final release for the frozen V0.11 Kuramoto-Sivashinsky feasibility/no-go closeout.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.11 feasibility/no-go closeout for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.12 diagnostics and supportability hardening slice for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -10,10 +10,12 @@ The current repository implements the frozen V0.11 feasibility/no-go closeout fo
 - strict external structured ingestion into canonical `FieldBatch`
 - deterministic window-indexed weak residual reports under `pdelie.residuals`
 - JSON-compatible runtime supportability summaries under `pdelie.reporting`
+- generator-fit diagnostic summaries under `pdelie.reporting.summarize_generator_fit_diagnostics`
 - uniform periodic grid
 - `spectral_fd` derivatives through `u_xxxx`
 - normalized KdV strong residuals under `pdelie.residuals.KdVResidualEvaluator`
-- internal Kuramoto-Sivashinsky feasibility evidence with stable runtime promotion deferred
+- internal Kuramoto-Sivashinsky diagnostic sweep evidence with stable runtime promotion deferred
+- internal orbit/coverage diagnostic feasibility over stable Heat and KdV fixtures
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -28,7 +30,7 @@ The current repository implements the frozen V0.11 feasibility/no-go closeout fo
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_11-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_12-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -77,7 +79,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.11`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.12`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -136,7 +138,7 @@ Included in the current stable core:
 - strict structured external-data ingestion into canonical `FieldBatch` via `from_numpy(...)` and `from_xarray(...)`
 - stable weak residual report APIs under `pdelie.residuals` for Heat and Burgers
 - stable normalized KdV strong residual evaluator under `pdelie.residuals`
-- stable supportability reporting helpers under `pdelie.reporting`
+- stable supportability reporting helpers under `pdelie.reporting`, including generator-fit diagnostic summaries
 - polynomial translation baseline for the stable PDE slice
 - finite-transform verification for the stable PDE slice
 - family-shaped `GeneratorFamily` serialization and narrow translation compatibility migration
@@ -147,9 +149,10 @@ Included in the current stable core:
 - matched Heat/Burgers benchmark and release-gate checks in the test layer
 - consolidated current release-gate CI visibility while retaining historical gate tests in the full test suite
 - KdV is stable only for the normalized periodic short-horizon strong path; weak KdV remains explicitly deferred
-- KS remains internal feasibility evidence in `v0.11`; no stable KS runtime API is promoted
+- KS remains internal feasibility/no-go evidence from `v0.11` plus internal diagnostic sweep evidence in `v0.12`; no stable KS runtime API is promoted
+- orbit/coverage work in `v0.12` is internal diagnostic feasibility only; no public orbit/coverage or augmentation API is promoted
 
-Runtime-level public APIs in the frozen V0.11 slice:
+Runtime-level public APIs in the frozen V0.12 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -162,6 +165,7 @@ Runtime-level public APIs in the frozen V0.11 slice:
 - `pdelie.reporting.summarize_residual_batch` for JSON-compatible runtime summaries of `ResidualBatch` outputs
 - `pdelie.reporting.summarize_weak_residual_report` for JSON-compatible summaries of frozen weak residual report dicts
 - `pdelie.reporting.summarize_generator_family` for JSON-compatible summaries of `GeneratorFamily` coefficients and diagnostics
+- `pdelie.reporting.summarize_generator_fit_diagnostics` for JSON-compatible summaries of generator-fit diagnostics, singular values, condition number, selected/SVD span distances, fallback status, and evidence labels
 - `pdelie.reporting.summarize_verification_report` for JSON-compatible summaries of finite-transform verification sweeps
 - `pdelie.reporting.summarize_vertical_slice` for nested derivative/residual/generator/verification runtime summaries
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
@@ -187,6 +191,8 @@ The `v0.10` reporting helpers are supportability APIs. They produce JSON-compati
 
 The `v0.11` KS feasibility track does not promote stable KS runtime support. Internal feasibility evidence passes residual, mass, and canonical held-out verification checks, but translation fitting is reference-fallback-backed rather than direct SVD in-tolerance recovery.
 
+The `v0.12` diagnostics work hardens supportability without changing numerical scope. The public addition is the submodule-only `summarize_generator_fit_diagnostics(...)` helper. The internal KS diagnostic sweep and orbit/coverage feasibility helpers remain test-only evidence, not public runtime APIs.
+
 Explicitly deferred:
 - stable multi-generator PDE fitting
 - multi-generator invariant machinery
@@ -201,4 +207,5 @@ Explicitly deferred:
 - custom KdV initial conditions or configurable KdV coefficients
 - general KdV support outside the frozen normalized periodic short-horizon regime
 - stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export
+- public orbit/coverage helpers or augmentation utilities
 - broad adapters and interoperability work

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -329,19 +329,78 @@ M3 strengthens the no-go diagnosis:
 
 ## Milestone 4 - Orbit / Coverage Diagnostic Feasibility
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Evaluate paper-agnostic orbit and coverage diagnostics without implementing downstream experiment policy.
 
-### Planned Scope
+### Completed Outcome
 
-- read-only finite-transform or orbit views if scoped tightly
-- periodic `x` coverage diagnostics
-- augmentation provenance summaries
-- finite-transform consistency checks
-- reporting-only coverage summaries before any mutation or augmentation API
+- added internal test-only helper:
+  - `tests._helpers.orbit_coverage_feasibility.run_orbit_coverage_feasibility()`
+- kept the helper out of runtime `src/`
+- kept output as a JSON-compatible plain dict only
+- wrote no artifact files by default
+- reused existing canonical objects and stable runtime surfaces:
+  - `FieldBatch`
+  - `InvariantMapSpec`
+  - `InvariantApplier`
+  - `HeatResidualEvaluator`
+  - `KdVResidualEvaluator`
+- recorded periodic-window coverage diagnostics over a 64-point `x` grid on `[0, 2*pi)`
+- recorded transform consistency diagnostics for stable Heat and KdV fixtures
+- confirmed transform provenance uses:
+  - `operation == "invariant_apply"`
+  - `construction_method == "uniform_translation"`
+- confirmed no public orbit/coverage helper, augmentation API, KS API, weak KS API, broad adapter, or root export landed
+
+### Observed Coverage Evidence
+
+Coverage cases:
+
+- `half_coverage_quarter_shifts`
+  - base window width: `pi/4`
+  - shifts: `0`, `pi/2`, `pi`, `3*pi/2`
+  - covered grid points: `32` of `64`
+  - coverage fraction: `0.5`
+  - min/max coverage count: `0` / `1`
+  - mean coverage count: `0.5`
+  - max uncovered run: `8` grid points
+- `full_coverage_quarter_shifts`
+  - base window width: `pi/2`
+  - shifts: `0`, `pi/2`, `pi`, `3*pi/2`
+  - covered grid points: `64` of `64`
+  - coverage fraction: `1.0`
+  - min/max coverage count: `1` / `1`
+  - mean coverage count: `1.0`
+  - max uncovered run: `0` grid points
+
+Transform consistency cases:
+
+- shifts tested:
+  - `0`
+  - one grid spacing: `0.09817477042468103`
+  - `pi/4`
+  - `-pi/4`
+  - `2*pi`
+- Heat fixture:
+  - residual RMS before shift: `6.40792354432063e-05`
+  - maximum inverse-transform relative L2 error: `2.9650883564194283e-16`
+  - maximum period-wrap relative L2 error: `9.323430358904992e-16`
+  - maximum residual relative RMS delta: `3.2117841724670052e-12`
+- KdV fixture:
+  - residual RMS before shift: `0.0003844090459507004`
+  - maximum inverse-transform relative L2 error: `2.932669879841721e-16`
+  - maximum period-wrap relative L2 error: `7.866600220513022e-16`
+  - maximum residual relative RMS delta: `5.571776753786444e-13`
+
+M4 conclusion:
+
+- periodic-window coverage diagnostics are feasible and deterministic
+- uniform-translation transform consistency diagnostics are feasible over stable Heat and KdV fixtures
+- these diagnostics are not promoted as public APIs in M4
+- public orbit/coverage APIs require a later explicit API freeze before implementation
 
 ### Explicit Non-goals
 
@@ -350,6 +409,9 @@ Evaluate paper-agnostic orbit and coverage diagnostics without implementing down
 - no train-augmentation recipes
 - no PDEBench or The Well
 - no multidimensional, nonuniform, or multivariable expansion
+- no public orbit/coverage helper
+- no public augmentation utility
+- no API stability entry for the internal feasibility helper
 
 ---
 
@@ -436,6 +498,6 @@ Milestone 6 -> release gate and readiness
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
-- Milestone 4: PENDING
+- Milestone 4: COMPLETE
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,19 +1,24 @@
-# PDELie - Execution Plan (V0.11)
+# PDELie - Execution Plan (V0.12)
 
 ## Current Release Status
 
-**V0.11 complete as Kuramoto-Sivashinsky feasibility/no-go closeout**
+**V0.12 is active as diagnostics and supportability hardening**
 
-This file is the completed execution record for the `v0.11` release series.
+This file is the active execution record for the `v0.12` release series.
 
-`v0.11` is a feasibility-first release that evaluated whether normalized scalar 1D periodic Kuramoto-Sivashinsky could be promoted safely into the stable strong-path runtime surface.
+`v0.12` is not a new numerics release. It is a supportability release focused on:
 
-Candidate stable path:
+- generator-fit diagnostics
+- verification diagnostics
+- reporting helper hardening
+- internal KS diagnostic sweeps
+- orbit/coverage diagnostic feasibility
+- API/public-surface audit
+- compact release-gate readiness
 
-`canonical scalar 1D uniform periodic FieldBatch -> spectral_fd higher spatial derivatives -> normalized KS residual evaluator -> translation fit/verification`
+Committed release theme:
 
-Stable KS runtime promotion is deferred.
-`v0.11` closes as an explicit no-go/defer feasibility release while retaining the public order-4 derivative extension.
+`existing stable Heat/Burgers/weak-report/KdV/reporting surfaces -> fit and verification diagnostics -> orbit/coverage reporting feasibility -> release supportability`
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -22,411 +27,276 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_11_SCOPE.md`
+- `docs/planning/V0_12_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0/M1, then updated in M2 when the public order-4 derivative API landed.
-It must be updated in the same milestone where any public KS API or other public API lands.
+`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.12` public API lands in M0.
+It should change only if M2 or M4 lands a public reporting or diagnostic API.
 
 ---
 
-## V0.10 Closeout
+## V0.11 Closeout
 
-`v0.10` is complete as the supportability and `v1.0` readiness release.
+`v0.11` is complete as a Kuramoto-Sivashinsky feasibility/no-go release.
 
 Completed outcome:
 
-- public runtime reporting helpers under `pdelie.reporting`
-- consistent nested Heat/KdV example summaries
-- API stability and public-surface audit coverage
-- one current release-gate CI job plus full editable tests and package smoke
-- package/readiness documentation cleanup for eventual `v1.0` publishing decisions
-- explicit deferral of new PDE scope, weak KdV, broad adapters, operator work, and manuscript-specific reporting logic
+- public `compute_spectral_fd_derivatives(..., max_spatial_order=4)` order-4 derivative extension
+- internal KS generator feasibility helper under tests only
+- internal KS residual feasibility helper under tests only
+- internal KS vertical-slice feasibility coverage
+- explicit no-go/defer decision for stable KS runtime promotion
+- compact `v0_11-release-gate` CI visibility
 
-`v0.11` begins from the frozen `v0.10` surface.
-It does not reopen Heat/Burgers, weak-report, KdV, reporting, CI cleanup, or publishing decisions.
+The important `v0.11` conclusion is unchanged:
+
+- KS residual feasibility passed with large margin
+- mass drift passed with large margin
+- held-out canonical translation verification passed
+- direct residual-based SVD fitting was out of tolerance
+- vertical-slice evidence was reference-fallback-backed
+- stable KS generator/residual/example promotion was deferred
+
+`v0.12` begins from that closeout.
+It does not reopen KS promotion.
 
 ---
 
-## Milestone 0 - KS Feasibility Scope Reset
+## Milestone 0 - Scope Freeze
 
 **Status:** COMPLETE
 
 ### Goal
 
-Promote `v0.11` to the next committed release target, create `V0_11_SCOPE.md`, reset `PLAN.md`, and audit `API_STABILITY.md` without changing it.
+Freeze `v0.12` as diagnostics and supportability hardening, not a numerical expansion release.
 
 ### Completed Outcome
 
-- promoted `v0.11` to committed feasibility-first scope in `ROADMAP.md`
-- created `docs/planning/V0_11_SCOPE.md`
-- reset `docs/planning/PLAN.md` as the active `v0.11` execution record
-- recorded `v0.10` as completed
-- recorded Kuramoto-Sivashinsky as the feasibility candidate
-- recorded stable KS promotion as conditional on later numerical evidence
-- recorded that `v0.11` may close as either stable KS promotion or no-go/defer
+- added `docs/planning/V0_12_SCOPE.md`
+- kept `docs/planning/V0_12_OPTIONS.md` as the supporting diagnosis/options document
+- reset `docs/planning/PLAN.md` as the active `v0.12` execution record
+- updated `docs/planning/ROADMAP.md` to make `v0.12` the next committed release target
+- recorded `v0.11` as completed/no-go feasibility history
+- recorded that KS remains internal feasibility/no-go evidence from `v0.11`
+- recorded that `v0.12` does not add a new PDE, weak KS, stable KS runtime APIs, broad adapters, multidimensional grids, or private-paper policy
+- recorded that any public `v0.12` API must be a reporting/diagnostic helper frozen in M1 before implementation
 - audited `docs/specs/API_STABILITY.md`
-- left `docs/specs/API_STABILITY.md` unchanged because no new `v0.11` public API landed in M0
-- left runtime code, tests, package metadata, CI, README, changelog, and release-readiness docs unchanged
+- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M0
+- left runtime source, tests, README, changelog, package metadata, release readiness, and CI unchanged
 
 ### Acceptance Criteria
 
 M0 is complete only if:
 
-- `ROADMAP.md`, `PLAN.md`, and `V0_11_SCOPE.md` are internally consistent
-- `v0.10` is consistently described as completed
-- `v0.11` is consistently described as committed and feasibility-first
-- `v0.11` is not described as unconditional stable KS support
-- exact KS equation normalization and numerical thresholds remain deferred to M1
-- public KS APIs remain uncommitted until later milestones
-- `API_STABILITY.md` remains unchanged during M0
-- no runtime code, tests, package metadata, CI, README, changelog, or release-readiness docs are edited in M0
+- `V0_12_SCOPE.md`, `PLAN.md`, and `ROADMAP.md` agree on the committed `v0.12` scope
+- `v0.11` remains described as a completed KS feasibility/no-go release
+- `v0.12` is described as diagnostics and supportability hardening
+- no stable KS generator, residual evaluator, example, imported parity, weak API, or root export is promoted
+- no new PDE or broad adapter scope is introduced
+- `API_STABILITY.md` remains unchanged
+- no runtime source files change
 
 ---
 
-## Milestone 1 - KS Equation and Numerical Semantics Freeze
+## Milestone 1 - Fit / Verification Diagnostic Semantics Freeze
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Freeze the exact normalized KS equation and numerical semantics before any runtime prototype or public API is considered.
+Freeze diagnostic semantics before implementation.
 
-### Completed Outcome
+### Planned Scope
 
-- froze normalized nonconservative strong-form KS:
-  - `u_t + u*u_x + u_xx + u_xxxx = 0`
-- froze residual form:
-  - `u_t + u*u_x + u_xx + u_xxxx`
-- recorded the equivalent conservative nonlinear term `1/2*(u^2)_x` as explanatory only
-- froze required KS residual derivatives:
-  - `u_t`
-  - `u_x`
-  - `u_xx`
-  - `u_xxxx`
-- recorded that `u_xxx` is not required by the KS residual evaluator
-- froze future derivative-backend strategy:
-  - later `compute_spectral_fd_derivatives(..., max_spatial_order=4)` emits `u_t`, `u_x`, `u_xx`, `u_xxx`, and `u_xxxx`
-  - default `max_spatial_order=2` must preserve current behavior, arrays, config, and diagnostics
-  - `u_xxxx` must use the same FFT wavenumber convention as existing `u_x`, `u_xx`, and `u_xxx`
-  - unsupported orders still raise `ScopeValidationError`
-- froze coordinate and fixture conventions:
-  - dims exactly `("batch", "time", "x", "var")`
-  - scalar finite unmasked values only
-  - `x = linspace(0, domain_length, num_points, endpoint=False)`
-  - `time = linspace(0, max_time, num_times)`
-  - strictly increasing uniform `time`
-  - uniform periodic `x`
-  - zero-mean Fourier-mode initial conditions for synthetic feasibility fixtures
-  - two-thirds dealiasing
-  - periodic RK-style rollout unless M2 proves unsuitable
-- froze feasibility diagnostics:
-  - residual `max_abs_residual`
-  - residual `rms_residual`
-  - mass drift as the conserved diagnostic
-  - relative L2 drift as diagnostic-only
-  - translation span distance
-  - first-epsilon held-out verification error
-  - verification classification with acceptance requiring only `classification != "failed"`
-- froze preliminary feasibility targets:
-  - residual max `< 5e-2`
-  - residual RMS `< 1e-2`
-  - mass drift `<= 1e-8`
-  - translation span distance `<= 1e-1`
-  - first-epsilon held-out verification error `< 5e-4`
-  - verification classification is not `failed`
-- recorded that these are feasibility targets, not release gates
-- recorded that M4 must replace or confirm them with observed-margin thresholds before stable KS promotion
-- kept public API names and stable promotion conditional
-- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M1
-- left runtime code, tests, package metadata, CI, README, changelog, and release-readiness docs unchanged
+- define fit diagnostic summary fields:
+  - singular values
+  - condition number
+  - basis delta norms
+  - column norms or scaling diagnostics
+  - selected span distance
+  - SVD span distance
+  - fallback status
+  - stable fallback category
+  - epsilon sweep structure
+- define verification diagnostic summary fields
+- decide whether later helpers are public under `pdelie.reporting` or remain internal
+- decide whether any public helper names are frozen for M2
+- keep M1 docs-only unless a docs consistency test needs a tiny update
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- `V0_11_SCOPE.md` and `PLAN.md` agree on KS equation, derivative requirements, coordinate conventions, diagnostics, and preliminary targets
-- `ROADMAP.md` still describes `v0.11` as feasibility-first, not stable KS support
-- `API_STABILITY.md` remains unchanged during M1
-- no runtime code, tests, package metadata, CI, README, changelog, or release-readiness docs are edited in M1
+- no runtime implementation
+- no algorithmic fitting changes
+- no public KS runtime APIs
+- no orbit augmentation implementation
+- no API stability update unless a real contradiction is found
 
 ---
 
-## Milestone 2 - KS Feasibility Generator / Prototype
+## Milestone 2 - Diagnostic / Reporting Helper Implementation
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Create or adapt a deterministic KS feasibility generator/prototype under the frozen M1 semantics.
+Implement the M1-frozen diagnostic/reporting helpers.
 
-### Completed Outcome
+### Planned Scope
 
-- extended public `compute_spectral_fd_derivatives(...)` to accept `max_spatial_order=4`
-- preserved default `max_spatial_order=2` behavior, arrays, config, and diagnostics
-- froze order-4 derivative output keys:
-  - `u_t`
-  - `u_x`
-  - `u_xx`
-  - `u_xxx`
-  - `u_xxxx`
-- computed `u_xxxx` with the same FFT wavenumber convention as the existing spectral derivatives
-- kept invalid derivative orders rejected with typed `ScopeValidationError`
-- updated `docs/specs/API_STABILITY.md` for the public order-4 derivative API
-- added internal KS feasibility generator helpers under tests only
-- froze internal KS generator defaults:
-  - `seed = 11101`
-  - `batch_size = 5`
-  - `num_times = 33`
-  - `num_points = 128`
-  - `max_time = 0.2`
-  - `num_modes = 6`
-  - `amplitude = 0.08`
-  - `num_substeps = 8`
-  - `domain_length = 32*pi`
-- froze KS rollout evolution:
-  - `u_t = -u*u_x - u_xx - u_xxxx`
-- froze nonlinear evaluation:
-  - conservative spectral form `u*u_x = 0.5*(u^2)_x`
-  - two-thirds dealiasing for nonlinear products
-- froze ETDRK4 as the internal rollout scheme
-- explicitly preserved the zero Fourier mode through rollout
-- verified the internal generator is deterministic, canonical, finite, zero-mean, and mass-preserving within the M1 target
-- verified exact Fourier `u_xxxx` sign convention through derivative tests
-- verified no public KS generator, residual evaluator, root export, custom initial-condition API, or configurable KS coefficient family landed
+- implement only helpers whose names and schemas were frozen in M1
+- keep outputs JSON-compatible and supportability-oriented
+- include singular-value and condition-number diagnostics if frozen in M1
+- preserve existing canonical object schemas
+- preserve existing fitting and verification behavior unless a deterministic blocker appears
+- update `API_STABILITY.md` only if public helpers land
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- order-4 derivative tests pass
-- internal KS generator feasibility tests pass
-- `API_STABILITY.md` documents only the public derivative extension, not KS generator/residual APIs
-- public-surface tests keep KS generator and residual APIs absent
-- no README, changelog, package metadata, release-readiness docs, or CI changes land in M2
+- no new canonical object unless M1 proves it is necessary
+- no KS generator/residual promotion
+- no weak KS
+- no private-paper reporting policy
+- no root export expansion unless explicitly frozen
 
 ---
 
-## Milestone 3 - KS Residual Feasibility Prototype
+## Milestone 3 - Internal KS Diagnostic Sweep Harness
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Evaluate the strong-form KS residual path under the frozen semantics.
+Keep KS internal and add bounded diagnostics for the `v0.11` no-go failure mode.
 
-### Completed Outcome
+### Planned Scope
 
-- added internal `KSFeasibilityResidualEvaluator` under test helpers only
-- implemented frozen residual:
-  - `u_t + u*u_x + u_xx + u_xxxx`
-- implemented derivative contract:
-  - omitted derivatives compute `compute_spectral_fd_derivatives(field, max_spatial_order=4)`
-  - supplied derivatives must validate against the field
-  - supplied derivatives must include `u_t`, `u_x`, `u_xx`, and `u_xxxx`
-  - `u_xxx` may be present but is not used
-- returned `ResidualBatch(definition_type="analytic", normalization="none")`
-- froze diagnostics:
-  - `equation`
-  - `backend`
-  - `max_abs_residual`
-  - `rms_residual`
-- verified local validation:
-  - dims exactly `("batch", "time", "x", "var")`
-  - scalar `var`
-  - finite unmasked values
-  - periodic `x`
-  - `field.metadata["parameter_tags"]["equation"] == "ks_normalized"`
-- verified valid-looking Heat and KdV fields are rejected by equation tag
-- verified public KS generator/residual/root exports remain absent
-- observed frozen-fixture residual diagnostics:
-  - max absolute residual: `4.042559716230937e-09`
-  - RMS residual: `3.756593955706264e-10`
-- kept public residual evaluator promotion conditional
-- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M3
+- bounded epsilon sweeps
+- selected span distance
+- SVD span distance
+- fallback status and reason
+- first verification error
+- singular values and condition number if M2 exposes them
+- cheap fixture variants only if they remain internal and non-gated
+- no promotion gate
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- internal and explicit order-4 derivative residual paths match
-- order-3 derivatives fail clearly because `u_xxxx` is missing
-- residual diagnostics satisfy M1 feasibility targets
-- public-surface tests keep KS generator and residual APIs absent
-- no README, changelog, package metadata, release-readiness docs, or CI changes land in M3
+- no stable KS data generator
+- no stable KS residual evaluator
+- no KS vertical-slice example
+- no KS imported parity
+- no API stability entry for KS generator/residual APIs
 
 ---
 
-## Milestone 4 - KS Vertical-Slice Feasibility
+## Milestone 4 - Orbit / Coverage Diagnostic Feasibility
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Run the candidate KS path through the existing strong-path fitting and verification stack.
+Evaluate paper-agnostic orbit and coverage diagnostics without implementing downstream experiment policy.
 
-### Completed Outcome
+### Planned Scope
 
-- added internal KS vertical-slice feasibility coverage under tests only
-- used frozen KS fixture from `generate_ks_feasibility_field_batch()`
-- split train/heldout with `train_size = 2` and `seed = 11102`
-- computed train derivatives with `compute_spectral_fd_derivatives(..., max_spatial_order=4)`
-- evaluated train residual with internal `KSFeasibilityResidualEvaluator`
-- fit with `fit_translation_generator(..., epsilon=1e-4)`
-- verified heldout data with `verify_translation_generator(...)`
-- verified derivative keys:
-  - `u_t`
-  - `u_x`
-  - `u_xx`
-  - `u_xxx`
-  - `u_xxxx`
-- observed M4 feasibility metrics:
-  - residual max absolute value: `2.276047466221332e-09`
-  - residual RMS value: `3.450580898077348e-10`
-  - mass drift: `4.686823294199099e-16`
-  - relative L2 drift: `0.0070894859776733715`
-  - selected span distance: `0.0`
-  - SVD span distance: `0.4178159498317849`
-  - fit mode: `reference_fallback`
-  - reference fallback used: `True`
-  - fallback reason: `svd_translation_span_drift`
-  - first-epsilon heldout verification error: `2.533384127588474e-13`
-  - verification classification: `exact`
-  - transform mode: `uniform_translation`
-  - evidence label: `reference_fallback`
-- recorded that relative L2 drift is diagnostic-only for KS
-- recorded that KS feasibility passed via reference fallback, not direct SVD in-tolerance recovery
-- verified no public KS generator, residual evaluator, root export, example, broad adapter, or runtime surface landed
+- read-only finite-transform or orbit views if scoped tightly
+- periodic `x` coverage diagnostics
+- augmentation provenance summaries
+- finite-transform consistency checks
+- reporting-only coverage summaries before any mutation or augmentation API
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- KS vertical slice passes M1 feasibility thresholds for residual, mass drift, selected span, first-epsilon verification error, and classification
-- relative L2 drift is recorded but not used as a gate
-- fallback-backed evidence records fallback reason and SVD span distance
-- repeated vertical-slice summaries are deterministic within numerical tolerance
-- public-surface tests keep KS generator and residual APIs absent
+- no private sparse-discovery branch logic
+- no manuscript-specific thresholds, labels, tables, or figures
+- no train-augmentation recipes
+- no PDEBench or The Well
+- no multidimensional, nonuniform, or multivariable expansion
 
 ---
 
-## Milestone 5 - Promotion Decision and Imported-Parity / Non-goal Guards
+## Milestone 5 - API / Public-surface Audit
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Make the explicit stable-promotion versus no-go decision.
+Audit API stability and public exports after M2/M4 helper decisions.
 
-### Completed Outcome
+### Planned Scope
 
-- decided to defer stable KS promotion for `v0.11`
-- recorded the outcome as no-go/defer for stable KS runtime APIs in this release
-- preserved the M2 public derivative extension as the only public `v0.11` API change so far:
-  - `compute_spectral_fd_derivatives(..., max_spatial_order=4)`
-- recorded M4 feasibility evidence:
-  - residual evaluation passes with large margin:
-    - max absolute residual: `2.276047466221332e-09`
-    - RMS residual: `3.450580898077348e-10`
-  - mass conservation passes with large margin:
-    - mass drift: `4.686823294199099e-16`
-  - held-out canonical translation verification passes:
-    - first-epsilon heldout verification error: `2.533384127588474e-13`
-    - verification classification: `exact`
-  - selected span distance passes because canonical reference fallback is used:
-    - selected span distance: `0.0`
-    - fit mode: `reference_fallback`
-    - fallback reason: `svd_translation_span_drift`
-  - direct SVD span distance is out of tolerance:
-    - SVD span distance: `0.4178159498317849`
-  - M4 evidence label: `reference_fallback`
-- recorded that the M4 evidence is strong feasibility evidence but not direct residual-based fitting recovery
-- kept KS as internal feasibility evidence in `v0.11`
-- did not add stable KS data generator, residual evaluator, vertical-slice example, imported parity, root export, weak KS API, or broad adapter scope
-- skipped KS imported parity because there is no stable public KS runtime surface to validate
-- added focused no-go guard coverage tying the decision to reference-fallback evidence and absent public KS APIs
+- verify `API_STABILITY.md` matches any public reporting/diagnostic helpers that landed
+- verify root exports remain narrow
+- verify public KS generator/residual/example APIs remain absent
+- verify weak KS remains absent
+- verify broad adapters remain absent
+- update public-surface guards only for real scope changes
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- M4 feasibility tests remain green
-- public KS generator/residual/example exports remain absent
-- `API_STABILITY.md` still documents no stable public KS generator or residual evaluator
-- `PLAN.md` and `V0_11_SCOPE.md` state KS promotion is deferred for `v0.11`
-- no runtime source files change in M5
+- no new numerical scope
+- no CI restructuring beyond release-gate hygiene
+- no release-facing metadata changes before M6
 
 ---
 
-## Milestone 6 - Release Gate / Readiness or No-go Closeout
+## Milestone 6 - Release Gate and Readiness
 
-**Status:** COMPLETE
+**Status:** PENDING
 
 ### Goal
 
-Close `v0.11` according to the M5 decision.
+Close `v0.12` with compact release-gate coverage, docs alignment, package metadata, and direct Git-tag readiness.
 
-### Completed Outcome
+### Planned Scope
 
-- added compact `tests/test_v0_11_release_gate.py`
-- replaced the explicit current CI release-gate job with `v0_11-release-gate`
-- kept full `editable-tests` and `package-smoke` CI coverage
-- kept package smoke compact:
-  - stable root imports
-  - `pdelie.reporting` submodule imports
-  - weak Heat report smoke
-  - KdV strong-path residual smoke
-  - order-4 derivative smoke
-- bumped package metadata to `0.11.0`
-- aligned README and changelog with the `v0.11` no-go/defer closeout
-- created `docs/releases/V0_11_RELEASE_READINESS.md`
-- updated publishing docs to include `v0.11.0` in the Git-tag-only `v0.x` deferral policy
-- updated `ROADMAP.md` to mark `v0.11` completed and leave `v0.12+` conditional
-- audited `docs/specs/API_STABILITY.md`
-- left `API_STABILITY.md` unchanged because it already documented only the order-4 derivative extension and no stable KS generator/residual APIs
-- left the stable public surface unchanged except for the existing M2 order-4 derivative API
-- documented that no PyPI or TestPyPI publishing is part of `v0.11`
+- add compact `v0_12-release-gate`
+- keep full editable tests as historical gate coverage
+- keep package smoke small
+- update README, changelog, release readiness, roadmap, and package metadata
+- audit `API_STABILITY.md`
+- document final release path
 
-### Acceptance Criteria
+### Explicit Non-goals
 
-- `v0_11-release-gate`, `editable-tests`, and `package-smoke` are the required CI checks before tagging
-- release-facing docs describe `v0.11` as a KS feasibility/no-go release
-- `pyproject.toml` version is `0.11.0`
-- no stable KS generator, residual evaluator, example, imported parity, weak API, or root export lands
-- release docs state package-index publishing remains deferred until `v1.0` or later
+- no package-index publishing before the `v1.0` policy is accepted
+- no KS promotion unless a prior milestone explicitly changes the no-go decision with evidence
+- no new PDE or broad adapter scope
 
 ---
 
-## Executed Milestone Sequence
+## Locked Milestone Sequence
 
-Locked sequence:
-
-Milestone 0 -> KS feasibility scope reset
-Milestone 1 -> KS equation and numerical semantics freeze
-Milestone 2 -> KS feasibility generator / prototype
-Milestone 3 -> KS residual feasibility prototype
-Milestone 4 -> KS vertical-slice feasibility
-Milestone 5 -> promotion decision and imported-parity / non-goal guards
-Milestone 6 -> release gate / readiness and no-go closeout
+Milestone 0 -> scope freeze
+Milestone 1 -> fit / verification diagnostic semantics freeze
+Milestone 2 -> diagnostic / reporting helper implementation
+Milestone 3 -> internal KS diagnostic sweep harness
+Milestone 4 -> orbit / coverage diagnostic feasibility
+Milestone 5 -> API / public-surface audit
+Milestone 6 -> release gate and readiness
 
 ---
 
 ## Rules
 
-- DO NOT add public KS APIs in M0.
-- DO NOT update `API_STABILITY.md` for KS generator or residual APIs until those public APIs actually land or an audit finds a real omission.
-- DO NOT describe `v0.11` as unconditional stable KS support before M5.
-- DO NOT treat the internal M2 KS generator helper as public API.
-- DO NOT treat the internal M3 KS residual evaluator as public API.
-- DO NOT treat M4 fallback-backed verification as direct KS residual-fit recovery.
-- DO NOT add KS imported parity unless a stable public KS runtime surface is promoted.
-- DO NOT promote a stable KS generator, residual evaluator, or example in `v0.11` after the M5 no-go/defer decision.
-- DO NOT treat preliminary M1 feasibility targets as final release gates without observed M4 margin.
-- DO NOT promote weak KS in `v0.11`.
-- DO NOT add a new weak derivative API in `v0.11`.
-- DO NOT broaden `v0.11` into broad adapters, multidimensional grids, nonuniform grids, multivariable systems, or operator-facing work.
-- DO NOT add custom KS initial-condition APIs or configurable KS coefficient families unless a later milestone explicitly freezes them.
-- DO NOT add manuscript-specific logic.
-- DO preserve existing Heat/Burgers, `v0.8` weak-report, `v0.9` KdV, and `v0.10` reporting behavior.
+- DO NOT add a new PDE in `v0.12`.
+- DO NOT promote public KS generator, residual evaluator, example, imported parity, weak API, or root exports.
+- DO NOT implement weak KS.
+- DO NOT add broad dataset adapters, PDEBench, The Well, multidimensional grids, nonuniform grids, or multivariable systems.
+- DO NOT implement private-paper experiment policy.
+- DO NOT implement orbit augmentation utilities before M4 scope is frozen.
+- DO NOT implement reporting helpers before M1 freezes exact semantics and M2 accepts implementation.
+- DO NOT update `API_STABILITY.md` unless a public API lands or an audit finds a real mismatch.
+- DO preserve existing Heat/Burgers, `v0.8` weak-report, `v0.9` KdV, `v0.10` reporting, and `v0.11` order-4 derivative behavior.
 
 ---
 
 ## Status
 
-- `v0.10`: COMPLETE
+- `v0.11`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: COMPLETE
-- Milestone 2: COMPLETE
-- Milestone 3: COMPLETE
-- Milestone 4: COMPLETE
-- Milestone 5: COMPLETE
-- Milestone 6: COMPLETE
+- Milestone 1: PENDING
+- Milestone 2: PENDING
+- Milestone 3: PENDING
+- Milestone 4: PENDING
+- Milestone 5: PENDING
+- Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -2,9 +2,9 @@
 
 ## Current Release Status
 
-**V0.12 is active as diagnostics and supportability hardening**
+**V0.12 is complete as diagnostics and supportability hardening**
 
-This file is the active execution record for the `v0.12` release series.
+This file is the completed execution record for the `v0.12` release series.
 
 `v0.12` is not a new numerics release. It is a supportability release focused on:
 
@@ -29,8 +29,8 @@ Contracts and stable behavior belong in:
 - `docs/planning/ROADMAP.md`
 - `docs/planning/V0_12_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0 and M1 and remains unchanged because no new `v0.12` public API lands in either milestone.
-It should change in M2 if the frozen public reporting helper lands.
+`API_STABILITY.md` was audited in M0 and M1 with no changes because no public `v0.12` API landed in either milestone.
+It was updated in M2 when the frozen `pdelie.reporting.summarize_generator_fit_diagnostics(...)` helper landed.
 
 ---
 
@@ -454,20 +454,29 @@ Audit API stability and public exports after M2/M4 helper decisions.
 
 ## Milestone 6 - Release Gate and Readiness
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Close `v0.12` with compact release-gate coverage, docs alignment, package metadata, and direct Git-tag readiness.
 
-### Planned Scope
+### Completed Outcome
 
-- add compact `v0_12-release-gate`
-- keep full editable tests as historical gate coverage
-- keep package smoke small
-- update README, changelog, release readiness, roadmap, and package metadata
-- audit `API_STABILITY.md`
-- document final release path
+- added compact `tests/test_v0_12_release_gate.py`
+- updated CI so the current explicit release gate is `v0_12-release-gate`
+- kept full editable tests as historical gate coverage
+- kept package smoke small and added a tiny generator-fit diagnostic summary smoke
+- bumped package metadata to `0.12.0`
+- updated README, changelog, publishing docs, release readiness, roadmap, and package metadata for `v0.12.0`
+- audited `API_STABILITY.md` and left it unchanged because it already documents the only public `v0.12` API addition
+- documented the direct Git-tag release path
+- preserved all non-goals:
+  - no KS promotion
+  - no public orbit/coverage helper
+  - no public augmentation utility
+  - no weak KS
+  - no broad adapters
+  - no package-index publishing before `v1.0`
 
 ### Explicit Non-goals
 
@@ -512,4 +521,4 @@ Milestone 6 -> release gate and readiness
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
 - Milestone 5: COMPLETE
-- Milestone 6: PENDING
+- Milestone 6: COMPLETE

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -229,22 +229,91 @@ Implement the M1-frozen diagnostic/reporting helper.
 
 ## Milestone 3 - Internal KS Diagnostic Sweep Harness
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Keep KS internal and add bounded diagnostics for the `v0.11` no-go failure mode.
 
-### Planned Scope
+### Completed Outcome
 
-- bounded epsilon sweeps
-- selected span distance
-- SVD span distance
-- fallback status and reason
-- first verification error
-- singular values and condition number if M2 exposes them
-- cheap fixture variants only if they remain internal and non-gated
-- no promotion gate
+- added internal test-only helper:
+  - `tests._helpers.ks_diagnostic_sweep.run_ks_fit_diagnostic_sweep()`
+- kept the helper out of runtime `src/`
+- kept output as a JSON-compatible plain dict only
+- wrote no artifact files by default
+- froze sweep epsilons:
+  - `1e-5`
+  - `3e-5`
+  - `1e-4`
+  - `3e-4`
+  - `1e-3`
+- froze sweep variants:
+  - `default`
+  - `lower_amplitude` with `amplitude=0.04`
+  - `shorter_time` with `max_time=0.1`
+- reused existing internal KS feasibility helpers
+- reused `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+- recorded per-fit diagnostics:
+  - selected span distance
+  - SVD span distance
+  - fallback status and reason
+  - evidence label
+  - first verification error
+  - verification classification
+  - transform mode
+  - singular values
+  - condition number
+- recorded variant-level aggregates:
+  - min/median/max finite condition number
+  - min/median/max SVD span distance
+  - direct-SVD recovery boolean
+  - fallback reason stability
+  - categorical conclusion
+- confirmed no public KS generator, residual evaluator, example, imported parity, weak API, or root export landed
+
+### Observed Sweep Evidence
+
+All frozen variants concluded:
+
+`fallback_stable_across_epsilons`
+
+Default variant:
+
+- residual max: `2.276047466221332e-09`
+- residual RMS: `3.450580898077348e-10`
+- mass drift: `4.686823294199099e-16`
+- relative L2 drift: `0.0070894859776733715` diagnostic-only
+- condition number summary:
+  - min: `214493.66414183375`
+  - median: `214513.53360977306`
+  - max: `214713.8659786387`
+- SVD span-distance summary:
+  - min: `0.4173259267972907`
+  - median: `0.4178159498317849`
+  - max: `0.41786515613952585`
+- direct SVD in tolerance: `False`
+- fallback reason stable: `True`
+- fallback reason: `svd_translation_span_drift`
+
+Cheap variants:
+
+- `lower_amplitude` also remained fallback-backed:
+  - residual max: `6.365170833444976e-10`
+  - SVD span-distance median: `0.4231999049223962`
+  - condition-number median: `421919.8443762055`
+- `shorter_time` also remained fallback-backed:
+  - residual max: `5.564387484851066e-10`
+  - SVD span-distance median: `0.41787321170397507`
+  - condition-number median: `215280.21488729605`
+
+M3 strengthens the no-go diagnosis:
+
+- KS residuals are healthy
+- canonical translation verification remains healthy after fallback
+- direct residual-based SVD fitting remains out of tolerance across the bounded epsilon and cheap-variant sweep
+- changing only amplitude or horizon did not recover direct SVD behavior
+- the stable failure category remains `svd_translation_span_drift`
 
 ### Explicit Non-goals
 
@@ -253,6 +322,8 @@ Keep KS internal and add bounded diagnostics for the `v0.11` no-go failure mode.
 - no KS vertical-slice example
 - no KS imported parity
 - no API stability entry for KS generator/residual APIs
+- no API stability entry for the internal sweep helper
+- no release gate or package smoke dependency on internal KS sweeps
 
 ---
 
@@ -364,7 +435,7 @@ Milestone 6 -> release gate and readiness
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: PENDING
+- Milestone 3: COMPLETE
 - Milestone 4: PENDING
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -29,8 +29,8 @@ Contracts and stable behavior belong in:
 - `docs/planning/ROADMAP.md`
 - `docs/planning/V0_12_SCOPE.md`
 
-`API_STABILITY.md` was audited in M0 and remains unchanged because no new `v0.12` public API lands in M0.
-It should change only if M2 or M4 lands a public reporting or diagnostic API.
+`API_STABILITY.md` was audited in M0 and M1 and remains unchanged because no new `v0.12` public API lands in either milestone.
+It should change in M2 if the frozen public reporting helper lands.
 
 ---
 
@@ -99,36 +99,72 @@ M0 is complete only if:
 
 ## Milestone 1 - Fit / Verification Diagnostic Semantics Freeze
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Freeze diagnostic semantics before implementation.
 
-### Planned Scope
+### Completed Outcome
 
-- define fit diagnostic summary fields:
-  - singular values
-  - condition number
-  - basis delta norms
-  - column norms or scaling diagnostics
-  - selected span distance
-  - SVD span distance
-  - fallback status
-  - stable fallback category
-  - epsilon sweep structure
-- define verification diagnostic summary fields
-- decide whether later helpers are public under `pdelie.reporting` or remain internal
-- decide whether any public helper names are frozen for M2
-- keep M1 docs-only unless a docs consistency test needs a tiny update
+- froze one future M2 public reporting helper:
+  - `pdelie.reporting.summarize_generator_fit_diagnostics(generator: GeneratorFamily) -> dict[str, Any]`
+- froze public helper policy:
+  - submodule-only under `pdelie.reporting`
+  - no root `pdelie` export
+  - JSON-compatible plain dict output
+  - input is `GeneratorFamily`
+  - wrong input type raises the existing typed schema validation error in M2
+  - helper summarizes `GeneratorFamily.diagnostics`
+  - helper does not create a canonical object or mutate inputs
+- froze summary metadata:
+  - `summary_schema_version = "0.1"`
+  - `summary_type = "generator_fit_diagnostics"`
+- froze fit diagnostic fields:
+  - `parameterization`
+  - `fit_mode`
+  - `training_epsilon`
+  - `basis`
+  - `basis_delta_norms`
+  - `design_column_norms`
+  - `singular_values`
+  - `condition_number`
+  - `fit_residual`
+  - `min_delta_basis`
+  - `selected_coefficients`
+  - `svd_coefficients`
+  - `selected_span_distance`
+  - `svd_span_distance`
+  - `reference_fallback_used`
+  - `fallback_reason`
+  - `evidence_label`
+- froze condition-number policy:
+  - `condition_number = largest_singular_value / smallest_singular_value`
+  - if the denominator is zero or nonfinite, report `condition_number = None`
+- froze fallback reason policy:
+  - `fallback_reason` is a stable category string, not prose
+  - current stable fallback category remains `svd_translation_span_drift`
+- froze evidence labels:
+  - `direct_svd_in_tolerance`
+  - `direct_svd_out_of_tolerance`
+  - `reference_fallback`
+  - `mixed`
+  - `unavailable`
+- froze verification diagnostic semantics:
+  - keep `pdelie.reporting.summarize_verification_report(...)` as the verification summary surface
+  - M2 may harden its top-level summary fields for transform, span, and batch-error diagnostics if needed
+  - M1/M2 do not change verification classification rules or finite-transform behavior
+- froze M3 internal KS sweep semantics:
+  - sweeps record epsilon, fit mode, fallback status/reason, selected span, SVD span, first verification error, classification, singular values, and condition number
+  - sweeps are diagnostic artifacts, not promotion gates
+- left `docs/specs/API_STABILITY.md` unchanged because no public API landed in M1
 
-### Explicit Non-goals
+### Acceptance Criteria
 
-- no runtime implementation
-- no algorithmic fitting changes
-- no public KS runtime APIs
-- no orbit augmentation implementation
-- no API stability update unless a real contradiction is found
+- `V0_12_SCOPE.md` and `PLAN.md` agree on the future public helper name and diagnostic fields
+- `ROADMAP.md` still describes `v0.12` as diagnostics/supportability, not new numerical scope
+- `API_STABILITY.md` remains unchanged during M1
+- no runtime source, tests, README, changelog, release docs, package metadata, or CI files change in M1
 
 ---
 
@@ -138,20 +174,28 @@ Freeze diagnostic semantics before implementation.
 
 ### Goal
 
-Implement the M1-frozen diagnostic/reporting helpers.
+Implement the M1-frozen diagnostic/reporting helper.
 
 ### Planned Scope
 
-- implement only helpers whose names and schemas were frozen in M1
+- add `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+- update `pdelie.reporting.summarize_generator_family(...)` only if needed to share internal formatting or include the fit summary without changing canonical objects
 - keep outputs JSON-compatible and supportability-oriented
-- include singular-value and condition-number diagnostics if frozen in M1
+- add missing fit diagnostics to `fit_translation_generator(...)` if required for the frozen summary:
+  - singular values
+  - condition number
+  - design column norms
+  - selected coefficients
+  - selected span distance
+  - evidence label
 - preserve existing canonical object schemas
-- preserve existing fitting and verification behavior unless a deterministic blocker appears
-- update `API_STABILITY.md` only if public helpers land
+- preserve fitting selection behavior unless a deterministic blocker appears
+- update `API_STABILITY.md` when the public reporting helper lands
 
 ### Explicit Non-goals
 
 - no new canonical object unless M1 proves it is necessary
+- no fitting algorithm change
 - no KS generator/residual promotion
 - no weak KS
 - no private-paper reporting policy
@@ -294,7 +338,7 @@ Milestone 6 -> release gate and readiness
 
 - `v0.11`: COMPLETE
 - Milestone 0: COMPLETE
-- Milestone 1: PENDING
+- Milestone 1: COMPLETE
 - Milestone 2: PENDING
 - Milestone 3: PENDING
 - Milestone 4: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -417,26 +417,38 @@ M4 conclusion:
 
 ## Milestone 5 - API / Public-surface Audit
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Audit API stability and public exports after M2/M4 helper decisions.
 
-### Planned Scope
+### Completed Outcome
 
-- verify `API_STABILITY.md` matches any public reporting/diagnostic helpers that landed
-- verify root exports remain narrow
-- verify public KS generator/residual/example APIs remain absent
-- verify weak KS remains absent
-- verify broad adapters remain absent
-- update public-surface guards only for real scope changes
+- tightened API stability audit coverage
+- confirmed `API_STABILITY.md` documents the only public `v0.12` API addition:
+  - `pdelie.reporting.summarize_generator_fit_diagnostics`
+- confirmed `API_STABILITY.md` still documents stable carried surfaces:
+  - `v0.8` weak Heat/Burgers report APIs
+  - `v0.9` normalized periodic KdV APIs
+  - `v0.10` reporting helpers
+  - `v0.11` `max_spatial_order=4` derivative extension
+- confirmed `API_STABILITY.md` does not document public orbit/coverage helpers, augmentation utilities, stable KS generator/residual APIs, weak KS APIs, broad dataset adapters, multidimensional/nonuniform support, or operator-facing APIs
+- tightened specific-name public-surface guards without freezing complete module export lists
+- confirmed root `pdelie` remains limited to canonical objects, the base evaluator, and typed errors
+- confirmed M4 orbit/coverage diagnostics remain internal test-only helpers
+- confirmed no runtime behavior, canonical object schema, numerical scope, or CI behavior changed in M5
+- left `docs/specs/API_STABILITY.md` unchanged because no mismatch was found
 
 ### Explicit Non-goals
 
 - no new numerical scope
 - no CI restructuring beyond release-gate hygiene
 - no release-facing metadata changes before M6
+- no public orbit/coverage helper
+- no public augmentation utility
+- no KS promotion
+- no weak KS or broad adapter scope
 
 ---
 
@@ -499,5 +511,5 @@ Milestone 6 -> release gate and readiness
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
-- Milestone 5: PENDING
+- Milestone 5: COMPLETE
 - Milestone 6: PENDING

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -170,36 +170,60 @@ Freeze diagnostic semantics before implementation.
 
 ## Milestone 2 - Diagnostic / Reporting Helper Implementation
 
-**Status:** PENDING
+**Status:** COMPLETE
 
 ### Goal
 
 Implement the M1-frozen diagnostic/reporting helper.
 
-### Planned Scope
+### Completed Outcome
 
-- add `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
-- update `pdelie.reporting.summarize_generator_family(...)` only if needed to share internal formatting or include the fit summary without changing canonical objects
-- keep outputs JSON-compatible and supportability-oriented
-- add missing fit diagnostics to `fit_translation_generator(...)` if required for the frozen summary:
-  - singular values
-  - condition number
-  - design column norms
-  - selected coefficients
-  - selected span distance
-  - evidence label
-- preserve existing canonical object schemas
-- preserve fitting selection behavior unless a deterministic blocker appears
-- update `API_STABILITY.md` when the public reporting helper lands
+- added public submodule-only helper:
+  - `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+- exported the helper from `pdelie.reporting`
+- kept root `pdelie` unchanged
+- kept `summarize_generator_family(...)` top-level keys unchanged
+- kept `summarize_vertical_slice(...)` output shape unchanged
+- enriched `fit_translation_generator(...)` diagnostics without changing coefficient selection:
+  - `singular_values`
+  - `condition_number`
+  - `design_column_norms`
+  - `selected_coefficients`
+  - `selected_span_distance`
+  - `evidence_label`
+- preserved existing fit diagnostics:
+  - `fit_mode`
+  - `fallback_reason`
+  - `reference_fallback_used`
+  - `svd_coefficients`
+  - `svd_span_distance`
+  - `fit_residual`
+  - `basis`
+  - `basis_delta_norms`
+  - `min_delta_basis`
+  - `training_epsilon`
+- implemented the frozen condition-number policy:
+  - `largest_singular_value / smallest_singular_value`
+  - `None` if denominator is zero or nonfinite
+- implemented deterministic evidence labels:
+  - `direct_svd_in_tolerance`
+  - `direct_svd_out_of_tolerance`
+  - `reference_fallback`
+  - `unavailable` for insufficient manually supplied diagnostics
+- updated `docs/specs/API_STABILITY.md` for the new public reporting helper
+- kept canonical object schemas unchanged
+- kept verification classification and finite-transform behavior unchanged
+- kept KS generator/residual/example/imported-parity APIs absent
 
-### Explicit Non-goals
+### Acceptance Criteria
 
-- no new canonical object unless M1 proves it is necessary
-- no fitting algorithm change
-- no KS generator/residual promotion
-- no weak KS
-- no private-paper reporting policy
-- no root export expansion unless explicitly frozen
+- new helper is importable from `pdelie.reporting`
+- new helper is absent from root `pdelie`
+- helper output is JSON-compatible and includes the M1-frozen fields
+- Heat direct-SVD and Burgers reference-fallback fits expose the richer diagnostics
+- sparse manually supplied diagnostics summarize as `evidence_label == "unavailable"`
+- `API_STABILITY.md` documents the new helper
+- no new numerical scope, KS promotion, weak KS, private-paper policy, or root export lands
 
 ---
 
@@ -339,7 +363,7 @@ Milestone 6 -> release gate and readiness
 - `v0.11`: COMPLETE
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: PENDING
+- Milestone 2: COMPLETE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -384,10 +384,67 @@ The authoritative `v0.11` scope freeze belongs in:
 
 ---
 
-## No Committed Release Target
+## Next Committed Release Target
 
-No next release is committed after `v0.11`.
-`v0.12+` remains planned and conditional until a separate scope freeze is accepted.
+### `v0.12` - Diagnostics and supportability hardening
+**Status:** Committed
+
+`v0.12` is the committed release after the completed `v0.11` KS feasibility no-go closeout.
+
+Its purpose is:
+
+> harden diagnostics and reporting around generator fitting, verification, and orbit/coverage supportability without adding new numerical scope.
+
+Committed release definition:
+
+`existing stable Heat/Burgers/weak-report/KdV/reporting surfaces -> fit and verification diagnostics -> orbit/coverage reporting feasibility -> release supportability`
+
+Committed scope:
+
+- fit and verification diagnostic semantics
+- diagnostic/reporting helper implementation if exact public helper names are frozen
+- internal KS diagnostic sweeps, with KS remaining unpromoted
+- paper-agnostic orbit/coverage diagnostic feasibility
+- API and public-surface audit
+- compact current release-gate readiness
+
+Release interpretation:
+
+- this is a supportability release, not a new PDE release
+- KS remains internal feasibility/no-go evidence from `v0.11`
+- public `v0.12` APIs, if any, must be reporting or diagnostic helpers frozen before implementation
+- `API_STABILITY.md` changes only if such public helpers land
+
+Explicit non-goals:
+
+- no new PDE
+- no stable KS generator
+- no stable KS residual evaluator
+- no KS vertical-slice example
+- no KS imported parity
+- no weak KS API
+- no broad dataset adapters
+- no PDEBench or The Well support
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no private-paper experiment policy
+- no root export expansion unless explicitly accepted by a later milestone
+
+The authoritative `v0.12` scope freeze belongs in:
+
+- `V0_12_SCOPE.md`
+
+### Release Gate for `v0.12`
+
+`v0.12` is complete only if:
+
+- fit/verification diagnostics are frozen before implementation
+- any new public reporting/diagnostic helpers are documented in `API_STABILITY.md`
+- KS public generator, residual, example, weak API, imported parity, and root exports remain absent
+- orbit/coverage work remains paper-agnostic and diagnostic unless explicitly frozen otherwise
+- examples and reporting remain JSON-compatible runtime summaries
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
 
 ---
 
@@ -512,10 +569,10 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
-### `v0.12+` - Later PDE and dataset coverage
+### `v0.13+` - Later PDE and dataset coverage
 **Status:** Planned
 
-Later PDE and dataset coverage remains planned after the supportability release and the completed `v0.11` KS feasibility no-go closeout.
+Later PDE and dataset coverage remains planned after the `v0.12` diagnostics/supportability release and the completed `v0.11` KS feasibility no-go closeout.
 
 Candidate directions:
 
@@ -567,6 +624,7 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_9_SCOPE.md` once frozen
 - `V0_10_SCOPE.md` once frozen
 - `V0_11_SCOPE.md` once frozen
+- `V0_12_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -602,6 +660,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.9` = stable normalized periodic short-horizon KdV strong path
 - `v0.10` = supportability and `v1.0` readiness for the existing stable engine
 - `v0.11` = order-4 spectral derivatives and Kuramoto-Sivashinsky feasibility no-go/defer closeout
-- `v0.12+` = wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
+- `v0.12` = diagnostics and supportability hardening for fitting, verification, reporting, and orbit/coverage diagnostics
+- `v0.13+` = wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -317,7 +317,7 @@ The authoritative `v0.10` scope freeze belongs in:
 
 ---
 
-## Current Completed Release
+## Recent Completed Feasibility Release
 
 ### `v0.11` - Kuramoto-Sivashinsky strong-path feasibility
 **Status:** Completed / Feasibility no-go
@@ -384,36 +384,38 @@ The authoritative `v0.11` scope freeze belongs in:
 
 ---
 
-## Next Committed Release Target
+## Current Completed Release
 
 ### `v0.12` - Diagnostics and supportability hardening
-**Status:** Committed
+**Status:** Completed
 
-`v0.12` is the committed release after the completed `v0.11` KS feasibility no-go closeout.
+`v0.12` is the completed diagnostics/supportability release after the completed `v0.11` KS feasibility no-go closeout.
 
 Its purpose is:
 
 > harden diagnostics and reporting around generator fitting, verification, and orbit/coverage supportability without adding new numerical scope.
 
-Committed release definition:
+Completed release definition:
 
 `existing stable Heat/Burgers/weak-report/KdV/reporting surfaces -> fit and verification diagnostics -> orbit/coverage reporting feasibility -> release supportability`
 
-Committed scope:
+Completed scope:
 
 - fit and verification diagnostic semantics
-- diagnostic/reporting helper implementation if exact public helper names are frozen
+- `pdelie.reporting.summarize_generator_fit_diagnostics(...)` as the only public `v0.12` API addition
+- richer translation-fit diagnostics without changing fitting behavior
 - internal KS diagnostic sweeps, with KS remaining unpromoted
-- paper-agnostic orbit/coverage diagnostic feasibility
+- paper-agnostic orbit/coverage diagnostic feasibility kept internal
 - API and public-surface audit
-- compact current release-gate readiness
+- compact current `v0_12-release-gate` readiness
 
 Release interpretation:
 
 - this is a supportability release, not a new PDE release
 - KS remains internal feasibility/no-go evidence from `v0.11`
-- public `v0.12` APIs, if any, must be reporting or diagnostic helpers frozen before implementation
-- `API_STABILITY.md` changes only if such public helpers land
+- public `v0.12` API growth is limited to the reporting helper documented in `API_STABILITY.md`
+- internal KS diagnostic sweeps and orbit/coverage feasibility remain test-only evidence
+- `v0.12.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
 
 Explicit non-goals:
 
@@ -429,6 +431,7 @@ Explicit non-goals:
 - no operator-facing symmetry work
 - no private-paper experiment policy
 - no root export expansion unless explicitly accepted by a later milestone
+- no public orbit/coverage helper or augmentation utility
 
 The authoritative `v0.12` scope freeze belongs in:
 

--- a/docs/planning/V0_12_OPTIONS.md
+++ b/docs/planning/V0_12_OPTIONS.md
@@ -1,0 +1,397 @@
+# V0.12 Options and KS No-go Diagnosis
+
+## Summary
+
+`v0.12` should not add another PDE, promote stable KS runtime APIs, or broaden adapters.
+The best next release target is supportability for fitting, verification, reporting, and orbit
+coverage diagnostics.
+
+Recommended theme:
+
+> Diagnostics and supportability hardening for generator fitting, verification, and
+> translation-orbit coverage, with KS remaining internal feasibility evidence.
+
+This keeps the library on a v1.0-readiness path while directly addressing the `v0.11`
+KS no-go result.
+
+## KS No-go Diagnosis
+
+`v0.11` showed that the KS residual path is healthy, but the residual-based generator
+fit is not direct-fit stable on the frozen fixture.
+
+Observed status:
+
+- KS equation under test: `u_t + u*u_x + u_xx + u_xxxx = 0`
+- derivative backend: `compute_spectral_fd_derivatives(..., max_spatial_order=4)`
+- residual feasibility: healthy, with large margin against the M1 targets
+- vertical-slice verification: passes only after reference fallback selects the canonical
+  translation generator
+- stable KS public promotion: deferred
+
+The failure is localized to residual-based generator fitting, not to the KS residual
+definition, derivative sign convention, or finite-transform verification stack.
+
+### Current Fit Diagnostics
+
+The current translation fitter records these high-level diagnostics:
+
+- `basis`
+- `basis_delta_norms`
+- `fallback_reason`
+- `fit_mode`
+- `fit_residual`
+- `min_delta_basis`
+- `reference_fallback_used`
+- `svd_coefficients`
+- `svd_span_distance`
+- `training_epsilon`
+
+These are enough to identify the no-go outcome:
+
+- `reference_fallback_used == True`
+- `fallback_reason == "svd_translation_span_drift"`
+- direct SVD span distance is out of tolerance, around `0.418`
+- selected span distance passes only because the fallback generator is used
+
+They are not enough to fully diagnose conditioning:
+
+- full singular values are not recorded
+- condition number is not recorded
+- column scaling diagnostics are limited to `basis_delta_norms`
+- epsilon sensitivity is available only through ad hoc sweeps, not a standard report
+
+### Bounded Diagnostic Sweep
+
+A bounded local sweep was run for planning only. No release gate or tracked artifact was
+created from it.
+
+Sweep dimensions:
+
+- fit epsilon values: `1e-5`, `3e-5`, `1e-4`, `3e-4`, `1e-3`
+- default fixture: `amplitude=0.08`, `max_time=0.2`
+- cheap variants:
+  - lower amplitude: `amplitude=0.04`, `max_time=0.2`
+  - shorter time: `amplitude=0.08`, `max_time=0.1`
+
+Results:
+
+| Variant | Residual Max | Residual RMS | Mass Drift | SVD Span Range | Fit Outcome |
+| --- | ---: | ---: | ---: | ---: | --- |
+| default | `2.28e-9` | `3.45e-10` | `4.69e-16` | `0.4173` to `0.4179` | reference fallback for all epsilons |
+| lower amplitude | `6.36e-10` | `1.06e-10` | `2.40e-16` | `0.4227` to `0.4233` | reference fallback for all epsilons |
+| shorter time | `5.56e-10` | `8.54e-11` | `4.35e-16` | `0.4174` to `0.4179` | reference fallback for all epsilons |
+
+The epsilon sweep did not rescue direct SVD fitting. Lower amplitude and shorter horizon
+did not rescue it either.
+
+The default fixture's basis delta norms are highly imbalanced:
+
+- `x`: about `309`
+- `t`: about `1.12`
+- `u`: about `4.7e-3`
+- `1`: about `2.5e-3`
+
+That imbalance points to conditioning and basis/objective design as the highest-probability
+failure mode. The direct SVD vector mixes the constant and `u` directions instead of
+recovering the canonical translation direction, while fallback verification succeeds.
+
+Likely causes, in priority order:
+
+1. Fit conditioning and basis scaling.
+2. Residual-delta objective design for stiff fourth-order KS dynamics.
+3. Frozen fixture geometry, though cheap amplitude/time variants did not fix the issue.
+4. Epsilon sensitivity, currently unlikely based on the sweep.
+5. Implementation ambiguity in how direct residual-based fitting should identify a
+   translation generator for KS.
+
+Not supported by current evidence:
+
+- a broken KS residual equation
+- a derivative sign error for `u_xxxx`
+- a verification-stack failure
+- a missing fallback reason
+
+The fallback reason is stable and explicit: `svd_translation_span_drift`.
+
+## V0.12 Theme Options
+
+### Ranking
+
+| Rank | Theme | ROI | Risk | V1.0 Relevance | Recommendation |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | A. Stable diagnostics/reporting hardening | High | Low to medium | High | Primary v0.12 theme |
+| 2 | D. CI/release/API supportability | Medium to high | Low | High | Include as release hardening |
+| 3 | C. KS fit stabilization diagnostics | Medium | Medium | Medium | Keep internal and diagnostic-only |
+| 4 | B. Generic orbit/coverage augmentation utilities | Medium | Medium to high | Medium to high | Scope carefully; defer mutation-heavy APIs |
+
+### A. Stable Diagnostics and Reporting Hardening
+
+This has the best ROI because it addresses the KS no-go without expanding numerical scope.
+It also improves supportability for Heat, Burgers, KdV, and downstream sparse-discovery
+workflows.
+
+Candidate work:
+
+- summarize residual diagnostics more consistently
+- summarize generator fit diagnostics, including singular values and condition numbers
+- summarize verification reports and branch-level outcomes
+- make examples and release gates less ad hoc
+- keep summaries JSON-compatible and supportability-oriented
+- avoid new canonical objects unless a narrow need is proven
+
+Recommended for `v0.12`.
+
+### B. Generic Orbit and Coverage Augmentation Utilities
+
+This could be valuable, but it has a higher boundary risk. It can easily become downstream
+experiment orchestration if the scope is not frozen tightly.
+
+Candidate work:
+
+- read-only finite-transform or orbit views over `FieldBatch`
+- periodic `x` window coverage diagnostics
+- augmentation provenance summaries
+- finite-transform consistency checks
+- train-only augmentation utilities only if kept generic and paper-agnostic
+
+Recommended as a secondary track only after diagnostics semantics are frozen. Mutating
+augmentation utilities should remain downstream unless a small reusable API is clearly
+identified.
+
+### C. KS Fit Stabilization Diagnostics
+
+KS should stay internal in `v0.12`. The useful work is diagnostic, not promotion.
+
+Candidate work:
+
+- standard epsilon sweep summaries for generator fitting
+- full singular-value and condition-number diagnostics
+- basis column scaling diagnostics
+- KS fixture variants as non-gated evidence
+- explicit classification of direct SVD, reference fallback, and mixed evidence
+
+Recommended as an internal diagnostic track feeding future promotion decisions.
+
+### D. CI, Release, and API Supportability
+
+`v0.10` already consolidated release-gate CI, but this remains important for v1.0 readiness.
+
+Candidate work:
+
+- keep one current release gate
+- keep package smoke compact and representative
+- continue API stability audit tests
+- maintain root/submodule export guards
+- keep package-index publishing deferred until the project is ready for v1.0 policy
+
+Recommended as M6 release hardening, not as the primary feature theme.
+
+## Paper-agnostic Utilities for Orbit Augmentation Work
+
+The private downstream result suggests that coverage-mediated translation-orbit augmentation
+can improve sparse PDE recovery under localized observations. The reusable pieces that may
+belong in `pdelie` are the generic mechanics, not the experiment policy.
+
+Good candidates for `pdelie`:
+
+- `FieldBatch` finite-transform views that expose transformed data without changing the
+  original canonical object.
+- Translation-orbit coverage diagnostics for periodic `x` windows.
+- Generic augmentation provenance helpers that record operation type, parameters, and
+  source batch identity.
+- Standard runtime summaries for branch-level residual, fit, verification, and coverage
+  results.
+- Finite-transform consistency checks that verify shape, coordinates, metadata, and
+  residual behavior after a transform.
+
+Likely downstream-only:
+
+- branch naming tied to a private experiment
+- manuscript-specific success labels or thresholds
+- sparse-regression policy decisions
+- train/test split policy for a particular benchmark
+- automatic augmentation recipes tuned to one dataset
+
+`v0.12` should consider only the reusable diagnostics and read-only orbit views first.
+Train-only augmentation APIs should wait until the boundary between reusable library logic
+and downstream experiment policy is clearer.
+
+## Recommended V0.12 Milestone Sequence
+
+### M0: Scope Freeze for Diagnostics and Orbit Supportability
+
+Public API changes: none.
+
+Tests:
+
+- docs consistency checks
+- no runtime tests required
+
+Docs:
+
+- add `V0_12_SCOPE.md`
+- reset `PLAN.md`
+- update `ROADMAP.md` to make `v0.12` committed only after scope is frozen
+
+Out of scope:
+
+- stable KS generator/residual promotion
+- new PDEs
+- weak KS
+- broad adapters
+- public augmentation policy APIs
+
+### M1: Fit and Verification Diagnostic Semantics Freeze
+
+Public API changes: none.
+
+Tests:
+
+- docs-only validation
+
+Docs:
+
+- freeze summary fields for fit diagnostics:
+  - singular values
+  - condition number
+  - basis delta norms
+  - column norms or scaling diagnostics
+  - selected span distance
+  - SVD span distance
+  - fallback status and stable fallback category
+  - epsilon sweep structure
+- decide whether later APIs live under `pdelie.reporting` or remain internal summaries
+
+Out of scope:
+
+- algorithm changes to fitting
+- KS promotion
+- manuscript-specific tables or labels
+
+### M2: Fit Diagnostic Implementation
+
+Public API changes: possible, only if M1 freezes a narrow `pdelie.reporting` helper.
+
+Candidate API:
+
+- `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+
+Tests:
+
+- Heat, Burgers, KdV fit summaries remain JSON-compatible
+- KS internal fit diagnostics expose singular values and condition number
+- fallback reasons remain stable categories
+- no input mutation
+
+Docs:
+
+- update `API_STABILITY.md` only if a public reporting helper lands
+- update `PLAN.md`
+
+Out of scope:
+
+- changing fitter selection behavior
+- adding KS runtime APIs
+
+### M3: KS Diagnostic Sweep Harness
+
+Public API changes: none.
+
+Tests:
+
+- internal KS epsilon sweep remains bounded and deterministic
+- sweep records selected span distance, SVD span distance, fallback status, first
+  verification error, singular values, and condition number when available
+- sweep is not a release gate for promotion
+
+Docs:
+
+- record whether conditioning evidence explains the no-go
+- keep KS public promotion deferred unless direct evidence changes
+
+Out of scope:
+
+- stable KS generator/residual APIs
+- making KS fixture variants public
+
+### M4: Orbit Coverage Diagnostic Feasibility
+
+Public API changes: possible only if M1/M2 show a stable, paper-agnostic shape.
+
+Candidate API direction:
+
+- reporting-only coverage summaries before mutation or augmentation APIs
+
+Tests:
+
+- periodic `x` window coverage metrics on canonical `FieldBatch`
+- finite-transform consistency diagnostics on Heat/KdV fixtures
+- provenance summaries are JSON-compatible
+
+Docs:
+
+- define what is reusable library behavior versus downstream experiment policy
+
+Out of scope:
+
+- PDEBench/The Well
+- multidimensional grids
+- private sparse-discovery branch logic
+- automatic train augmentation recipes
+
+### M5: Public-surface and API Stability Audit
+
+Public API changes: none unless M2/M4 landed public reporting helpers.
+
+Tests:
+
+- API stability audit
+- public export guards
+- no KS public generator/residual/example exports
+- no weak KS or weak derivative expansion
+
+Docs:
+
+- update `API_STABILITY.md` for any reporting APIs that landed
+- record no new PDE scope
+
+Out of scope:
+
+- CI restructuring beyond current release-gate hygiene
+
+### M6: Release Gate and Readiness
+
+Public API changes: none.
+
+Tests:
+
+- compact `v0_12-release-gate`
+- full suite
+- build
+- clean wheel smoke
+- Heat and KdV example smokes
+
+Docs:
+
+- README, changelog, release readiness, roadmap, package metadata
+- direct Git-tag release path
+
+Out of scope:
+
+- package-index publishing before v1.0 policy is finalized
+- stable KS promotion unless a separate M5 decision changes the scope
+
+## Docs Consistency Audit
+
+Audit result:
+
+- `ROADMAP.md` does not imply stable KS promotion after the `v0.11` no-go. It keeps
+  future work conditional.
+- `API_STABILITY.md` documents the `max_spatial_order=4` derivative extension and does
+  not document stable KS generator or residual APIs.
+- `README.md`, `CHANGELOG.md`, and `docs/releases/V0_11_RELEASE_READINESS.md` describe
+  `v0.11` as KS feasibility/no-go evidence, not stable KS runtime support.
+- public KS generator, residual, example, and root exports remain absent.
+- `v0.12+` planning remains conditional before M0.
+
+No consistency fixes were required during this audit.

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -319,6 +319,18 @@ Release-gate expectations stay representative:
 - no KS promotion claims
 - no PyPI or TestPyPI publishing before the v1.0 publishing policy is accepted
 
+Milestone 6: COMPLETE.
+
+Completed closeout:
+
+- package metadata is aligned with `0.12.0`
+- release-facing docs are aligned with `v0.12.0`
+- CI exposes one compact current `v0_12-release-gate`
+- full editable tests remain the historical gate coverage
+- package smoke remains compact and includes a tiny generator-fit diagnostic summary check
+- `API_STABILITY.md` remains aligned and required no M6 change
+- M3 internal KS diagnostics and M4 orbit/coverage diagnostics remain internal
+
 ---
 
 ## Relationship to Downstream Orbit-augmentation Work
@@ -375,4 +387,4 @@ Historical release-gate tests should remain runnable locally and covered by the 
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
 - Milestone 5: COMPLETE
-- Milestone 6: PENDING
+- Milestone 6: COMPLETE

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -229,10 +229,14 @@ Completed decisions:
 
 Implement the M1-frozen diagnostics.
 
-Implement `pdelie.reporting.summarize_generator_fit_diagnostics(...)`.
-If the helper lands as public runtime API, update `API_STABILITY.md` in M2.
+Completed implementation:
 
-No algorithmic fitting changes are part of M2 unless a deterministic blocker appears.
+- added `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+- enriched translation-fit diagnostics with singular values, condition number, design column norms, selected coefficients, selected span distance, and evidence label
+- updated `API_STABILITY.md` for the new public reporting helper
+- kept fitting coefficient selection unchanged
+- kept existing reporting summary shapes unchanged except for the new helper
+- kept KS public runtime APIs absent
 
 ### Milestone 3 - Internal KS Diagnostic Sweep Harness
 
@@ -337,7 +341,7 @@ Historical release-gate tests should remain runnable locally and covered by the 
 - `v0.11`: COMPLETE as KS feasibility/no-go closeout
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
-- Milestone 2: PENDING
+- Milestone 2: COMPLETE
 - Milestone 3: PENDING
 - Milestone 4: PENDING
 - Milestone 5: PENDING

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -242,15 +242,32 @@ Completed implementation:
 
 Keep KS internal and diagnostic-only.
 
-Expected scope:
+Completed scope:
 
 - bounded epsilon sweeps
 - selected span distance
 - SVD span distance
 - fallback status and reason
 - first verification error
-- singular values and condition number if M2 exposes them
+- singular values and condition number from the M2 fit diagnostics
 - no promotion gate
+
+Completed sweep matrix:
+
+- epsilons: `1e-5`, `3e-5`, `1e-4`, `3e-4`, `1e-3`
+- variants:
+  - `default`
+  - `lower_amplitude` with `amplitude=0.04`
+  - `shorter_time` with `max_time=0.1`
+
+Completed diagnosis:
+
+- all frozen variants concluded `fallback_stable_across_epsilons`
+- no epsilon or cheap fixture variant recovered direct SVD in-tolerance behavior
+- fallback reason was stable as `svd_translation_span_drift`
+- residual and verification evidence remained healthy
+- relative L2 drift remained diagnostic-only
+- no public KS generator, residual evaluator, example, imported parity, weak API, or root export landed
 
 ### Milestone 4 - Orbit / Coverage Diagnostic Feasibility
 
@@ -342,7 +359,7 @@ Historical release-gate tests should remain runnable locally and covered by the 
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
-- Milestone 3: PENDING
+- Milestone 3: COMPLETE
 - Milestone 4: PENDING
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -129,6 +129,79 @@ It should change only if M2 or M4 actually lands a public reporting/diagnostic A
 
 ---
 
+## M1 Fit and Verification Diagnostic Semantics Freeze
+
+M1 freezes one future M2 public reporting helper:
+
+```python
+pdelie.reporting.summarize_generator_fit_diagnostics(
+    generator: GeneratorFamily,
+) -> dict[str, Any]
+```
+
+Public helper policy:
+
+- helper lives under `pdelie.reporting` only
+- no root `pdelie` export
+- input is a `GeneratorFamily`
+- output is a JSON-compatible plain Python dict
+- summary type is `generator_fit_diagnostics`
+- summary schema version is `"0.1"`
+- wrong input type raises the existing typed schema validation error in M2
+- helper summarizes existing and future `GeneratorFamily.diagnostics`
+- helper does not create a canonical object
+- helper does not mutate inputs
+
+Frozen generator-fit diagnostic fields for M2:
+
+- `parameterization`
+- `fit_mode`
+- `training_epsilon`
+- `basis`
+- `basis_delta_norms`
+- `design_column_norms`
+- `singular_values`
+- `condition_number`
+- `fit_residual`
+- `min_delta_basis`
+- `selected_coefficients`
+- `svd_coefficients`
+- `selected_span_distance`
+- `svd_span_distance`
+- `reference_fallback_used`
+- `fallback_reason`
+- `evidence_label`
+
+Diagnostic conventions:
+
+- `condition_number = largest_singular_value / smallest_singular_value`
+- if the denominator is zero or nonfinite, report `condition_number = None`
+- `fallback_reason` is a stable category string, not prose
+- current stable fallback category remains `svd_translation_span_drift`
+- `evidence_label` categories are:
+  - `direct_svd_in_tolerance`
+  - `direct_svd_out_of_tolerance`
+  - `reference_fallback`
+  - `mixed`
+  - `unavailable`
+
+Verification diagnostic semantics:
+
+- `pdelie.reporting.summarize_verification_report(...)` remains the verification summary surface
+- M2 may harden top-level verification summary fields for transform, span, and batch-error diagnostics if needed
+- M1 and M2 do not change verification classification rules
+- M1 and M2 do not change finite-transform behavior
+
+M3 internal KS sweep semantics:
+
+- internal KS sweeps record epsilon, fit mode, fallback status/reason, selected span, SVD span, first verification error, classification, singular values, and condition number
+- sweeps are diagnostic artifacts, not promotion gates
+
+`API_STABILITY.md` remains unchanged in M1.
+It should be updated in M2 only if `summarize_generator_fit_diagnostics(...)` lands as public runtime API.
+
+---
+
 ## Milestones
 
 ### Milestone 0 - Scope Freeze
@@ -142,22 +215,22 @@ It does not change runtime code, tests, package metadata, README, changelog, rel
 
 Freeze diagnostic semantics before implementation.
 
-Expected decisions:
+Completed decisions:
 
-- fit diagnostic summary fields
-- verification diagnostic summary fields
-- singular-value and condition-number reporting policy
-- basis delta norm and column scaling fields
-- epsilon sweep summary shape
-- fallback reason category policy
-- whether later helpers are public under `pdelie.reporting` or internal only
+- future M2 helper is `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
+- helper is submodule-only and returns a JSON-compatible runtime dict
+- summary type is `generator_fit_diagnostics`
+- summary schema version is `"0.1"`
+- fit diagnostic fields, condition-number policy, fallback category policy, and evidence labels are frozen above
+- verification keeps `summarize_verification_report(...)` as its public summary surface
+- M3 KS sweep semantics are diagnostic-only and not promotion gates
 
 ### Milestone 2 - Diagnostic / Reporting Helper Implementation
 
 Implement the M1-frozen diagnostics.
 
-Public API is allowed only if M1 freezes exact helper names and schemas.
-If public helpers land, update `API_STABILITY.md` in M2.
+Implement `pdelie.reporting.summarize_generator_fit_diagnostics(...)`.
+If the helper lands as public runtime API, update `API_STABILITY.md` in M2.
 
 No algorithmic fitting changes are part of M2 unless a deterministic blocker appears.
 
@@ -263,7 +336,7 @@ Historical release-gate tests should remain runnable locally and covered by the 
 
 - `v0.11`: COMPLETE as KS feasibility/no-go closeout
 - Milestone 0: COMPLETE
-- Milestone 1: PENDING
+- Milestone 1: COMPLETE
 - Milestone 2: PENDING
 - Milestone 3: PENDING
 - Milestone 4: PENDING

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -296,13 +296,16 @@ M4 did not implement private-paper policy, train-augmentation recipes, public or
 
 Audit API stability and public exports after any M2/M4 helper decisions.
 
-Required checks:
+Completed checks:
 
 - `API_STABILITY.md` matches actual public helper surface
 - root exports remain narrow
 - KS generator/residual/example APIs remain absent
 - weak KS remains absent
 - broad adapters remain absent
+- M4 orbit/coverage diagnostics remain internal test-only helpers
+- no public augmentation utilities landed
+- `API_STABILITY.md` required no update in M5
 
 ### Milestone 6 - Release Gate and Readiness
 
@@ -371,5 +374,5 @@ Historical release-gate tests should remain runnable locally and covered by the 
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
 - Milestone 4: COMPLETE
-- Milestone 5: PENDING
+- Milestone 5: COMPLETE
 - Milestone 6: PENDING

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -273,14 +273,24 @@ Completed diagnosis:
 
 Evaluate paper-agnostic orbit and coverage diagnostics.
 
-Allowed direction:
+Completed direction:
 
-- read-only finite-transform or orbit views, if scoped tightly
-- periodic `x` coverage diagnostics
-- augmentation provenance summaries
-- finite-transform consistency checks
+- internal test-only periodic `x` coverage diagnostics
+- internal test-only finite-transform consistency diagnostics
+- deterministic JSON-compatible summary output
+- no artifact files by default
+- no public API promotion
 
-M4 must not implement private-paper policy or train-augmentation recipes.
+Completed evidence:
+
+- half-coverage quarter-shift case covered `32 / 64` points with coverage fraction `0.5`
+- full-coverage quarter-shift case covered `64 / 64` points with coverage fraction `1.0`
+- stable Heat and KdV fixtures preserved dims, coords, var names, metadata, and mask under uniform translations
+- inverse-transform and period-wrap errors remained at floating-point noise levels
+- residual RMS was stable under shifts for both fixtures
+- transform provenance recorded `invariant_apply` and `uniform_translation`
+
+M4 did not implement private-paper policy, train-augmentation recipes, public orbit/coverage helpers, or API stability entries.
 
 ### Milestone 5 - API / Public-surface Audit
 
@@ -360,6 +370,6 @@ Historical release-gate tests should remain runnable locally and covered by the 
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE
 - Milestone 3: COMPLETE
-- Milestone 4: PENDING
+- Milestone 4: COMPLETE
 - Milestone 5: PENDING
 - Milestone 6: PENDING

--- a/docs/planning/V0_12_SCOPE.md
+++ b/docs/planning/V0_12_SCOPE.md
@@ -1,0 +1,271 @@
+# V0.12 Scope Freeze
+
+## Summary
+
+`v0.12` is the diagnostics and supportability hardening release for `pdelie`.
+
+Its purpose is:
+
+> harden diagnostics and reporting around generator fitting, verification, and orbit/coverage supportability without adding new numerical scope.
+
+Committed release theme:
+
+`existing stable Heat/Burgers/weak-report/KdV/reporting surfaces -> fit and verification diagnostics -> orbit/coverage reporting feasibility -> release supportability`
+
+`v0.12` does not add a new PDE and does not promote Kuramoto-Sivashinsky runtime APIs.
+The `v0.11` KS evidence remains internal feasibility/no-go evidence.
+
+---
+
+## Motivation From V0.11 KS No-go
+
+`v0.11` added the public order-4 derivative backend extension:
+
+```python
+compute_spectral_fd_derivatives(field, *, max_spatial_order=4)
+```
+
+It also evaluated normalized scalar 1D periodic Kuramoto-Sivashinsky internally.
+The result was useful but not strong enough for public runtime promotion:
+
+- KS residual feasibility passed with large margin
+- mass drift passed with large margin
+- held-out canonical translation verification passed
+- vertical-slice evidence passed through `reference_fallback`
+- direct residual-based SVD fitting was out of tolerance
+- direct SVD span distance was around `0.418`
+- stable KS generator/residual/example promotion was deferred
+
+The main supportability gap is diagnostic, not PDE coverage:
+
+- fit diagnostics do not expose full singular values
+- fit diagnostics do not expose condition number
+- epsilon sensitivity is not standardized
+- fallback-backed versus direct-fit evidence needs clearer reporting
+- orbit/coverage diagnostics are not yet reusable library utilities
+
+`v0.12` should address those supportability gaps before any further numerical expansion.
+
+---
+
+## Stable Scope
+
+The stable scope carried into `v0.12` remains:
+
+- canonical `FieldBatch`, `DerivativeBatch`, `ResidualBatch`, `GeneratorFamily`, `InvariantMapSpec`, and `VerificationReport`
+- uniform rectilinear scalar 1D stable paths
+- Heat and Burgers strong-form paths
+- frozen `v0.8` weak Heat/Burgers residual report APIs
+- frozen `v0.9` normalized periodic short-horizon KdV strong path
+- frozen `v0.10` supportability reporting helpers under `pdelie.reporting`
+- frozen `v0.11` order-4 spectral derivative extension
+- existing polynomial translation fitting and finite-transform verification
+
+The new `v0.12` scope is supportability around those existing surfaces:
+
+- generator-fit diagnostic semantics
+- verification diagnostic semantics
+- reporting helper hardening, if public helper names are frozen in M1/M2
+- internal KS diagnostic sweep reporting, without promotion
+- orbit/coverage diagnostic feasibility, without augmentation APIs in M0
+- API/public-surface audit and compact release-gate coverage
+
+---
+
+## Non-goals
+
+`v0.12` explicitly does not include:
+
+- a new PDE
+- stable KS generator promotion
+- stable KS residual evaluator promotion
+- stable KS vertical-slice example promotion
+- KS imported parity
+- weak KS
+- weak derivative expansion
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional grids
+- nonuniform grids
+- multivariable systems
+- custom KS initial-condition APIs
+- configurable KS coefficient families
+- neural generators
+- operator-facing symmetry work
+- manuscript-specific experiment policy
+- private-paper branch logic
+- private-paper thresholds, tables, figures, or labels
+- public orbit augmentation utilities in M0
+- public reporting helpers in M0
+- root `pdelie` export expansion unless a later milestone explicitly accepts it
+
+---
+
+## Candidate Public API Policy
+
+M0 lands no public API.
+
+If `v0.12` lands public APIs later, they must be reporting or diagnostic helpers only.
+Candidate public APIs must be frozen in M1 before implementation in M2 or M4.
+
+Likely allowed API direction:
+
+- submodule-only helpers under `pdelie.reporting`
+- JSON-compatible runtime summaries
+- diagnostic reports over existing canonical objects and runtime reports
+- no new canonical object unless a later milestone proves it is necessary
+
+Likely rejected API direction:
+
+- root `pdelie` exports
+- stable KS generator/residual APIs
+- broad adapter APIs
+- manuscript-table or figure APIs
+- mutation-heavy augmentation APIs
+- downstream sparse-discovery experiment policy
+
+`docs/specs/API_STABILITY.md` remains unchanged in M0.
+It should change only if M2 or M4 actually lands a public reporting/diagnostic API.
+
+---
+
+## Milestones
+
+### Milestone 0 - Scope Freeze
+
+Freeze `v0.12` as diagnostics and supportability hardening, add this scope document, reset `PLAN.md`, and update `ROADMAP.md`.
+
+M0 is docs-only.
+It does not change runtime code, tests, package metadata, README, changelog, release readiness, or API stability docs.
+
+### Milestone 1 - Fit / Verification Diagnostic Semantics Freeze
+
+Freeze diagnostic semantics before implementation.
+
+Expected decisions:
+
+- fit diagnostic summary fields
+- verification diagnostic summary fields
+- singular-value and condition-number reporting policy
+- basis delta norm and column scaling fields
+- epsilon sweep summary shape
+- fallback reason category policy
+- whether later helpers are public under `pdelie.reporting` or internal only
+
+### Milestone 2 - Diagnostic / Reporting Helper Implementation
+
+Implement the M1-frozen diagnostics.
+
+Public API is allowed only if M1 freezes exact helper names and schemas.
+If public helpers land, update `API_STABILITY.md` in M2.
+
+No algorithmic fitting changes are part of M2 unless a deterministic blocker appears.
+
+### Milestone 3 - Internal KS Diagnostic Sweep Harness
+
+Keep KS internal and diagnostic-only.
+
+Expected scope:
+
+- bounded epsilon sweeps
+- selected span distance
+- SVD span distance
+- fallback status and reason
+- first verification error
+- singular values and condition number if M2 exposes them
+- no promotion gate
+
+### Milestone 4 - Orbit / Coverage Diagnostic Feasibility
+
+Evaluate paper-agnostic orbit and coverage diagnostics.
+
+Allowed direction:
+
+- read-only finite-transform or orbit views, if scoped tightly
+- periodic `x` coverage diagnostics
+- augmentation provenance summaries
+- finite-transform consistency checks
+
+M4 must not implement private-paper policy or train-augmentation recipes.
+
+### Milestone 5 - API / Public-surface Audit
+
+Audit API stability and public exports after any M2/M4 helper decisions.
+
+Required checks:
+
+- `API_STABILITY.md` matches actual public helper surface
+- root exports remain narrow
+- KS generator/residual/example APIs remain absent
+- weak KS remains absent
+- broad adapters remain absent
+
+### Milestone 6 - Release Gate and Readiness
+
+Add compact `v0_12-release-gate`, align release-facing docs and package metadata, and close the direct Git-tag release path.
+
+Release-gate expectations stay representative:
+
+- current release gate is compact
+- full editable tests cover historical gates
+- package smoke remains small
+- no KS promotion claims
+- no PyPI or TestPyPI publishing before the v1.0 publishing policy is accepted
+
+---
+
+## Relationship to Downstream Orbit-augmentation Work
+
+Downstream work has shown that coverage-mediated translation-orbit augmentation can help sparse PDE recovery under localized observations.
+
+The reusable `pdelie` candidates are the generic mechanics:
+
+- finite-transform or orbit views over canonical `FieldBatch`
+- periodic `x` window coverage diagnostics
+- generic augmentation provenance summaries
+- runtime summaries for residual, fit, verification, and coverage results
+- finite-transform consistency checks
+
+The downstream-only pieces remain outside `pdelie`:
+
+- manuscript-specific branch naming
+- sparse-regression policy decisions
+- dataset-specific train/test policy
+- paper-specific thresholds and labels
+- automatic augmentation recipes tuned to one experiment
+
+`v0.12` may evaluate reusable diagnostics for this direction.
+It must not implement private-paper experiment policy.
+
+---
+
+## Release-gate Expectations
+
+The eventual `v0_12-release-gate` should be compact and representative.
+It should not duplicate full diagnostic, reporting, KS, or historical release-gate suites.
+
+Expected release-gate shape:
+
+- public reporting/diagnostic APIs exist only if frozen and implemented in M2/M4
+- root export boundaries remain intact
+- stable Heat/Burgers/weak-report/KdV surfaces remain importable
+- order-4 derivative API remains documented and available
+- public KS generator/residual/example APIs remain absent
+- no weak KS API appears
+- examples remain JSON-compatible runtime summaries
+- package smoke remains small and avoids KS internal feasibility sweeps
+
+Historical release-gate tests should remain runnable locally and covered by the full editable test suite.
+
+---
+
+## Status
+
+- `v0.11`: COMPLETE as KS feasibility/no-go closeout
+- Milestone 0: COMPLETE
+- Milestone 1: PENDING
+- Milestone 2: PENDING
+- Milestone 3: PENDING
+- Milestone 4: PENDING
+- Milestone 5: PENDING
+- Milestone 6: PENDING

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.11.0`, release completion means:
+For the current `v0.x` series, including `v0.12.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.11.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.11`.
+`v0.12.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.12`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_12_RELEASE_READINESS.md
+++ b/docs/releases/V0_12_RELEASE_READINESS.md
@@ -1,0 +1,200 @@
+# V0.12 Release Readiness
+
+## Release Target
+
+- package version: `0.12.0`
+- git tag: `v0.12.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.12.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.12`.
+
+## Done
+
+- M0 is complete:
+  - `v0.12` was frozen as diagnostics and supportability hardening
+  - `v0.11` was recorded as a completed KS feasibility/no-go release
+  - stable KS promotion remained closed as deferred
+- M1 is complete:
+  - generator-fit diagnostic semantics were frozen
+  - evidence labels and fallback reason categories were fixed
+- M2 is complete:
+  - `pdelie.reporting.summarize_generator_fit_diagnostics(...)` landed as the only public `v0.12` API addition
+  - `fit_translation_generator(...)` gained richer diagnostics without changing coefficient selection
+  - `API_STABILITY.md` documents the new reporting helper
+- M3 is complete:
+  - internal KS fit diagnostic sweeps confirmed fallback-backed evidence across the frozen epsilon and fixture-variant matrix
+  - no public KS API landed
+- M4 is complete:
+  - internal orbit/coverage feasibility diagnostics passed on stable Heat and KdV fixtures
+  - no public orbit/coverage helper or augmentation utility landed
+- M5 is complete:
+  - API stability and public-surface guards confirmed the `v0.12` public surface
+  - internal M3/M4 helpers remained test-only
+- M6 is complete:
+  - package metadata and release-facing docs are aligned with `0.12.0`
+  - this readiness note is current
+  - the compact `v0_12-release-gate` is the current explicit release-gate CI job
+
+## Public API Notes
+
+New stable runtime API in `v0.12`:
+
+- `pdelie.reporting.summarize_generator_fit_diagnostics(generator)`
+
+The helper returns a JSON-compatible runtime summary of `GeneratorFamily` fit diagnostics, including:
+
+- singular values
+- condition number
+- selected coefficients
+- selected span distance
+- SVD coefficients
+- SVD span distance
+- fit mode
+- fallback status and reason
+- evidence label
+
+The helper is submodule-only:
+
+- import from `pdelie.reporting`
+- no root `pdelie` export
+- no new canonical object
+- no fitting algorithm change
+- no promotion gate
+
+Retained stable surfaces include:
+
+- Heat and Burgers strong paths
+- `v0.8` weak Heat/Burgers residual report APIs
+- `v0.9` normalized periodic short-horizon KdV strong path
+- `v0.10` reporting helpers and nested Heat/KdV example summaries
+- `v0.11` order-4 spectral derivative extension
+- structured `from_numpy(...)` and optional `from_xarray(...)` ingestion
+- existing discovery, portability, symmetry, and visualization runtime helpers
+
+## Internal Diagnostic Evidence
+
+### KS Diagnostic Sweep
+
+The bounded internal KS sweep remained diagnostic-only.
+All frozen variants concluded:
+
+`fallback_stable_across_epsilons`
+
+Default variant evidence:
+
+- residual max absolute value: `2.276047466221332e-09`
+- residual RMS value: `3.450580898077348e-10`
+- mass drift: `4.686823294199099e-16`
+- relative L2 drift: `0.0070894859776733715` as diagnostic-only
+- condition-number median: `214513.53360977306`
+- SVD span-distance median: `0.4178159498317849`
+- direct SVD in tolerance: `False`
+- fallback reason stable: `True`
+- fallback reason: `svd_translation_span_drift`
+
+Interpretation:
+
+- KS residual and canonical held-out verification behavior remain healthy
+- direct residual-based SVD fitting remains out of tolerance
+- stable KS runtime promotion remains deferred
+
+### Orbit / Coverage Feasibility
+
+The internal orbit/coverage feasibility helper remained test-only.
+
+Coverage cases:
+
+- half-coverage quarter-shift case: `32 / 64` points, coverage fraction `0.5`
+- full-coverage quarter-shift case: `64 / 64` points, coverage fraction `1.0`
+
+Transform consistency:
+
+- stable Heat and KdV fixtures preserved dims, coords, var names, metadata, and mask under uniform translations
+- inverse-transform and period-wrap errors remained at floating-point noise levels
+- residual RMS stayed stable under shifts
+- provenance recorded `operation == "invariant_apply"` and `construction_method == "uniform_translation"`
+
+Interpretation:
+
+- paper-agnostic orbit/coverage diagnostics are feasible
+- no public orbit/coverage helper landed
+- no public augmentation utility landed
+
+## Explicitly Deferred
+
+- new PDE support
+- stable KS data generator
+- stable KS residual evaluator
+- KS vertical-slice example
+- KS imported parity
+- weak KS APIs
+- root `pdelie` exports for KS runtime APIs
+- public orbit/coverage helpers
+- public augmentation utilities
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid support
+- operator-facing APIs
+- manuscript-specific experiment logic
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
+## CI Expectations
+
+Before tagging `v0.12.0`, the release PR should have these CI jobs green:
+
+- `v0_12-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+Historical release-gate test modules remain runnable locally and are covered by `editable-tests`.
+
+## Local Release Checklist
+
+Before tagging `v0.12.0`:
+
+1. Inspect consistency across:
+   - `pyproject.toml`
+   - `README.md`
+   - `CHANGELOG.md`
+   - `docs/releases/V0_12_RELEASE_READINESS.md`
+   - `docs/releases/PUBLISHING.md`
+   - `docs/specs/API_STABILITY.md`
+2. Run the full test suite:
+   - `python -m pytest`
+3. Build the package:
+   - `python -m build --sdist --wheel`
+4. Install `dist/pdelie-0.12.0-py3-none-any.whl` into a clean environment and verify:
+   - stable root imports
+   - `pdelie.reporting` helper imports from the submodule, including `summarize_generator_fit_diagnostics`
+   - one tiny weak Heat report
+   - one tiny KdV strong-path residual
+   - one tiny order-4 derivative smoke
+   - one tiny generator-fit diagnostic summary
+   - root `pdelie` does not export KS, orbit/coverage, augmentation, or weak KS APIs
+5. Run examples:
+   - `python -m pdelie.examples.heat_vertical_slice`
+   - `python -m pdelie.examples.kdv_vertical_slice`
+6. Run:
+   - `git diff --check`
+
+## Direct Final Tag Checklist
+
+After local checks and CI pass:
+
+- merge the release PR into `main`
+- tag the merged `main` commit as `v0.12.0`
+- do not publish to TestPyPI
+- do not publish to PyPI
+- record package-index publishing as deferred until `v1.0` or later
+
+## Final Release View
+
+`v0.12.0` is ready when the local release checklist and the current CI jobs pass.
+
+The stable release claim is intentionally narrow:
+
+`existing Heat/Burgers/weak-report/KdV/reporting surfaces -> generator-fit diagnostic summaries -> internal KS diagnostic sweep evidence -> internal orbit/coverage feasibility -> release supportability`
+
+M3 internal KS diagnostics and M4 orbit/coverage diagnostics remain internal.
+The final release view is that no stable KS runtime API is promoted.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -144,6 +144,13 @@ Runtime public API for the frozen `v0.10` Milestone 2 slice:
 - these APIs are runtime supportability helpers, not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs
 - these APIs have no root `pdelie` exports
 
+Runtime public API for the frozen `v0.12` Milestone 2 slice:
+
+- `pdelie.reporting.summarize_generator_fit_diagnostics` for JSON-compatible runtime summaries of `GeneratorFamily` fit diagnostics, including singular values, condition number, selected/SVD span distances, fallback status, and evidence labels
+- this API summarizes existing `GeneratorFamily` diagnostics and coefficients; it does not create a canonical object or mutate the generator
+- this API is a runtime supportability helper, not a manuscript table, fitting algorithm, promotion gate, or stable KS runtime surface
+- this API has no root `pdelie` export
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.11.0"
-description = "V0.11 order-4 spectral derivatives and Kuramoto-Sivashinsky feasibility no-go closeout for the Heat/Burgers/weak-report/KdV engine"
+version = "0.12.0"
+description = "V0.12 fit diagnostics, internal KS diagnostic sweep closeout, orbit/coverage feasibility, and supportability hardening for the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/reporting/__init__.py
+++ b/src/pdelie/reporting/__init__.py
@@ -1,4 +1,5 @@
 from pdelie.reporting.summaries import (
+    summarize_generator_fit_diagnostics,
     summarize_generator_family,
     summarize_residual_batch,
     summarize_verification_report,
@@ -7,6 +8,7 @@ from pdelie.reporting.summaries import (
 )
 
 __all__ = [
+    "summarize_generator_fit_diagnostics",
     "summarize_generator_family",
     "summarize_residual_batch",
     "summarize_verification_report",

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -7,11 +7,21 @@ from typing import Any
 import numpy as np
 
 from pdelie.contracts import DerivativeBatch, GeneratorFamily, ResidualBatch, VerificationReport
-from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.errors import PDELieValidationError, SchemaValidationError, ScopeValidationError
 from pdelie.symmetry.parameterization import translation_span_distance
+from pdelie.symmetry.parameterization.polynomial_translation import DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
 
 _SUMMARY_SCHEMA_VERSION = "0.1"
+_FIT_EVIDENCE_LABELS = frozenset(
+    {
+        "direct_svd_in_tolerance",
+        "direct_svd_out_of_tolerance",
+        "reference_fallback",
+        "mixed",
+        "unavailable",
+    }
+)
 _WEAK_REPORT_KEYS = frozenset(
     {
         "equation",
@@ -58,6 +68,34 @@ def _require_mapping(value: object, *, name: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise SchemaValidationError(f"{name} must be a mapping.")
     return value
+
+
+def _finite_float_or_none(value: Any, *, name: str) -> float | None:
+    if value is None:
+        return None
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite float or None.") from exc
+    if not np.isfinite(normalized):
+        return None
+    return normalized
+
+
+def _finite_list_or_none(value: Any, *, name: str) -> Any:
+    if value is None:
+        return None
+    return _require_finite(np.asarray(value, dtype=float), name=name).tolist()
+
+
+def _finite_mapping_or_none(value: Any, *, name: str) -> dict[str, float] | None:
+    if value is None:
+        return None
+    value_mapping = _require_mapping(value, name=name)
+    return {
+        str(key): float(_require_finite(np.asarray(item, dtype=float), name=f"{name}.{key}"))
+        for key, item in value_mapping.items()
+    }
 
 
 def _summary_payload(summary_type: str, **items: Any) -> dict[str, Any]:
@@ -111,6 +149,91 @@ def summarize_weak_residual_report(report: Mapping[str, Any]) -> dict[str, Any]:
         max_abs_residual=float(np.max(np.abs(window_residuals))),
         l2_residual=float(np.linalg.norm(window_residuals.ravel(), ord=2)),
         diagnostics=diagnostics,
+    )
+
+
+def _selected_coefficients_fallback(generator: GeneratorFamily) -> list[float] | list[list[float]]:
+    coefficients = _require_finite(generator.coefficients, name="GeneratorFamily.coefficients")
+    if coefficients.ndim == 2 and coefficients.shape[0] == 1:
+        return coefficients[0].tolist()
+    return coefficients.tolist()
+
+
+def _translation_span_or_none(coefficients: Any, *, parameterization: str) -> float | None:
+    if coefficients is None or parameterization != "polynomial_translation_affine":
+        return None
+    try:
+        return float(translation_span_distance(np.asarray(coefficients, dtype=float)))
+    except (PDELieValidationError, TypeError, ValueError):
+        return None
+
+
+def _condition_number_from_diagnostics(diagnostics: Mapping[str, Any]) -> float | None:
+    singular_values = diagnostics.get("singular_values")
+    if singular_values is not None:
+        normalized = _require_finite(np.asarray(singular_values, dtype=float), name="singular_values")
+        if normalized.size == 0:
+            return None
+        largest = float(normalized[0])
+        smallest = float(normalized[-1])
+        if not np.isfinite(largest) or not np.isfinite(smallest) or smallest == 0.0:
+            return None
+        return largest / smallest
+    return _finite_float_or_none(diagnostics.get("condition_number"), name="condition_number")
+
+
+def _evidence_label_from_diagnostics(diagnostics: Mapping[str, Any]) -> str:
+    label = diagnostics.get("evidence_label")
+    if isinstance(label, str) and label in _FIT_EVIDENCE_LABELS:
+        return label
+
+    reference_fallback_used = diagnostics.get("reference_fallback_used")
+    svd_span_distance = _finite_float_or_none(diagnostics.get("svd_span_distance"), name="svd_span_distance")
+    if reference_fallback_used is True:
+        return "reference_fallback"
+    if reference_fallback_used is False and svd_span_distance is not None:
+        if svd_span_distance <= DEFAULT_TRANSLATION_SPAN_TOLERANCE:
+            return "direct_svd_in_tolerance"
+        return "direct_svd_out_of_tolerance"
+    return "unavailable"
+
+
+def summarize_generator_fit_diagnostics(generator: GeneratorFamily) -> dict[str, Any]:
+    if not isinstance(generator, GeneratorFamily):
+        raise SchemaValidationError("summarize_generator_fit_diagnostics requires a GeneratorFamily.")
+
+    diagnostics = dict(generator.diagnostics)
+    selected_coefficients = diagnostics.get("selected_coefficients", _selected_coefficients_fallback(generator))
+    selected_span_distance = _finite_float_or_none(
+        diagnostics.get(
+            "selected_span_distance",
+            _translation_span_or_none(selected_coefficients, parameterization=generator.parameterization),
+        ),
+        name="selected_span_distance",
+    )
+
+    return _summary_payload(
+        "generator_fit_diagnostics",
+        parameterization=generator.parameterization,
+        fit_mode=diagnostics.get("fit_mode"),
+        training_epsilon=_finite_float_or_none(diagnostics.get("training_epsilon"), name="training_epsilon"),
+        basis=_json_safe(diagnostics.get("basis")),
+        basis_delta_norms=_finite_mapping_or_none(diagnostics.get("basis_delta_norms"), name="basis_delta_norms"),
+        design_column_norms=_finite_mapping_or_none(
+            diagnostics.get("design_column_norms"),
+            name="design_column_norms",
+        ),
+        singular_values=_finite_list_or_none(diagnostics.get("singular_values"), name="singular_values"),
+        condition_number=_condition_number_from_diagnostics(diagnostics),
+        fit_residual=_finite_float_or_none(diagnostics.get("fit_residual"), name="fit_residual"),
+        min_delta_basis=diagnostics.get("min_delta_basis"),
+        selected_coefficients=_finite_list_or_none(selected_coefficients, name="selected_coefficients"),
+        svd_coefficients=_finite_list_or_none(diagnostics.get("svd_coefficients"), name="svd_coefficients"),
+        selected_span_distance=selected_span_distance,
+        svd_span_distance=_finite_float_or_none(diagnostics.get("svd_span_distance"), name="svd_span_distance"),
+        reference_fallback_used=diagnostics.get("reference_fallback_used"),
+        fallback_reason=diagnostics.get("fallback_reason"),
+        evidence_label=_evidence_label_from_diagnostics(diagnostics),
     )
 
 

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -76,7 +76,9 @@ def _finite_float_or_none(value: Any, *, name: str) -> float | None:
     try:
         normalized = float(value)
     except (TypeError, ValueError) as exc:
-        raise SchemaValidationError(f"{name} must be a finite float or None.") from exc
+        raise SchemaValidationError(
+            f"{name} must be a float-like value or None; non-finite values are normalized to None."
+        ) from exc
     if not np.isfinite(normalized):
         return None
     return normalized
@@ -92,10 +94,17 @@ def _finite_mapping_or_none(value: Any, *, name: str) -> dict[str, float] | None
     if value is None:
         return None
     value_mapping = _require_mapping(value, name=name)
-    return {
-        str(key): float(_require_finite(np.asarray(item, dtype=float), name=f"{name}.{key}"))
-        for key, item in value_mapping.items()
-    }
+    normalized_mapping: dict[str, float] = {}
+    for key, item in value_mapping.items():
+        field_name = f"{name}.{key}"
+        try:
+            normalized = _require_finite(np.asarray(item, dtype=float), name=field_name)
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError(f"{field_name} must be a finite scalar float.") from exc
+        if normalized.size != 1:
+            raise SchemaValidationError(f"{field_name} must be a finite scalar float.")
+        normalized_mapping[str(key)] = float(normalized.item())
+    return normalized_mapping
 
 
 def _summary_payload(summary_type: str, **items: Any) -> dict[str, Any]:
@@ -171,11 +180,11 @@ def _translation_span_or_none(coefficients: Any, *, parameterization: str) -> fl
 def _condition_number_from_diagnostics(diagnostics: Mapping[str, Any]) -> float | None:
     singular_values = diagnostics.get("singular_values")
     if singular_values is not None:
-        normalized = _require_finite(np.asarray(singular_values, dtype=float), name="singular_values")
+        normalized = _require_finite(np.asarray(singular_values, dtype=float), name="singular_values").ravel()
         if normalized.size == 0:
             return None
-        largest = float(normalized[0])
-        smallest = float(normalized[-1])
+        largest = float(np.max(normalized))
+        smallest = float(np.min(normalized))
         if not np.isfinite(largest) or not np.isfinite(smallest) or smallest == 0.0:
             return None
         return largest / smallest

--- a/src/pdelie/symmetry/fitting/translation_baseline.py
+++ b/src/pdelie/symmetry/fitting/translation_baseline.py
@@ -17,6 +17,26 @@ from pdelie.symmetry.parameterization.polynomial_translation import (
 TRANSLATION_FALLBACK_SPAN_TOLERANCE = DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
 
+def _condition_number(singular_values: np.ndarray) -> float | None:
+    largest = float(singular_values[0])
+    smallest = float(singular_values[-1])
+    if not np.isfinite(largest) or not np.isfinite(smallest) or smallest == 0.0:
+        return None
+    return largest / smallest
+
+
+def _translation_evidence_label(
+    *,
+    reference_fallback_used: bool,
+    svd_span_distance: float,
+) -> str:
+    if reference_fallback_used:
+        return "reference_fallback"
+    if svd_span_distance <= TRANSLATION_FALLBACK_SPAN_TOLERANCE:
+        return "direct_svd_in_tolerance"
+    return "direct_svd_out_of_tolerance"
+
+
 def _select_translation_coefficients(
     svd_coefficients: np.ndarray,
     basis_delta_norms: dict[str, float],
@@ -59,11 +79,13 @@ def fit_translation_generator(
     design = np.column_stack(columns)
     _, singular_values, vh = np.linalg.svd(design, full_matrices=False)
     svd_coefficients = normalize_translation_coefficients(vh[-1])
+    svd_span_distance = float(translation_span_distance(svd_coefficients))
 
     coefficients, fit_mode, reference_fallback_used, fallback_reason, min_delta_basis = _select_translation_coefficients(
         svd_coefficients,
         basis_delta_norms,
     )
+    selected_span_distance = float(translation_span_distance(coefficients))
 
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
@@ -73,13 +95,22 @@ def fit_translation_generator(
         diagnostics={
             "basis": list(POLYNOMIAL_TRANSLATION_BASIS),
             "basis_delta_norms": basis_delta_norms,
+            "condition_number": _condition_number(singular_values),
+            "design_column_norms": dict(basis_delta_norms),
+            "evidence_label": _translation_evidence_label(
+                reference_fallback_used=reference_fallback_used,
+                svd_span_distance=svd_span_distance,
+            ),
             "fallback_reason": fallback_reason,
             "fit_mode": fit_mode,
             "fit_residual": float(singular_values[-1]),
             "min_delta_basis": min_delta_basis,
             "reference_fallback_used": reference_fallback_used,
+            "selected_coefficients": coefficients.tolist(),
+            "selected_span_distance": selected_span_distance,
+            "singular_values": singular_values.tolist(),
             "svd_coefficients": svd_coefficients.tolist(),
-            "svd_span_distance": float(translation_span_distance(svd_coefficients)),
+            "svd_span_distance": svd_span_distance,
             "training_epsilon": float(epsilon),
         },
     )

--- a/tests/_helpers/ks_diagnostic_sweep.py
+++ b/tests/_helpers/ks_diagnostic_sweep.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+
+from pdelie.data import split_batch_train_heldout
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.reporting import summarize_generator_fit_diagnostics
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+from tests._helpers.ks_feasibility import (
+    KSFeasibilityResidualEvaluator,
+    compute_l2_norm,
+    compute_mass,
+    generate_ks_feasibility_field_batch,
+)
+
+
+KS_SWEEP_EPSILONS = (1e-5, 3e-5, 1e-4, 3e-4, 1e-3)
+KS_SWEEP_VARIANTS: tuple[dict[str, object], ...] = (
+    {"variant_name": "default", "generator_kwargs": {}},
+    {"variant_name": "lower_amplitude", "generator_kwargs": {"amplitude": 0.04}},
+    {"variant_name": "shorter_time", "generator_kwargs": {"max_time": 0.1}},
+)
+KS_SWEEP_TRAIN_SIZE = 2
+KS_SWEEP_SPLIT_SEED = 11102
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _summary(values: list[float]) -> dict[str, float | None]:
+    if not values:
+        return {"min": None, "median": None, "max": None}
+    array = np.asarray(values, dtype=float)
+    return {
+        "min": float(np.min(array)),
+        "median": float(np.median(array)),
+        "max": float(np.max(array)),
+    }
+
+
+def _variant_conclusion(fits: list[dict[str, object]], *, fallback_reason_stable: bool) -> str:
+    labels = [str(fit["evidence_label"]) for fit in fits]
+    fallback_flags = [bool(fit["reference_fallback_used"]) for fit in fits]
+    verification_passes = [str(fit["classification"]) != "failed" for fit in fits]
+
+    if any(label == "direct_svd_in_tolerance" for label in labels):
+        return "direct_svd_recovered"
+    if all(fallback_flags) and fallback_reason_stable and all(verification_passes):
+        return "fallback_stable_across_epsilons"
+    if len(set(labels)) > 1 or len(set(fallback_flags)) > 1:
+        return "epsilon_sensitive"
+    return "inconclusive"
+
+
+def _variant_aggregates(fits: list[dict[str, object]]) -> dict[str, object]:
+    condition_numbers = [
+        float(fit["condition_number"])
+        for fit in fits
+        if fit["condition_number"] is not None and np.isfinite(float(fit["condition_number"]))
+    ]
+    svd_span_distances = [
+        float(fit["svd_span_distance"])
+        for fit in fits
+        if fit["svd_span_distance"] is not None and np.isfinite(float(fit["svd_span_distance"]))
+    ]
+    fallback_reasons = sorted(
+        {
+            str(fit["fallback_reason"])
+            for fit in fits
+            if isinstance(fit["fallback_reason"], str) and fit["fallback_reason"]
+        }
+    )
+    fallback_reason_stable = bool(fallback_reasons) and len(fallback_reasons) == 1
+
+    aggregates = {
+        "condition_number_summary": _summary(condition_numbers),
+        "svd_span_distance_summary": _summary(svd_span_distances),
+        "any_direct_svd_in_tolerance": any(
+            fit["evidence_label"] == "direct_svd_in_tolerance" for fit in fits
+        ),
+        "fallback_reason_stable": fallback_reason_stable,
+        "fallback_reasons": fallback_reasons,
+    }
+    aggregates["conclusion"] = _variant_conclusion(fits, fallback_reason_stable=fallback_reason_stable)
+    return aggregates
+
+
+def _run_variant(*, variant_name: str, generator_kwargs: dict[str, object]) -> dict[str, object]:
+    field = generate_ks_feasibility_field_batch(**generator_kwargs)
+    training, heldout = split_batch_train_heldout(
+        field,
+        train_size=KS_SWEEP_TRAIN_SIZE,
+        seed=KS_SWEEP_SPLIT_SEED,
+    )
+
+    derivatives = compute_spectral_fd_derivatives(training, max_spatial_order=4)
+    residual_evaluator = KSFeasibilityResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    mass = compute_mass(field)
+    l2 = compute_l2_norm(field)
+    fits: list[dict[str, object]] = []
+
+    for epsilon in KS_SWEEP_EPSILONS:
+        generator = fit_translation_generator(training, residual_evaluator, epsilon=epsilon)
+        fit_diagnostics = summarize_generator_fit_diagnostics(generator)
+        verification = verify_translation_generator(heldout, generator, residual_evaluator)
+        fit = {
+            "epsilon": float(epsilon),
+            "fit_diagnostics": fit_diagnostics,
+            "selected_span_distance": fit_diagnostics["selected_span_distance"],
+            "svd_span_distance": fit_diagnostics["svd_span_distance"],
+            "reference_fallback_used": fit_diagnostics["reference_fallback_used"],
+            "fallback_reason": fit_diagnostics["fallback_reason"],
+            "evidence_label": fit_diagnostics["evidence_label"],
+            "first_verification_error": float(verification.error_curve[0]),
+            "classification": verification.classification,
+            "transform_mode": verification.diagnostics["transform_mode"],
+            "singular_values": fit_diagnostics["singular_values"],
+            "condition_number": fit_diagnostics["condition_number"],
+        }
+        fits.append(_json_safe(fit))
+
+    aggregates = _variant_aggregates(fits)
+    return _json_safe(
+        {
+            "variant_name": variant_name,
+            "generator_kwargs": generator_kwargs,
+            "residual_max_abs": float(residual.diagnostics["max_abs_residual"]),
+            "residual_rms": float(residual.diagnostics["rms_residual"]),
+            "mass_drift": float(np.max(np.abs(mass - mass[:, [0]]))),
+            "relative_l2_drift": float(
+                np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12))
+            ),
+            **aggregates,
+            "fits": fits,
+        }
+    )
+
+
+def run_ks_fit_diagnostic_sweep() -> dict[str, object]:
+    return _json_safe(
+        {
+            "summary_schema_version": "0.1",
+            "summary_type": "ks_fit_diagnostic_sweep",
+            "epsilons": [float(epsilon) for epsilon in KS_SWEEP_EPSILONS],
+            "train_size": KS_SWEEP_TRAIN_SIZE,
+            "split_seed": KS_SWEEP_SPLIT_SEED,
+            "variants": [
+                _run_variant(
+                    variant_name=str(variant["variant_name"]),
+                    generator_kwargs=dict(variant["generator_kwargs"]),
+                )
+                for variant in KS_SWEEP_VARIANTS
+            ],
+        }
+    )
+
+
+@lru_cache(maxsize=1)
+def _cached_ks_fit_diagnostic_sweep() -> dict[str, object]:
+    return run_ks_fit_diagnostic_sweep()
+
+
+def cached_ks_fit_diagnostic_sweep() -> dict[str, object]:
+    return deepcopy(_cached_ks_fit_diagnostic_sweep())

--- a/tests/_helpers/orbit_coverage_feasibility.py
+++ b/tests/_helpers/orbit_coverage_feasibility.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+
+from pdelie import GeneratorFamily, InvariantMapSpec
+from pdelie.contracts import FieldBatch, _translation_generator_basis_spec
+from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
+from pdelie.invariants import InvariantApplier
+from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator, ResidualEvaluator
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_DOMAIN_LENGTH = 2.0 * np.pi
+_GRID_POINTS = 64
+_COVERAGE_SHIFTS = (0.0, _DOMAIN_LENGTH / 4.0, _DOMAIN_LENGTH / 2.0, 3.0 * _DOMAIN_LENGTH / 4.0)
+_TRANSFORM_SHIFTS = (0.0, _DOMAIN_LENGTH / _GRID_POINTS, _DOMAIN_LENGTH / 8.0, -_DOMAIN_LENGTH / 8.0, _DOMAIN_LENGTH)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _relative_l2(left: np.ndarray, right: np.ndarray) -> float:
+    return float(np.linalg.norm(np.asarray(left) - np.asarray(right)) / (np.linalg.norm(np.asarray(right)) + 1e-12))
+
+
+def _rms(values: np.ndarray) -> float:
+    normalized = np.asarray(values, dtype=float)
+    return float(np.sqrt(np.mean(np.square(normalized))))
+
+
+def _translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={},
+    )
+
+
+def _translation_spec(shift: float) -> InvariantMapSpec:
+    return InvariantMapSpec(
+        generator_metadata=_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": float(shift)},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={"source": "v0.12_m4_orbit_coverage_feasibility"},
+    )
+
+
+def _periodic_window_mask(x: np.ndarray, *, start: float, width: float, domain_length: float) -> np.ndarray:
+    normalized = (np.asarray(x, dtype=float) - float(start)) % float(domain_length)
+    return normalized < float(width)
+
+
+def _coverage_case(*, case_name: str, window_width: float) -> dict[str, object]:
+    x = np.linspace(0.0, _DOMAIN_LENGTH, _GRID_POINTS, endpoint=False, dtype=float)
+    base_windows = [{"start": 0.0, "width": float(window_width)}]
+    coverage_counts = np.zeros(_GRID_POINTS, dtype=int)
+
+    for window in base_windows:
+        for shift in _COVERAGE_SHIFTS:
+            coverage_counts += _periodic_window_mask(
+                x,
+                start=float(window["start"]) + float(shift),
+                width=float(window["width"]),
+                domain_length=_DOMAIN_LENGTH,
+            ).astype(int)
+
+    covered = int(np.count_nonzero(coverage_counts))
+    zero_runs = _zero_run_lengths(coverage_counts)
+    return _json_safe(
+        {
+            "case_name": case_name,
+            "domain_length": _DOMAIN_LENGTH,
+            "grid_points": _GRID_POINTS,
+            "base_windows": base_windows,
+            "shifts": list(_COVERAGE_SHIFTS),
+            "covered_grid_point_count": covered,
+            "coverage_fraction": float(covered / _GRID_POINTS),
+            "min_coverage_count": int(np.min(coverage_counts)),
+            "max_coverage_count": int(np.max(coverage_counts)),
+            "mean_coverage_count": float(np.mean(coverage_counts)),
+            "max_uncovered_run_points": int(max(zero_runs, default=0)),
+        }
+    )
+
+
+def _zero_run_lengths(counts: np.ndarray) -> list[int]:
+    uncovered = np.asarray(counts) == 0
+    if not np.any(uncovered):
+        return []
+    doubled = np.concatenate([uncovered, uncovered])
+    runs: list[int] = []
+    current = 0
+    for value in doubled:
+        if value:
+            current += 1
+        elif current:
+            runs.append(min(current, uncovered.size))
+            current = 0
+    if current:
+        runs.append(min(current, uncovered.size))
+    return runs
+
+
+def _residual_rms(field: FieldBatch, evaluator: ResidualEvaluator) -> float:
+    return _rms(evaluator.evaluate(field).residual)
+
+
+def _transform_consistency_case(
+    *,
+    field_name: str,
+    field: FieldBatch,
+    evaluator: ResidualEvaluator,
+) -> dict[str, object]:
+    applier = InvariantApplier()
+    before_rms = _residual_rms(field, evaluator)
+    shift_reports: list[dict[str, object]] = []
+
+    for shift in _TRANSFORM_SHIFTS:
+        transformed = applier.apply(field, _translation_spec(float(shift)))
+        inverted = applier.apply(transformed, _translation_spec(-float(shift)))
+        period_wrapped = applier.apply(field, _translation_spec(float(shift) + _DOMAIN_LENGTH))
+        after_rms = _residual_rms(transformed, evaluator)
+        relative_delta = abs(after_rms - before_rms) / (abs(before_rms) + 1e-12)
+        provenance = transformed.preprocess_log[-1]
+        shift_reports.append(
+            _json_safe(
+                {
+                    "shift": float(shift),
+                    "dims_preserved": transformed.dims == field.dims,
+                    "coords_preserved": all(
+                        np.allclose(transformed.coords[name], field.coords[name], rtol=0.0, atol=1e-12)
+                        for name in field.coords
+                    ),
+                    "var_names_preserved": transformed.var_names == field.var_names,
+                    "metadata_preserved": transformed.metadata == field.metadata,
+                    "mask_preserved": (
+                        transformed.mask is None
+                        if field.mask is None
+                        else np.array_equal(transformed.mask, field.mask)
+                    ),
+                    "inverse_relative_l2_error": _relative_l2(inverted.values, field.values),
+                    "period_wrap_relative_l2_error": _relative_l2(period_wrapped.values, transformed.values),
+                    "residual_rms_before": before_rms,
+                    "residual_rms_after": after_rms,
+                    "residual_relative_rms_delta": float(relative_delta),
+                    "provenance_operation": provenance["operation"],
+                    "provenance_construction_method": provenance["construction_method"],
+                    "preprocess_log_length_delta": len(transformed.preprocess_log) - len(field.preprocess_log),
+                }
+            )
+        )
+
+    return _json_safe(
+        {
+            "field_name": field_name,
+            "equation": field.metadata["parameter_tags"].get("equation", "heat_1d"),
+            "shifts": list(_TRANSFORM_SHIFTS),
+            "shift_reports": shift_reports,
+        }
+    )
+
+
+def run_orbit_coverage_feasibility() -> dict[str, object]:
+    heat = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=_GRID_POINTS, seed=1201)
+    kdv = generate_kdv_1d_field_batch(batch_size=2, num_times=17, num_points=_GRID_POINTS, seed=1202)
+
+    return _json_safe(
+        {
+            "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+            "summary_type": "orbit_coverage_feasibility",
+            "coverage_cases": [
+                _coverage_case(case_name="half_coverage_quarter_shifts", window_width=_DOMAIN_LENGTH / 8.0),
+                _coverage_case(case_name="full_coverage_quarter_shifts", window_width=_DOMAIN_LENGTH / 4.0),
+            ],
+            "transform_consistency_cases": [
+                _transform_consistency_case(
+                    field_name="heat_default",
+                    field=heat,
+                    evaluator=HeatResidualEvaluator(),
+                ),
+                _transform_consistency_case(
+                    field_name="kdv_default",
+                    field=kdv,
+                    evaluator=KdVResidualEvaluator(),
+                ),
+            ],
+        }
+    )
+
+
+@lru_cache(maxsize=1)
+def _cached_orbit_coverage_feasibility() -> dict[str, object]:
+    return run_orbit_coverage_feasibility()
+
+
+def cached_orbit_coverage_feasibility() -> dict[str, object]:
+    return deepcopy(_cached_orbit_coverage_feasibility())

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -249,15 +249,16 @@ def test_v0_12_planning_docs_record_m4_internal_and_m5_audit_scope() -> None:
     assert "no API stability entry for the internal feasibility helper" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
     assert "left `docs/specs/API_STABILITY.md` unchanged because no mismatch was found" in plan
-    assert "**Status:** PENDING" in plan
     assert "## Milestone 6 - Release Gate and Readiness" in plan
+    assert "updated CI so the current explicit release gate is `v0_12-release-gate`" in plan
+    assert "- Milestone 6: COMPLETE" in plan
 
     assert "M4 did not implement private-paper policy, train-augmentation recipes" in scope
     assert "public orbit/coverage helpers" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
-    assert "- Milestone 6: PENDING" in scope
+    assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.12` is the committed release" in roadmap
+    assert "`v0.12` is the completed diagnostics/supportability release" in roadmap
     assert "without adding new numerical scope" in roadmap
     assert "- no new PDE" in roadmap

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -51,11 +51,16 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "OperatorSymmetry",
     "KSResidualEvaluator",
     "KuramotoSivashinskyResidualEvaluator",
+    "WeakKSResidualEvaluator",
     "WeakBurgersResidualEvaluator",
     "WeakHeatResidualEvaluator",
     "WeakKdVResidualEvaluator",
+    "augment_translation_orbit",
+    "build_translation_orbit_views",
+    "compute_coverage_diagnostics",
     "compute_weak_derivatives",
     "evaluate_weak_kdv_residual",
+    "evaluate_weak_ks_residual",
     "from_pdebench",
     "from_the_well",
     "generate_ks_1d_field_batch",
@@ -63,6 +68,25 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "load_pdebench",
     "load_the_well",
     "sample_kdv_mode_coefficients",
+    "summarize_orbit_coverage",
+    "summarize_orbit_coverage_feasibility",
+}
+_DEFERRED_API_STABILITY_NAMES = {
+    "pdelie.data.augment_translation_orbit",
+    "pdelie.data.build_translation_orbit_views",
+    "pdelie.data.compute_coverage_diagnostics",
+    "pdelie.data.from_pdebench",
+    "pdelie.data.from_the_well",
+    "pdelie.data.generate_ks_1d_field_batch",
+    "pdelie.data.load_pdebench",
+    "pdelie.data.load_the_well",
+    "pdelie.reporting.summarize_orbit_coverage",
+    "pdelie.reporting.summarize_orbit_coverage_feasibility",
+    "pdelie.residuals.KSResidualEvaluator",
+    "pdelie.residuals.KuramotoSivashinskyResidualEvaluator",
+    "pdelie.residuals.WeakKSResidualEvaluator",
+    "pdelie.residuals.evaluate_weak_ks_residual",
+    "pdelie.symmetry.OperatorSymmetry",
 }
 _V0_10_REPORTING_APIS = {
     "pdelie.reporting.summarize_residual_batch",
@@ -92,6 +116,10 @@ def _api_stability_text() -> str:
     return (Path(__file__).resolve().parents[1] / "docs/specs/API_STABILITY.md").read_text(encoding="utf-8")
 
 
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
 def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
     text = _api_stability_text()
 
@@ -109,6 +137,19 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
     assert "not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs" in text
     assert "weak-form derivatives and weak-form methods beyond the frozen `v0.8` weak residual report slice" in text
     assert "operator symmetry" in text
+
+
+def test_api_stability_doc_does_not_promote_deferred_v0_12_surfaces() -> None:
+    text = _api_stability_text()
+
+    for api_name in sorted(_DEFERRED_API_STABILITY_NAMES):
+        assert api_name not in text
+
+    assert "PDEBench" not in text
+    assert "The Well" not in text
+    assert "multidimensional grids" not in text
+    assert "nonuniform grids" not in text
+    assert "public orbit/coverage" not in text
 
 
 def test_root_package_still_exposes_only_stable_canonical_surface() -> None:
@@ -195,3 +236,28 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
     for module in modules:
         for name in sorted(_DEFERRED_OR_PRIVATE_NAMES):
             assert not hasattr(module, name), f"{module.__name__}.{name}"
+
+
+def test_v0_12_planning_docs_record_m4_internal_and_m5_audit_scope() -> None:
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_12_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+
+    assert "**Status:** COMPLETE" in plan
+    assert "Milestone 4 - Orbit / Coverage Diagnostic Feasibility" in plan
+    assert "these diagnostics are not promoted as public APIs in M4" in plan
+    assert "no API stability entry for the internal feasibility helper" in plan
+    assert "## Milestone 5 - API / Public-surface Audit" in plan
+    assert "left `docs/specs/API_STABILITY.md` unchanged because no mismatch was found" in plan
+    assert "**Status:** PENDING" in plan
+    assert "## Milestone 6 - Release Gate and Readiness" in plan
+
+    assert "M4 did not implement private-paper policy, train-augmentation recipes" in scope
+    assert "public orbit/coverage helpers" in scope
+    assert "- Milestone 4: COMPLETE" in scope
+    assert "- Milestone 5: COMPLETE" in scope
+    assert "- Milestone 6: PENDING" in scope
+
+    assert "`v0.12` is the committed release" in roadmap
+    assert "without adding new numerical scope" in roadmap
+    assert "- no new PDE" in roadmap

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -37,6 +37,7 @@ _ROOT_RUNTIME_NAMES = {
     "split_batch_train_heldout",
     "subsample_time",
     "subsample_x",
+    "summarize_generator_fit_diagnostics",
     "summarize_generator_family",
     "summarize_recovery_grid",
     "summarize_residual_batch",
@@ -82,6 +83,9 @@ _V0_9_KDV_APIS = {
 _V0_11_DERIVATIVE_APIS = {
     "pdelie.derivatives.compute_spectral_fd_derivatives(field, *, max_spatial_order=4)",
 }
+_V0_12_REPORTING_APIS = {
+    "pdelie.reporting.summarize_generator_fit_diagnostics",
+}
 
 
 def _api_stability_text() -> str:
@@ -91,7 +95,13 @@ def _api_stability_text() -> str:
 def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
     text = _api_stability_text()
 
-    for api_name in sorted(_V0_10_REPORTING_APIS | _V0_8_WEAK_APIS | _V0_9_KDV_APIS | _V0_11_DERIVATIVE_APIS):
+    for api_name in sorted(
+        _V0_10_REPORTING_APIS
+        | _V0_8_WEAK_APIS
+        | _V0_9_KDV_APIS
+        | _V0_11_DERIVATIVE_APIS
+        | _V0_12_REPORTING_APIS
+    ):
         assert api_name in text
 
     assert "does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator" in text
@@ -135,6 +145,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "import_generator_family_manifest",
         },
         "pdelie.reporting": {
+            "summarize_generator_fit_diagnostics",
             "summarize_generator_family",
             "summarize_residual_batch",
             "summarize_verification_report",

--- a/tests/test_ks_diagnostic_sweep.py
+++ b/tests/test_ks_diagnostic_sweep.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib
+import json
+from numbers import Number
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import pdelie
+from tests._helpers.ks_diagnostic_sweep import (
+    KS_SWEEP_EPSILONS,
+    KS_SWEEP_VARIANTS,
+    cached_ks_fit_diagnostic_sweep,
+    run_ks_fit_diagnostic_sweep,
+)
+
+
+@pytest.fixture(scope="module")
+def sweep_summary() -> dict[str, object]:
+    return cached_ks_fit_diagnostic_sweep()
+
+
+def _variant_by_name(summary: dict[str, object], name: str) -> dict[str, object]:
+    variants = summary["variants"]
+    assert isinstance(variants, list)
+    for variant in variants:
+        assert isinstance(variant, dict)
+        if variant["variant_name"] == name:
+            return variant
+    raise AssertionError(f"missing variant {name!r}")
+
+
+def _assert_json_plain(value: object) -> None:
+    assert not isinstance(value, (np.ndarray, np.generic))
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert isinstance(key, str)
+            _assert_json_plain(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_json_plain(item)
+    else:
+        assert value is None or isinstance(value, (str, bool, int, float))
+
+
+def _assert_summary_close(left: Any, right: Any) -> None:
+    if isinstance(left, dict):
+        assert isinstance(right, dict)
+        assert set(left) == set(right)
+        for key in left:
+            _assert_summary_close(left[key], right[key])
+        return
+    if isinstance(left, list):
+        assert isinstance(right, list)
+        assert len(left) == len(right)
+        for left_item, right_item in zip(left, right, strict=True):
+            _assert_summary_close(left_item, right_item)
+        return
+    if isinstance(left, Number) and not isinstance(left, bool):
+        assert isinstance(right, Number)
+        np.testing.assert_allclose(left, right, rtol=1e-7, atol=1e-10)
+        return
+    assert left == right
+
+
+def test_ks_diagnostic_sweep_output_is_json_plain(sweep_summary: dict[str, object]) -> None:
+    assert sweep_summary["summary_schema_version"] == "0.1"
+    assert sweep_summary["summary_type"] == "ks_fit_diagnostic_sweep"
+    assert json.loads(json.dumps(sweep_summary)) == sweep_summary
+    _assert_json_plain(sweep_summary)
+
+
+def test_ks_diagnostic_sweep_matrix_is_frozen(sweep_summary: dict[str, object]) -> None:
+    expected_variant_names = [str(variant["variant_name"]) for variant in KS_SWEEP_VARIANTS]
+
+    assert sweep_summary["epsilons"] == [float(epsilon) for epsilon in KS_SWEEP_EPSILONS]
+    assert sweep_summary["train_size"] == 2
+    assert sweep_summary["split_seed"] == 11102
+
+    variants = sweep_summary["variants"]
+    assert isinstance(variants, list)
+    assert [variant["variant_name"] for variant in variants] == expected_variant_names
+    for variant in variants:
+        assert isinstance(variant, dict)
+        fits = variant["fits"]
+        assert isinstance(fits, list)
+        assert [fit["epsilon"] for fit in fits] == [float(epsilon) for epsilon in KS_SWEEP_EPSILONS]
+
+
+def test_ks_diagnostic_sweep_writes_no_artifacts_and_is_deterministic(
+    sweep_summary: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path
+    monkeypatch.chdir(workdir)
+
+    assert list(workdir.iterdir()) == []
+    repeated = run_ks_fit_diagnostic_sweep()
+    assert list(workdir.iterdir()) == []
+    _assert_summary_close(sweep_summary, repeated)
+
+
+def test_ks_diagnostic_sweep_fit_diagnostics_are_well_formed(sweep_summary: dict[str, object]) -> None:
+    variants = sweep_summary["variants"]
+    assert isinstance(variants, list)
+
+    for variant in variants:
+        assert isinstance(variant, dict)
+        for fit in variant["fits"]:
+            assert isinstance(fit, dict)
+            singular_values = fit["singular_values"]
+            assert isinstance(singular_values, list)
+            assert singular_values
+            singular_array = np.asarray(singular_values, dtype=float)
+            assert np.all(np.isfinite(singular_array))
+            assert np.all(singular_array >= 0.0)
+            assert np.all(singular_array[:-1] >= singular_array[1:] - 1e-12)
+
+            condition_number = fit["condition_number"]
+            if condition_number is not None:
+                assert isinstance(condition_number, float)
+                assert np.isfinite(condition_number)
+                assert condition_number > 0.0
+
+            fit_diagnostics = fit["fit_diagnostics"]
+            assert isinstance(fit_diagnostics, dict)
+            assert fit_diagnostics["summary_type"] == "generator_fit_diagnostics"
+            assert fit_diagnostics["singular_values"] == singular_values
+            assert fit_diagnostics["condition_number"] == condition_number
+
+
+def test_ks_diagnostic_sweep_variant_aggregates(sweep_summary: dict[str, object]) -> None:
+    variants = sweep_summary["variants"]
+    assert isinstance(variants, list)
+
+    for variant in variants:
+        assert isinstance(variant, dict)
+        assert set(variant["condition_number_summary"]) == {"min", "median", "max"}
+        assert set(variant["svd_span_distance_summary"]) == {"min", "median", "max"}
+        assert isinstance(variant["any_direct_svd_in_tolerance"], bool)
+        assert isinstance(variant["fallback_reason_stable"], bool)
+        assert isinstance(variant["fallback_reasons"], list)
+        assert variant["conclusion"] in {
+            "direct_svd_recovered",
+            "fallback_stable_across_epsilons",
+            "epsilon_sensitive",
+            "inconclusive",
+        }
+
+
+def test_ks_diagnostic_sweep_default_variant_records_stable_fallback(
+    sweep_summary: dict[str, object],
+) -> None:
+    default = _variant_by_name(sweep_summary, "default")
+
+    assert default["conclusion"] == "fallback_stable_across_epsilons"
+    assert default["fallback_reason_stable"] is True
+    assert default["fallback_reasons"] == ["svd_translation_span_drift"]
+    assert default["any_direct_svd_in_tolerance"] is False
+    assert default["mass_drift"] <= 1e-8
+    assert "relative_l2_drift" in default
+    assert default["relative_l2_drift"] >= 0.0
+
+    for fit in default["fits"]:
+        assert fit["evidence_label"] == "reference_fallback"
+        assert fit["reference_fallback_used"] is True
+        assert fit["fallback_reason"] == "svd_translation_span_drift"
+        assert fit["svd_span_distance"] > 1e-1
+        assert fit["selected_span_distance"] <= 1e-1
+        assert fit["first_verification_error"] < 5e-4
+        assert fit["classification"] != "failed"
+        assert fit["transform_mode"] == "uniform_translation"
+
+
+def test_ks_diagnostic_sweep_all_frozen_variants_remain_fallback_stable(
+    sweep_summary: dict[str, object],
+) -> None:
+    variants = sweep_summary["variants"]
+    assert isinstance(variants, list)
+
+    for variant in variants:
+        assert isinstance(variant, dict)
+        assert variant["conclusion"] == "fallback_stable_across_epsilons"
+        assert variant["fallback_reasons"] == ["svd_translation_span_drift"]
+        assert variant["any_direct_svd_in_tolerance"] is False
+
+
+def test_ks_diagnostic_sweep_adds_no_public_ks_surface() -> None:
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+    examples_module = importlib.import_module("pdelie.examples")
+
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
+    assert not hasattr(residuals_module, "KSResidualEvaluator")
+    assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(examples_module, "run_ks_vertical_slice_example")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")
+    assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(pdelie, "run_ks_vertical_slice_example")

--- a/tests/test_orbit_coverage_feasibility.py
+++ b/tests/test_orbit_coverage_feasibility.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib
+import json
+from numbers import Number
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import pdelie
+from tests._helpers.orbit_coverage_feasibility import (
+    cached_orbit_coverage_feasibility,
+    run_orbit_coverage_feasibility,
+)
+
+
+@pytest.fixture(scope="module")
+def feasibility_summary() -> dict[str, object]:
+    return cached_orbit_coverage_feasibility()
+
+
+def _assert_json_plain(value: object) -> None:
+    assert not isinstance(value, (np.ndarray, np.generic))
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert isinstance(key, str)
+            _assert_json_plain(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_json_plain(item)
+    else:
+        assert value is None or isinstance(value, (str, bool, int, float))
+
+
+def _assert_summary_close(left: Any, right: Any) -> None:
+    if isinstance(left, dict):
+        assert isinstance(right, dict)
+        assert set(left) == set(right)
+        for key in left:
+            _assert_summary_close(left[key], right[key])
+        return
+    if isinstance(left, list):
+        assert isinstance(right, list)
+        assert len(left) == len(right)
+        for left_item, right_item in zip(left, right, strict=True):
+            _assert_summary_close(left_item, right_item)
+        return
+    if isinstance(left, Number) and not isinstance(left, bool):
+        assert isinstance(right, Number)
+        np.testing.assert_allclose(left, right, rtol=1e-9, atol=1e-12)
+        return
+    assert left == right
+
+
+def _coverage_case(summary: dict[str, object], case_name: str) -> dict[str, object]:
+    cases = summary["coverage_cases"]
+    assert isinstance(cases, list)
+    for case in cases:
+        assert isinstance(case, dict)
+        if case["case_name"] == case_name:
+            return case
+    raise AssertionError(f"missing coverage case {case_name!r}")
+
+
+def test_orbit_coverage_feasibility_output_is_json_plain(
+    feasibility_summary: dict[str, object],
+) -> None:
+    assert feasibility_summary["summary_schema_version"] == "0.1"
+    assert feasibility_summary["summary_type"] == "orbit_coverage_feasibility"
+    assert json.loads(json.dumps(feasibility_summary)) == feasibility_summary
+    _assert_json_plain(feasibility_summary)
+
+
+def test_orbit_coverage_feasibility_writes_no_artifacts_and_is_deterministic(
+    feasibility_summary: dict[str, object],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+    repeated = run_orbit_coverage_feasibility()
+    assert list(tmp_path.iterdir()) == []
+    _assert_summary_close(feasibility_summary, repeated)
+
+
+def test_periodic_window_coverage_cases_match_frozen_expectations(
+    feasibility_summary: dict[str, object],
+) -> None:
+    half = _coverage_case(feasibility_summary, "half_coverage_quarter_shifts")
+    full = _coverage_case(feasibility_summary, "full_coverage_quarter_shifts")
+
+    assert half["grid_points"] == 64
+    assert half["covered_grid_point_count"] == 32
+    assert half["coverage_fraction"] == pytest.approx(0.5)
+    assert full["grid_points"] == 64
+    assert full["covered_grid_point_count"] == 64
+    assert full["coverage_fraction"] == pytest.approx(1.0)
+
+    for case in (half, full):
+        assert len(case["base_windows"]) == 1
+        assert len(case["shifts"]) == 4
+        assert 0 <= case["min_coverage_count"] <= case["max_coverage_count"] <= len(case["shifts"])
+        assert np.isfinite(case["mean_coverage_count"])
+        assert case["mean_coverage_count"] >= 0.0
+        assert isinstance(case["max_uncovered_run_points"], int)
+        assert case["max_uncovered_run_points"] >= 0
+
+
+def test_transform_consistency_preserves_structure_and_residuals(
+    feasibility_summary: dict[str, object],
+) -> None:
+    cases = feasibility_summary["transform_consistency_cases"]
+    assert isinstance(cases, list)
+    assert {case["field_name"] for case in cases} == {"heat_default", "kdv_default"}
+
+    for case in cases:
+        assert isinstance(case, dict)
+        assert case["equation"] in {"heat_1d", "kdv_normalized"}
+        assert len(case["shifts"]) == 5
+        shift_reports = case["shift_reports"]
+        assert isinstance(shift_reports, list)
+        assert len(shift_reports) == len(case["shifts"])
+
+        for report in shift_reports:
+            assert report["dims_preserved"] is True
+            assert report["coords_preserved"] is True
+            assert report["var_names_preserved"] is True
+            assert report["metadata_preserved"] is True
+            assert report["mask_preserved"] is True
+            assert report["inverse_relative_l2_error"] <= 1e-8
+            assert report["period_wrap_relative_l2_error"] <= 1e-8
+            assert np.isfinite(report["residual_rms_before"])
+            assert np.isfinite(report["residual_rms_after"])
+            assert report["residual_relative_rms_delta"] <= 1e-6
+            assert report["provenance_operation"] == "invariant_apply"
+            assert report["provenance_construction_method"] == "uniform_translation"
+            assert report["preprocess_log_length_delta"] == 1
+
+
+def test_orbit_coverage_feasibility_adds_no_public_surface() -> None:
+    reporting_module = importlib.import_module("pdelie.reporting")
+    data_module = importlib.import_module("pdelie.data")
+    residuals_module = importlib.import_module("pdelie.residuals")
+
+    for name in (
+        "summarize_orbit_coverage",
+        "summarize_orbit_coverage_feasibility",
+        "run_orbit_coverage_feasibility",
+        "augment_translation_orbit",
+        "build_translation_orbit_views",
+        "compute_coverage_diagnostics",
+    ):
+        assert not hasattr(pdelie, name)
+        assert not hasattr(reporting_module, name)
+        assert not hasattr(data_module, name)
+
+    assert not hasattr(residuals_module, "evaluate_weak_ks_residual")
+    assert not hasattr(residuals_module, "WeakKSResidualEvaluator")
+    assert not hasattr(residuals_module, "WeakKuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(data_module, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "generate_ks_1d_field_batch")
+    assert not hasattr(pdelie, "KSResidualEvaluator")

--- a/tests/test_polynomial_translation.py
+++ b/tests/test_polynomial_translation.py
@@ -11,6 +11,34 @@ from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import normalize_translation_coefficients, translation_span_distance
 
 
+def _assert_common_fit_diagnostics(generator: GeneratorFamily) -> None:
+    diagnostics = generator.diagnostics
+    for key in (
+        "basis",
+        "basis_delta_norms",
+        "condition_number",
+        "design_column_norms",
+        "evidence_label",
+        "fit_residual",
+        "selected_coefficients",
+        "selected_span_distance",
+        "singular_values",
+        "svd_coefficients",
+        "svd_span_distance",
+        "training_epsilon",
+    ):
+        assert key in diagnostics
+
+    assert diagnostics["design_column_norms"] == diagnostics["basis_delta_norms"]
+    assert diagnostics["condition_number"] > 0.0
+    assert np.all(np.isfinite(np.asarray(diagnostics["singular_values"], dtype=float)))
+    np.testing.assert_allclose(
+        np.asarray(diagnostics["selected_coefficients"], dtype=float),
+        generator.coefficients[0],
+    )
+    assert diagnostics["selected_span_distance"] == pytest.approx(translation_span_distance(generator.coefficients))
+
+
 def test_translation_baseline_recovers_spatial_translation_span() -> None:
     field = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=10)
     generator = fit_translation_generator(field, HeatResidualEvaluator(), epsilon=1e-4)
@@ -21,6 +49,8 @@ def test_translation_baseline_recovers_spatial_translation_span() -> None:
     assert translation_span_distance(generator.coefficients) < 5e-2
     assert generator.diagnostics["fit_mode"] == "svd"
     assert generator.diagnostics["reference_fallback_used"] is False
+    assert generator.diagnostics["evidence_label"] == "direct_svd_in_tolerance"
+    _assert_common_fit_diagnostics(generator)
     np.testing.assert_allclose(generator.coefficients[0], np.asarray(generator.diagnostics["svd_coefficients"], dtype=float))
 
 
@@ -39,7 +69,9 @@ def test_translation_baseline_recovers_spatial_translation_span_on_burgers() -> 
     assert generator.diagnostics["fit_mode"] == "reference_fallback"
     assert generator.diagnostics["reference_fallback_used"] is True
     assert generator.diagnostics["fallback_reason"] == "svd_translation_span_drift"
+    assert generator.diagnostics["evidence_label"] == "reference_fallback"
     assert generator.diagnostics["min_delta_basis"] == "1"
+    _assert_common_fit_diagnostics(generator)
     assert generator.diagnostics["svd_span_distance"] > 5e-2
     np.testing.assert_allclose(generator.coefficients, np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float))
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -53,6 +53,7 @@ def test_runtime_package_api_is_importable() -> None:
     )
     from pdelie.residuals import KdVResidualEvaluator, evaluate_weak_burgers_residual, evaluate_weak_heat_residual
     from pdelie.reporting import (
+        summarize_generator_fit_diagnostics,
         summarize_generator_family,
         summarize_residual_batch,
         summarize_verification_report,
@@ -84,6 +85,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert KdVResidualEvaluator is not None
     assert evaluate_weak_burgers_residual is not None
     assert evaluate_weak_heat_residual is not None
+    assert summarize_generator_fit_diagnostics is not None
     assert summarize_generator_family is not None
     assert summarize_residual_batch is not None
     assert summarize_verification_report is not None
@@ -123,6 +125,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "subsample_time")
     assert not hasattr(pdelie, "subsample_x")
     assert not hasattr(pdelie, "summarize_recovery_grid")
+    assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
     assert not hasattr(pdelie, "summarize_generator_family")
     assert not hasattr(pdelie, "summarize_residual_batch")
     assert not hasattr(pdelie, "summarize_verification_report")
@@ -196,6 +199,7 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
 def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
     reporting_module = importlib.import_module("pdelie.reporting")
 
+    assert hasattr(reporting_module, "summarize_generator_fit_diagnostics")
     assert hasattr(reporting_module, "summarize_generator_family")
     assert hasattr(reporting_module, "summarize_residual_batch")
     assert hasattr(reporting_module, "summarize_verification_report")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -114,12 +114,18 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "add_gaussian_noise")
     assert not hasattr(pdelie, "build_translation_canonical_discovery_inputs")
+    assert not hasattr(pdelie, "build_translation_orbit_views")
+    assert not hasattr(pdelie, "augment_translation_orbit")
     assert not hasattr(pdelie, "compute_weak_derivatives")
+    assert not hasattr(pdelie, "compute_coverage_diagnostics")
     assert not hasattr(pdelie, "evaluate_weak_burgers_residual")
     assert not hasattr(pdelie, "evaluate_weak_heat_residual")
+    assert not hasattr(pdelie, "evaluate_weak_ks_residual")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "fit_pysindy_discovery")
+    assert not hasattr(pdelie, "from_pdebench")
     assert not hasattr(pdelie, "from_numpy")
+    assert not hasattr(pdelie, "from_the_well")
     assert not hasattr(pdelie, "from_xarray")
     assert not hasattr(pdelie, "split_batch_train_heldout")
     assert not hasattr(pdelie, "subsample_time")
@@ -127,6 +133,8 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "summarize_recovery_grid")
     assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
     assert not hasattr(pdelie, "summarize_generator_family")
+    assert not hasattr(pdelie, "summarize_orbit_coverage")
+    assert not hasattr(pdelie, "summarize_orbit_coverage_feasibility")
     assert not hasattr(pdelie, "summarize_residual_batch")
     assert not hasattr(pdelie, "summarize_verification_report")
     assert not hasattr(pdelie, "summarize_vertical_slice")
@@ -141,6 +149,8 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "generate_ks_feasibility_field_batch")
     assert not hasattr(pdelie, "KSResidualEvaluator")
     assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(pdelie, "WeakKSResidualEvaluator")
+    assert not hasattr(pdelie, "OperatorSymmetry")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "sample_kdv_mode_coefficients")
     assert not hasattr(pdelie, "compare_generator_spans")
@@ -171,8 +181,15 @@ def test_data_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(data_module, "subsample_time")
     assert hasattr(data_module, "subsample_x")
     assert hasattr(data_module, "split_batch_train_heldout")
+    assert not hasattr(data_module, "augment_translation_orbit")
+    assert not hasattr(data_module, "build_translation_orbit_views")
+    assert not hasattr(data_module, "compute_coverage_diagnostics")
+    assert not hasattr(data_module, "from_pdebench")
+    assert not hasattr(data_module, "from_the_well")
     assert not hasattr(data_module, "generate_ks_1d_field_batch")
     assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
+    assert not hasattr(data_module, "load_pdebench")
+    assert not hasattr(data_module, "load_the_well")
     assert not hasattr(data_module, "sample_kdv_mode_coefficients")
 
 
@@ -187,9 +204,12 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(residuals_module, "evaluate_weak_burgers_residual")
     assert not hasattr(residuals_module, "compute_weak_derivatives")
     assert not hasattr(residuals_module, "evaluate_weak_kdv_residual")
+    assert not hasattr(residuals_module, "evaluate_weak_ks_residual")
     assert not hasattr(residuals_module, "WeakHeatResidualEvaluator")
     assert not hasattr(residuals_module, "WeakBurgersResidualEvaluator")
     assert not hasattr(residuals_module, "WeakKdVResidualEvaluator")
+    assert not hasattr(residuals_module, "WeakKSResidualEvaluator")
+    assert not hasattr(residuals_module, "WeakKuramotoSivashinskyResidualEvaluator")
     assert not hasattr(residuals_module, "KSResidualEvaluator")
     assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(residuals_module, "KDVResidualEvaluator")
@@ -201,6 +221,8 @@ def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
 
     assert hasattr(reporting_module, "summarize_generator_fit_diagnostics")
     assert hasattr(reporting_module, "summarize_generator_family")
+    assert not hasattr(reporting_module, "summarize_orbit_coverage")
+    assert not hasattr(reporting_module, "summarize_orbit_coverage_feasibility")
     assert hasattr(reporting_module, "summarize_residual_batch")
     assert hasattr(reporting_module, "summarize_verification_report")
     assert hasattr(reporting_module, "summarize_vertical_slice")
@@ -212,6 +234,8 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
 
     assert hasattr(examples_module, "run_heat_vertical_slice_example")
     assert hasattr(examples_module, "run_kdv_vertical_slice_example")
+    assert not hasattr(examples_module, "run_ks_vertical_slice_example")
+    assert not hasattr(examples_module, "run_orbit_coverage_feasibility")
 
 
 def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> None:
@@ -242,6 +266,8 @@ def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     assert hasattr(symmetry_module, "compare_generator_spans")
     assert hasattr(symmetry_module, "render_generator_family")
     assert hasattr(symmetry_module, "to_sympy_component_expressions")
+    assert not hasattr(symmetry_module, "OperatorSymmetry")
+    assert not hasattr(symmetry_module, "build_translation_orbit_views")
 
 
 def test_viz_package_runtime_api_matches_frozen_m5_surface() -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -6,24 +6,49 @@ import json
 import numpy as np
 import pytest
 
-from pdelie.contracts import ResidualBatch
+from pdelie.contracts import GeneratorFamily, ResidualBatch, _translation_generator_basis_spec
 from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_batch
 from pdelie.derivatives import compute_spectral_fd_derivatives
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 from pdelie.reporting import (
+    summarize_generator_fit_diagnostics,
     summarize_generator_family,
     summarize_residual_batch,
     summarize_verification_report,
     summarize_vertical_slice,
     summarize_weak_residual_report,
 )
-from pdelie.residuals import HeatResidualEvaluator, evaluate_weak_burgers_residual, evaluate_weak_heat_residual
+from pdelie.residuals import (
+    BurgersResidualEvaluator,
+    HeatResidualEvaluator,
+    evaluate_weak_burgers_residual,
+    evaluate_weak_heat_residual,
+)
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import translation_span_distance
 from pdelie.verification import verify_translation_generator
 
 
 _SUMMARY_PREFIX_KEYS = {"summary_schema_version", "summary_type"}
+_FIT_DIAGNOSTIC_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
+    "parameterization",
+    "fit_mode",
+    "training_epsilon",
+    "basis",
+    "basis_delta_norms",
+    "design_column_norms",
+    "singular_values",
+    "condition_number",
+    "fit_residual",
+    "min_delta_basis",
+    "selected_coefficients",
+    "svd_coefficients",
+    "selected_span_distance",
+    "svd_span_distance",
+    "reference_fallback_used",
+    "fallback_reason",
+    "evidence_label",
+}
 
 
 @pytest.fixture(scope="module")
@@ -130,6 +155,68 @@ def test_summarize_generator_family_reports_translation_fit_fields(heat_artifact
     _assert_json_serializable(summary)
 
 
+def test_summarize_generator_fit_diagnostics_reports_direct_svd_fit(heat_artifacts: dict[str, object]) -> None:
+    generator = heat_artifacts["generator"]
+
+    summary = summarize_generator_fit_diagnostics(generator)
+
+    assert set(summary) == _FIT_DIAGNOSTIC_SUMMARY_KEYS
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "generator_fit_diagnostics"
+    assert summary["parameterization"] == generator.parameterization
+    assert summary["fit_mode"] == "svd"
+    assert summary["training_epsilon"] == pytest.approx(1e-4)
+    assert summary["basis"] == generator.diagnostics["basis"]
+    assert summary["basis_delta_norms"] == generator.diagnostics["basis_delta_norms"]
+    assert summary["design_column_norms"] == generator.diagnostics["design_column_norms"]
+    assert np.all(np.isfinite(summary["singular_values"]))
+    assert summary["condition_number"] > 0.0
+    assert summary["fit_residual"] == pytest.approx(generator.diagnostics["fit_residual"])
+    assert summary["min_delta_basis"] == generator.diagnostics["min_delta_basis"]
+    assert summary["selected_coefficients"] == pytest.approx(generator.coefficients[0].tolist())
+    assert summary["svd_coefficients"] == pytest.approx(generator.diagnostics["svd_coefficients"])
+    assert summary["selected_span_distance"] == pytest.approx(translation_span_distance(generator.coefficients))
+    assert summary["svd_span_distance"] == pytest.approx(generator.diagnostics["svd_span_distance"])
+    assert summary["reference_fallback_used"] is False
+    assert summary["fallback_reason"] is None
+    assert summary["evidence_label"] == "direct_svd_in_tolerance"
+    _assert_json_serializable(summary)
+
+
+def test_summarize_generator_fit_diagnostics_reports_reference_fallback_fit() -> None:
+    field = generate_burgers_1d_field_batch(batch_size=4, num_times=33, num_points=64, seed=2010)
+    generator = fit_translation_generator(field, BurgersResidualEvaluator(), epsilon=1e-4)
+
+    summary = summarize_generator_fit_diagnostics(generator)
+
+    assert summary["fit_mode"] == "reference_fallback"
+    assert summary["reference_fallback_used"] is True
+    assert summary["fallback_reason"] == "svd_translation_span_drift"
+    assert summary["evidence_label"] == "reference_fallback"
+    assert summary["selected_span_distance"] <= 5e-2
+    assert summary["svd_span_distance"] > 5e-2
+    _assert_json_serializable(summary)
+
+
+def test_summarize_generator_fit_diagnostics_reports_unavailable_for_sparse_diagnostics() -> None:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={"singular_values": [2.0, 0.0]},
+    )
+
+    summary = summarize_generator_fit_diagnostics(generator)
+
+    assert set(summary) == _FIT_DIAGNOSTIC_SUMMARY_KEYS
+    assert summary["condition_number"] is None
+    assert summary["evidence_label"] == "unavailable"
+    assert summary["selected_coefficients"] == [1.0, 0.0, 0.0, 0.0]
+    assert summary["selected_span_distance"] == pytest.approx(0.0)
+    _assert_json_serializable(summary)
+
+
 def test_summarize_verification_report_returns_sweep_metrics(heat_artifacts: dict[str, object]) -> None:
     report = heat_artifacts["verification"]
 
@@ -200,6 +287,7 @@ def test_summarize_vertical_slice_defaults_extra_metrics_to_empty_mapping(heat_a
     ("helper", "argument"),
     [
         (summarize_residual_batch, object()),
+        (summarize_generator_fit_diagnostics, object()),
         (summarize_generator_family, object()),
         (summarize_verification_report, object()),
         (summarize_weak_residual_report, object()),
@@ -284,6 +372,7 @@ def test_reporting_helpers_do_not_mutate_inputs(heat_artifacts: dict[str, object
     verification_snapshot = verification.to_dict()
 
     summarize_residual_batch(residual)
+    summarize_generator_fit_diagnostics(generator)
     summarize_generator_family(generator)
     summarize_verification_report(verification)
     summarize_weak_residual_report(weak_report)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -217,6 +217,78 @@ def test_summarize_generator_fit_diagnostics_reports_unavailable_for_sparse_diag
     _assert_json_serializable(summary)
 
 
+def test_summarize_generator_fit_diagnostics_normalizes_nonfinite_optional_scalars() -> None:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={
+            "training_epsilon": np.inf,
+            "fit_residual": np.nan,
+            "singular_values": [2.0, 1.0],
+        },
+    )
+
+    summary = summarize_generator_fit_diagnostics(generator)
+
+    assert summary["training_epsilon"] is None
+    assert summary["fit_residual"] is None
+    assert summary["condition_number"] == pytest.approx(2.0)
+    _assert_json_serializable(summary)
+
+
+def test_summarize_generator_fit_diagnostics_rejects_non_scalar_mapping_values() -> None:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={
+            "basis_delta_norms": {"1": [1.0, 2.0]},
+            "singular_values": [2.0, 1.0],
+        },
+    )
+
+    with pytest.raises(SchemaValidationError, match=r"basis_delta_norms\.1"):
+        summarize_generator_fit_diagnostics(generator)
+
+
+def test_summarize_generator_fit_diagnostics_rejects_non_floatlike_mapping_values() -> None:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={
+            "design_column_norms": {"1": "not-a-number"},
+            "singular_values": [2.0, 1.0],
+        },
+    )
+
+    with pytest.raises(SchemaValidationError, match=r"design_column_norms\.1"):
+        summarize_generator_fit_diagnostics(generator)
+
+
+def test_summarize_generator_fit_diagnostics_computes_condition_number_from_unsorted_singular_values() -> None:
+    generator = GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.array([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={
+            "singular_values": [1.0, 4.0, 2.0],
+            "condition_number": 99.0,
+        },
+    )
+
+    summary = summarize_generator_fit_diagnostics(generator)
+
+    assert summary["condition_number"] == pytest.approx(4.0)
+    assert summary["singular_values"] == [1.0, 4.0, 2.0]
+    _assert_json_serializable(summary)
+
+
 def test_summarize_verification_report_returns_sweep_metrics(heat_artifacts: dict[str, object]) -> None:
     report = heat_artifacts["verification"]
 

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_11-release-gate"]
-    assert "python -m pytest tests/test_v0_11_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_12-release-gate"]
+    assert "python -m pytest tests/test_v0_12_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
-    for historical_job in range(4, 11):
+    for historical_job in range(4, 12):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import re
-import tomllib
 from pathlib import Path
 
 import numpy as np
@@ -74,7 +73,6 @@ def test_v0_11_release_gate_ks_closeout_remains_reference_fallback_no_go() -> No
 
 
 def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
-    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
     readiness = _repo_text("docs/releases/V0_11_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
@@ -82,15 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.11.0"
-    assert release_gate_jobs == ["v0_11-release-gate"]
-    assert "python -m pytest tests/test_v0_11_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_12-release-gate"]
+    assert "python -m pytest tests/test_v0_12_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.11" in readme
+    assert "V0.12" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.11.0`" in publishing
+    assert "including `v0.12.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie.contracts import GeneratorFamily, _translation_generator_basis_spec
+from pdelie.reporting import summarize_generator_fit_diagnostics
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def _diagnostic_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={
+            "fit_mode": "svd",
+            "training_epsilon": 1e-4,
+            "basis": ["1", "t", "x", "u"],
+            "basis_delta_norms": {"1": 1.0, "t": 2.0, "x": 3.0, "u": 4.0},
+            "design_column_norms": {"1": 1.0, "t": 2.0, "x": 3.0, "u": 4.0},
+            "singular_values": [4.0, 2.0, 1.0],
+            "condition_number": 4.0,
+            "fit_residual": 1e-8,
+            "min_delta_basis": "1",
+            "selected_coefficients": [1.0, 0.0, 0.0, 0.0],
+            "svd_coefficients": [1.0, 0.0, 0.0, 0.0],
+            "selected_span_distance": 0.0,
+            "svd_span_distance": 0.0,
+            "reference_fallback_used": False,
+            "fallback_reason": None,
+            "evidence_label": "direct_svd_in_tolerance",
+        },
+    )
+
+
+def test_v0_12_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_12_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_12_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.12.0"
+    assert release_gate_jobs == ["v0_12-release-gate"]
+    assert "python -m pytest tests/test_v0_12_release_gate.py" in workflow
+    assert "v0_11-release-gate" not in workflow
+
+    assert "## 0.12.0" in changelog
+    assert "V0.12" in readme
+    assert "summarize_generator_fit_diagnostics" in readme
+    assert "package version: `0.12.0`" in readiness
+    assert "git tag: `v0.12.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.12`" in readiness
+    assert "including `v0.12.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.12` - Diagnostics and supportability hardening" in roadmap
+    assert "**Status:** Completed" in roadmap
+
+
+def test_v0_12_release_gate_fit_diagnostic_helper_is_documented_and_submodule_only() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    reporting_module = importlib.import_module("pdelie.reporting")
+    summary = summarize_generator_fit_diagnostics(_diagnostic_generator())
+
+    assert hasattr(reporting_module, "summarize_generator_fit_diagnostics")
+    assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
+    assert "pdelie.reporting.summarize_generator_fit_diagnostics" in api_stability
+    assert "Runtime public API for the frozen `v0.12` Milestone 2 slice" in api_stability
+
+    assert json.loads(json.dumps(summary)) == summary
+    assert summary["summary_type"] == "generator_fit_diagnostics"
+    assert summary["singular_values"] == [4.0, 2.0, 1.0]
+    assert summary["condition_number"] == 4.0
+    assert summary["selected_span_distance"] == 0.0
+    assert summary["svd_span_distance"] == 0.0
+    assert summary["reference_fallback_used"] is False
+    assert summary["fallback_reason"] is None
+    assert summary["evidence_label"] == "direct_svd_in_tolerance"
+
+
+def test_v0_12_release_gate_internal_diagnostics_remain_non_public() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    modules = [
+        pdelie,
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.examples"),
+        importlib.import_module("pdelie.discovery"),
+    ]
+    forbidden_names = {
+        "augment_translation_orbit",
+        "build_translation_orbit_views",
+        "compute_coverage_diagnostics",
+        "compute_weak_derivatives",
+        "evaluate_weak_ks_residual",
+        "from_pdebench",
+        "from_the_well",
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "load_pdebench",
+        "load_the_well",
+        "run_ks_vertical_slice_example",
+        "summarize_orbit_coverage",
+        "summarize_orbit_coverage_feasibility",
+        "WeakKSResidualEvaluator",
+    }
+
+    for module in modules:
+        for name in sorted(forbidden_names):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"
+
+    for name in sorted(forbidden_names):
+        assert f"pdelie.{name}" not in api_stability
+
+
+def test_v0_12_release_gate_does_not_promote_ks_or_orbit_coverage_in_docs() -> None:
+    readme = _repo_text("README.md")
+    readiness = _repo_text("docs/releases/V0_12_RELEASE_READINESS.md")
+    scope = _repo_text("docs/planning/V0_12_SCOPE.md")
+
+    assert "internal KS diagnostic sweep" in readme
+    assert "internal orbit/coverage diagnostic feasibility" in readme
+    assert "no stable KS runtime API is promoted" in readiness
+    assert "no public orbit/coverage helper" in readiness
+    assert "no public augmentation utility" in readiness
+    assert "M3 internal KS diagnostics and M4 orbit/coverage diagnostics remain internal" in scope


### PR DESCRIPTION
**Title:** V0.12 diagnostics/supportability release hardening

**Summary**
Closes `v0.12` as a diagnostics and supportability release. This release adds the final release gate/readiness layer around the already-landed generator-fit diagnostic reporting helper, keeps KS and orbit/coverage work internal, and aligns package metadata and release docs for `0.12.0`.

**What Changed**
- Bumped package metadata to `0.12.0`.
- Added compact `tests/test_v0_12_release_gate.py`.
- Replaced CI’s explicit current release gate with `v0_12-release-gate`.
- Added package-smoke coverage for `pdelie.reporting.summarize_generator_fit_diagnostics`.
- Added `docs/releases/V0_12_RELEASE_READINESS.md`.
- Updated README, changelog, roadmap, plan, scope, and publishing docs for V0.12.
- Updated historical gate/audit tests to recognize `v0_12-release-gate` as the current CI gate.

**Release Scope**
V0.12 is supportability-only:
- public addition: `pdelie.reporting.summarize_generator_fit_diagnostics`
- internal evidence only: KS diagnostic sweep and orbit/coverage feasibility
- no KS promotion
- no new PDE
- no weak KS
- no public orbit/coverage or augmentation APIs
- no broad adapters or package-index publishing

**Validation**
- `.venv/bin/python -m pytest`  
  `590 passed, 2 skipped`
- `.venv/bin/python -m build --sdist --wheel`
- clean wheel smoke from `dist/pdelie-0.12.0-py3-none-any.whl`
- `.venv/bin/python -m pdelie.examples.heat_vertical_slice`
- `.venv/bin/python -m pdelie.examples.kdv_vertical_slice`
- `git diff --check`