### PR TITLE
Implemented the v0.14 plan, updated docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_13-release-gate:
+  v0_14-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.13 release gate
-        run: python -m pytest tests/test_v0_13_release_gate.py
+      - name: Run V0.14 release gate
+        run: python -m pytest tests/test_v0_14_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +68,7 @@ jobs:
           python -m pdelie.examples.heat_vertical_slice
           python -m pdelie.examples.kdv_vertical_slice
           python -m pdelie.examples.orbit_coverage_diagnostics
+          python -m pdelie.examples.invariant_workflow_summary
   package-smoke:
     runs-on: ubuntu-latest
     steps:
@@ -122,10 +123,15 @@ jobs:
           import pdelie
 
           from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport
-          from pdelie.invariants import compute_periodic_window_coverage, diagnose_uniform_translation_consistency
+          from pdelie.invariants import (
+              compute_periodic_window_coverage,
+              diagnose_uniform_translation_consistency,
+              summarize_uniform_translation_orbit,
+          )
           from pdelie.reporting import (
               summarize_generator_fit_diagnostics,
               summarize_generator_family,
+              summarize_invariant_workflow,
               summarize_residual_batch,
               summarize_verification_report,
               summarize_vertical_slice,
@@ -140,8 +146,10 @@ jobs:
           assert VerificationReport is not None
           assert compute_periodic_window_coverage is not None
           assert diagnose_uniform_translation_consistency is not None
+          assert summarize_uniform_translation_orbit is not None
           assert summarize_generator_fit_diagnostics is not None
           assert summarize_generator_family is not None
+          assert summarize_invariant_workflow is not None
           assert summarize_residual_batch is not None
           assert summarize_verification_report is not None
           assert summarize_vertical_slice is not None
@@ -150,6 +158,8 @@ jobs:
           assert not hasattr(pdelie, "summarize_vertical_slice")
           assert not hasattr(pdelie, "compute_periodic_window_coverage")
           assert not hasattr(pdelie, "diagnose_uniform_translation_consistency")
+          assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
+          assert not hasattr(pdelie, "summarize_invariant_workflow")
           print("stable-import-ok")
           PY
       - name: Invariant diagnostics smoke
@@ -160,7 +170,12 @@ jobs:
           import pdelie
 
           from pdelie.data import generate_heat_1d_field_batch
-          from pdelie.invariants import compute_periodic_window_coverage, diagnose_uniform_translation_consistency
+          from pdelie.invariants import (
+              compute_periodic_window_coverage,
+              diagnose_uniform_translation_consistency,
+              summarize_uniform_translation_orbit,
+          )
+          from pdelie.reporting import summarize_invariant_workflow
           from pdelie.residuals import HeatResidualEvaluator
 
           domain_length = 2.0 * np.pi
@@ -185,9 +200,29 @@ jobs:
           assert consistency["summary_type"] == "uniform_translation_consistency"
           assert all(report["inverse_passed"] for report in consistency["shift_reports"])
           assert all(report["period_wrap_passed"] for report in consistency["shift_reports"])
+          orbit = summarize_uniform_translation_orbit(
+              field,
+              shifts=[0.0, domain_length],
+              windows=[{"start": 0.0, "width": domain_length / 4.0}],
+              residual_evaluator=HeatResidualEvaluator(),
+              source_field_id="package-smoke-heat",
+          )
+          workflow = summarize_invariant_workflow(
+              orbit=orbit,
+              coverage=orbit["coverage"],
+              consistency=orbit["consistency"],
+              extra_metrics={"smoke": "invariant_workflow"},
+          )
+          json.dumps(workflow)
+          assert orbit["summary_type"] == "uniform_translation_orbit"
+          assert orbit["orbit_passed"] is True
+          assert workflow["summary_type"] == "invariant_workflow"
           assert not hasattr(pdelie, "compute_periodic_window_coverage")
           assert not hasattr(pdelie, "diagnose_uniform_translation_consistency")
+          assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
+          assert not hasattr(pdelie, "summarize_invariant_workflow")
           assert not hasattr(pdelie, "augment_translation_orbit")
+          assert not hasattr(pdelie, "build_translation_orbit_dataset")
           print("invariant-diagnostics-smoke-ok")
           PY
       - name: Generator fit diagnostics smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.14.0
+
+First final release for the frozen V0.14 invariant workflow summary and read-only translation orbit report slice.
+
+- adds `pdelie.reporting.summarize_invariant_workflow(...)` for JSON-compatible runtime summaries that combine coverage, consistency, orbit, generator, fit-diagnostic, verification, and extra-metric reports
+- adds `pdelie.invariants.summarize_uniform_translation_orbit(...)` for read-only uniform `x`-translation orbit reports over canonical scalar 1D periodic `FieldBatch` inputs
+- adds `python -m pdelie.examples.invariant_workflow_summary` and `pdelie.examples.run_invariant_workflow_summary_example(...)` as runtime smoke examples combining Heat, KdV, coverage, orbit, fit, and verification summaries
+- documents the new helpers in `API_STABILITY.md` as submodule-only runtime APIs with no root exports
+- tightens public-surface guards so augmentation, orbit datasets, time translation, KS APIs, weak KS, broad adapters, and root runtime exports remain absent
+- updates CI to the compact current `v0_14-release-gate` while preserving full editable tests and package smoke
+- preserves the prior Heat/Burgers strong paths, `v0.8` weak residual report APIs, `v0.9` normalized periodic KdV strong path, `v0.10` reporting helpers, `v0.11` order-4 derivatives, `v0.12` fit diagnostics, and `v0.13` orbit/coverage diagnostics
+
+Explicitly deferred for this final release:
+
+- augmented datasets or orbit dataset builders
+- transformed `FieldBatch` collections from reporting helpers
+- time-translation APIs or `axis="time"` support
+- new PDE support
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak API, or root KS exports
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- private-paper experiment policy, tables, figures, thresholds, or branch logic
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.13.0
 
 First final release for the frozen V0.13 public orbit and coverage diagnostics slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.13 public orbit and coverage diagnostics slice for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.14 invariant workflow summary and read-only translation orbit report slice for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -16,6 +16,8 @@ The current repository implements the frozen V0.13 public orbit and coverage dia
 - normalized KdV strong residuals under `pdelie.residuals.KdVResidualEvaluator`
 - internal Kuramoto-Sivashinsky diagnostic sweep evidence with stable runtime promotion deferred
 - public orbit/coverage diagnostics under `pdelie.invariants`
+- invariant workflow summaries under `pdelie.reporting.summarize_invariant_workflow`
+- read-only uniform translation orbit reports under `pdelie.invariants.summarize_uniform_translation_orbit`
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -30,7 +32,7 @@ The current repository implements the frozen V0.13 public orbit and coverage dia
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_13-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_14-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -79,7 +81,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.13`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.14`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -87,6 +89,7 @@ The repository includes exploratory notebooks under `notebooks/` for the shipped
 - `03_portability_round_trips.ipynb`
 - `04_discovered_vs_known_translation_generators.ipynb`
 - `05_closure_algebra_diagnostics.ipynb`
+- `06_orbit_coverage_diagnostics.ipynb`
 
 These notebooks are non-normative tutorials, not stability contracts.
 Most discovery notebooks require the downstream extras (`.[downstream]` or `.[test]`).
@@ -99,6 +102,7 @@ Run the packaged example modules from the repo root:
 python -m pdelie.examples.heat_vertical_slice
 python -m pdelie.examples.kdv_vertical_slice
 python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
 ```
 
 Those commands are validated in CI after editable install.
@@ -127,12 +131,21 @@ The orbit/coverage diagnostics example demonstrates:
 3. uniform-translation consistency checks on stable Heat and KdV fixtures
 4. residual RMS stability checks under the existing residual evaluators
 
+The invariant workflow summary example demonstrates:
+
+1. read-only uniform translation orbit reports for Heat and KdV fixtures
+2. coverage and consistency diagnostics nested into one workflow summary
+3. generator fit diagnostics and finite-transform verification summaries
+4. report-only provenance through optional `source_field_id` values
+
 You can also call the examples programmatically.
-They return nested `pdelie.reporting.summarize_vertical_slice(...)` runtime summaries, not canonical artifact schemas:
+They return JSON-compatible runtime summaries, not canonical artifact schemas.
+The Heat and KdV examples return nested `vertical_slice` summaries; the invariant examples return diagnostic/workflow summaries:
 
 ```python
 from pdelie.examples import (
     run_heat_vertical_slice_example,
+    run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
     run_orbit_coverage_diagnostics_example,
 )
@@ -142,6 +155,9 @@ print(result["verification"]["classification"])
 
 coverage = run_orbit_coverage_diagnostics_example()
 print(coverage["coverage_cases"][0]["coverage_fraction"])
+
+workflow = run_invariant_workflow_summary_example()
+print(workflow["workflows"][0]["summary_type"])
 ```
 
 ## Current Scope
@@ -165,9 +181,10 @@ Included in the current stable core:
 - consolidated current release-gate CI visibility while retaining historical gate tests in the full test suite
 - KdV is stable only for the normalized periodic short-horizon strong path; weak KdV remains explicitly deferred
 - KS remains internal feasibility/no-go evidence from `v0.11` plus internal diagnostic sweep evidence in `v0.12`; no stable KS runtime API is promoted
-- orbit/coverage diagnostics in `v0.13` are public under `pdelie.invariants`; they report coverage and consistency but do not construct augmented datasets
+- orbit/coverage diagnostics from `v0.13` are public under `pdelie.invariants`; they report coverage and consistency but do not construct augmented datasets
+- invariant workflow summaries and uniform translation orbit reports in `v0.14` are read-only runtime reports; they do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections
 
-Runtime-level public APIs in the frozen V0.13 slice:
+Runtime-level public APIs in the frozen V0.14 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -183,10 +200,13 @@ Runtime-level public APIs in the frozen V0.13 slice:
 - `pdelie.reporting.summarize_generator_fit_diagnostics` for JSON-compatible summaries of generator-fit diagnostics, singular values, condition number, selected/SVD span distances, fallback status, and evidence labels
 - `pdelie.reporting.summarize_verification_report` for JSON-compatible summaries of finite-transform verification sweeps
 - `pdelie.reporting.summarize_vertical_slice` for nested derivative/residual/generator/verification runtime summaries
+- `pdelie.reporting.summarize_invariant_workflow` for nested coverage, consistency, orbit, generator, fit-diagnostic, verification, and extra-metric runtime summaries
 - `pdelie.invariants.InvariantApplier` for single-generator periodic `x` uniform translation only
 - `pdelie.invariants.compute_periodic_window_coverage` for JSON-compatible grid-point coverage diagnostics over endpoint-excluded periodic 1D grids, half-open windows, and uniform translation shifts
 - `pdelie.invariants.diagnose_uniform_translation_consistency` for JSON-compatible diagnostics of uniform-translation structure, inverse/period-wrap consistency, provenance, and optional residual stability
+- `pdelie.invariants.summarize_uniform_translation_orbit` for read-only uniform `x`-translation orbit reports over canonical scalar 1D periodic `FieldBatch` inputs
 - `pdelie.examples.run_orbit_coverage_diagnostics_example` for a runtime smoke example of the public orbit/coverage diagnostics, not a canonical report schema
+- `pdelie.examples.run_invariant_workflow_summary_example` for a runtime smoke example combining Heat, KdV, coverage, orbit, fit, and verification summaries
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
 - `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support/coefficient recovery metrics over caller-supplied canonical term strings
 - `pdelie.discovery.fit_pysindy_discovery` for a runtime-only backend-native PySINDy fit adapter
@@ -213,6 +233,8 @@ The `v0.12` diagnostics work hardens supportability without changing numerical s
 
 The `v0.13` diagnostics work promotes only the reusable orbit/coverage reporting layer under `pdelie.invariants`. These diagnostics support invariant and finite-transform workflows but do not construct augmented datasets, orbit views, train branches, or manuscript artifacts.
 
+The `v0.14` workflow work adds read-only orbit reports and combined invariant workflow summaries. These helpers combine existing reports and canonical objects into JSON-compatible runtime summaries; they do not construct augmented datasets, orbit datasets, transformed `FieldBatch` collections, or time-translation APIs.
+
 Explicitly deferred:
 - stable multi-generator PDE fitting
 - multi-generator invariant machinery
@@ -228,4 +250,6 @@ Explicitly deferred:
 - general KdV support outside the frozen normalized periodic short-horizon regime
 - stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export
 - public orbit-view builders or augmentation utilities
+- orbit dataset builders or transformed `FieldBatch` collections from reporting helpers
+- time-translation APIs or `axis="time"` support
 - broad adapters and interoperability work

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,18 +1,18 @@
-# PDELie - Execution Plan (V0.13)
+# PDELie - Execution Plan (V0.14)
 
 ## Current Release Status
 
-**V0.13 is complete as public orbit and coverage diagnostics**
+**V0.14 is complete as invariant workflow summaries and read-only translation orbit reports**
 
-This file is the completed execution record for the `v0.13` release series.
+This file is the completed execution record for the `v0.14` release series.
 
 Committed release theme:
 
-`canonical periodic 1D FieldBatch + uniform translation action -> grid-point coverage diagnostics + transform-consistency diagnostics -> compact example/release gate`
+`FieldBatch + uniform x-translation shifts + optional windows + residual/fit/verification outputs -> read-only orbit report + combined invariant workflow summary`
 
 The important release boundary is:
 
-> diagnostics support invariant/finite-transform workflows but do not construct augmented datasets.
+> v0.14 adds read-only runtime reports, not augmented datasets, transformed FieldBatch collections, orbit datasets, or time-translation support.
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -21,27 +21,28 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_13_SCOPE.md`
+- `docs/planning/V0_14_SCOPE.md`
 
-`API_STABILITY.md` was updated when the two public `pdelie.invariants` diagnostics landed.
+`API_STABILITY.md` was updated when the two public `v0.14` reporting/invariant helpers landed.
 
 ---
 
-## V0.12 Closeout
+## V0.13 Closeout
 
 `v0.12` is complete as diagnostics and supportability hardening.
 
+`v0.13` is complete as public orbit and coverage diagnostics.
+
 Completed outcome:
 
-- public `pdelie.reporting.summarize_generator_fit_diagnostics(...)`
-- richer translation-fit diagnostics without changing fitting behavior
-- internal KS diagnostic sweep closeout with no stable KS promotion
-- internal orbit/coverage feasibility evidence
-- API/public-surface audit
-- compact `v0_12-release-gate`
+- public `pdelie.invariants.compute_periodic_window_coverage(...)`
+- public `pdelie.invariants.diagnose_uniform_translation_consistency(...)`
+- JSON-only orbit/coverage diagnostics example
+- no public augmentation utilities or orbit-view builders
+- compact `v0_13-release-gate`
 
-`v0.13` begins from that feasibility evidence and promotes only the reusable orbit/coverage diagnostics.
-It does not promote augmentation policy or KS runtime APIs.
+`v0.14` begins from that diagnostic evidence and promotes only read-only workflow summaries and orbit reports.
+It does not promote augmentation policy, transformed datasets, time translation, or KS runtime APIs.
 
 ---
 
@@ -51,20 +52,22 @@ It does not promote augmentation policy or KS runtime APIs.
 
 ### Goal
 
-Freeze `v0.13` as a public diagnostics promotion release under `pdelie.invariants`.
+Freeze `v0.14` as invariant workflow summaries plus read-only uniform translation orbit reports.
 
 ### Completed Outcome
 
-- added `docs/planning/V0_13_SCOPE.md`
-- reset `PLAN.md` as the active `v0.13` execution record
-- updated `ROADMAP.md` to record `v0.13` as the current completed diagnostics release
-- recorded that the release adds diagnostics only:
+- added `docs/planning/V0_14_SCOPE.md`
+- reset `PLAN.md` as the active `v0.14` execution record
+- updated `ROADMAP.md` to record `v0.14` as the current completed supportability release
+- recorded explicit non-goals:
   - no augmented datasets
-  - no orbit-view builders
+  - no transformed `FieldBatch` collections
+  - no orbit dataset builders
+  - no time-translation API
   - no KS promotion
   - no new PDE
   - no broad adapters
-  - no private-paper experiment policy
+  - no root export expansion
 
 ---
 
@@ -74,120 +77,104 @@ Freeze `v0.13` as a public diagnostics promotion release under `pdelie.invariant
 
 ### Goal
 
-Freeze the exact public semantics before implementation.
+Freeze report schemas and semantics before implementation.
 
 ### Completed Outcome
 
-For `compute_periodic_window_coverage(...)`, M1 froze:
-
-- endpoint-excluded uniform periodic 1D grid convention
-- inferred domain length as `len(x) * dx`
-- endpoint-duplicated grid rejection
-- grid-point coverage, not continuous interval measure
-- `coverage_fraction = covered_grid_points / num_grid_points`
-- half-open windows `[start, start + width)`
-- modulo reduction for coordinates, starts, and shifts
-- deterministic boundary tolerance `1e-12 * domain_length`
-- duplicate shifts and repeated windows are allowed and counted
-- repeated windows increase coverage counts but not covered point count
-- max uncovered run is reported in grid points and physical length
-- positive shift convention:
-  - `coverage_convention = "preimage_of_fixed_window_under_translation"`
-  - `shift_convention = "field_shift_then_fixed_window"`
-  - point `x0` is covered when `(x0 + shift) mod domain_length` lies inside the fixed window
-
-For `diagnose_uniform_translation_consistency(...)`, M1 froze:
+For `summarize_uniform_translation_orbit(...)`, M1 froze:
 
 - canonical scalar 1D uniform periodic `FieldBatch` scope
-- use of `InvariantApplier` and uniform translation
-- report-only behavior with no returned transformed `FieldBatch` objects
+- read-only report output
+- no returned transformed `FieldBatch` objects
 - no input mutation
-- shift equal to domain length is identity-equivalent within tolerance
-- dims, shape, coords, metadata, var names, and mask structure/content preservation checks
-- preprocess-log equality is not required
-- appended provenance checks for `operation == "invariant_apply"` and `construction_method == "uniform_translation"`
-- inverse and period-wrap relative L2 error definitions
-- residual RMS absolute/relative delta policy
-- residual stability pass rule:
-  - `absolute_delta <= 1e-8 or relative_delta <= 1e-6`
-- evaluator failures are fatal typed validation errors when a residual evaluator is supplied
+- raw shift order and duplicate shifts are preserved
+- optional `source_field_id` is JSON-compatible provenance metadata only
+- optional windows reuse `v0.13` periodic-window coverage semantics
+- optional residual evaluator reuses `v0.13` translation-consistency semantics
+- per-shift transform spec and provenance summaries are reported
+
+For `summarize_invariant_workflow(...)`, M1 froze:
+
+- JSON-compatible runtime summary output
+- nested coverage, consistency, orbit, generator, fit, and verification summaries
+- canonical `GeneratorFamily` and `VerificationReport` inputs are summarized through existing reporting helpers
+- existing `v0.10` and `v0.12` reporting schemas remain unchanged
+
+Time translation remains deferred.
 
 ---
 
-## Milestone 2 - Periodic Coverage Diagnostic
+## Milestone 2 - Combined Invariant Workflow Summary
 
 **Status:** COMPLETE
 
 ### Goal
 
-Promote periodic-window coverage diagnostics from `v0.12` feasibility into runtime.
+Add the combined workflow report helper under `pdelie.reporting`.
 
 ### Completed Outcome
 
 - added public submodule-only helper:
-  - `pdelie.invariants.compute_periodic_window_coverage(...)`
-- returned JSON-compatible dicts with:
-  - `summary_schema_version = "0.1"`
-  - `summary_type = "periodic_window_coverage"`
-  - domain length, inferred domain length, `dx`, grid point count
-  - raw/normalized windows and shifts
-  - coverage counts
-  - covered point count and coverage fraction
-  - min/max/mean coverage count
-  - max uncovered run in grid points and physical length
-- implemented typed validation for invalid grids, endpoint duplication, invalid windows, invalid shifts, and invalid domain lengths
+  - `pdelie.reporting.summarize_invariant_workflow(...)`
+- supports:
+  - `periodic_window_coverage` reports
+  - `uniform_translation_consistency` reports
+  - `uniform_translation_orbit` reports
+  - `GeneratorFamily` objects or `generator_family` summaries
+  - `VerificationReport` objects or `verification_report` summaries
+  - `GeneratorFamily` objects or `generator_fit_diagnostics` summaries for fit diagnostics
+  - optional extra metrics
+- returns `summary_type = "invariant_workflow"`
+- creates no canonical object and mutates no inputs
 - documented the API in `docs/specs/API_STABILITY.md`
-- kept computation report-only:
-  - no plotting
-  - no augmentation
-  - no `FieldBatch` mutation
-  - no root export
 
 ---
 
-## Milestone 3 - Translation Consistency Diagnostic
+## Milestone 3 - Uniform Translation Orbit Report
 
 **Status:** COMPLETE
 
 ### Goal
 
-Promote uniform-translation consistency diagnostics from `v0.12` feasibility into runtime.
+Add the read-only uniform translation orbit report under `pdelie.invariants`.
 
 ### Completed Outcome
 
 - added public submodule-only helper:
-  - `pdelie.invariants.diagnose_uniform_translation_consistency(...)`
-- validated canonical scalar 1D periodic `FieldBatch` inputs
-- used existing `InvariantApplier` and `uniform_translation`
-- returned JSON-compatible report dicts only
-- returned no transformed `FieldBatch` objects
-- did not mutate input fields
-- supported optional residual evaluator behavior:
-  - omitted residual evaluator leaves residual metrics as `None`
-  - supplied residual evaluator failures remain fatal typed validation errors
-- recorded structure flags, inverse/period-wrap errors, residual stability metrics, and appended provenance fields
-- validated stable Heat and KdV fixtures
+  - `pdelie.invariants.summarize_uniform_translation_orbit(...)`
+- returns `summary_type = "uniform_translation_orbit"`
+- includes:
+  - optional `source_field_id`
+  - field shape and equation metadata
+  - raw and normalized shifts
+  - one transform spec and provenance summary per shift
+  - optional coverage diagnostics
+  - translation consistency diagnostics
+  - orbit-level pass flags
+- returns no transformed `FieldBatch` objects
+- constructs no augmented dataset or orbit dataset
 - documented the API in `docs/specs/API_STABILITY.md`
-- kept KS out of the public diagnostics path
 
 ---
 
-## Milestone 4 - Example and Reporting Alignment
+## Milestone 4 - Useful End-to-end Example
 
 **Status:** COMPLETE
 
 ### Goal
 
-Add a compact runtime smoke example for the new diagnostics.
+Add a compact JSON-only example that combines the new report surfaces.
 
 ### Completed Outcome
 
-- added `python -m pdelie.examples.orbit_coverage_diagnostics`
-- added `pdelie.examples.run_orbit_coverage_diagnostics_example(...)`
-- example output is JSON-only on stdout
-- example demonstrates:
-  - half-coverage and full-coverage periodic-window cases
-  - uniform translation consistency on stable Heat and KdV fixtures
+- added `python -m pdelie.examples.invariant_workflow_summary`
+- added `pdelie.examples.run_invariant_workflow_summary_example(...)`
+- example combines:
+  - Heat orbit/coverage/consistency diagnostics
+  - KdV orbit/coverage/consistency diagnostics
+  - generator fit diagnostics
+  - verification summaries
+  - combined invariant workflow summaries
 - example output remains a runtime smoke summary, not a canonical artifact schema
 - root `pdelie` remains unchanged
 
@@ -199,19 +186,20 @@ Add a compact runtime smoke example for the new diagnostics.
 
 ### Goal
 
-Verify public surface and documentation match the frozen `v0.13` scope.
+Verify public surface and documentation match the frozen `v0.14` scope.
 
 ### Completed Outcome
 
-- confirmed `pdelie.invariants.compute_periodic_window_coverage(...)` is submodule-only
-- confirmed `pdelie.invariants.diagnose_uniform_translation_consistency(...)` is submodule-only
+- confirmed `pdelie.reporting.summarize_invariant_workflow(...)` is submodule-only
+- confirmed `pdelie.invariants.summarize_uniform_translation_orbit(...)` is submodule-only
 - confirmed root `pdelie` exports remain unchanged
 - confirmed no public augmentation utilities landed
-- confirmed no public orbit-view builders landed
+- confirmed no orbit dataset builder landed
+- confirmed no time-translation API landed
 - confirmed public KS generator/residual/example APIs remain absent
 - confirmed weak KS remains absent
 - confirmed broad adapters remain absent
-- confirmed `API_STABILITY.md` documents the new diagnostics and does not document augmentation or KS APIs
+- confirmed `API_STABILITY.md` documents the new helpers and does not document augmentation or time-translation APIs
 
 ---
 
@@ -225,30 +213,30 @@ Close the release with compact gate coverage, metadata, docs, and direct Git-tag
 
 ### Completed Outcome
 
-- added compact `tests/test_v0_13_release_gate.py`
-- updated CI so the current explicit release gate is `v0_13-release-gate`
+- added compact `tests/test_v0_14_release_gate.py`
+- updated CI so the current explicit release gate is `v0_14-release-gate`
 - retained full editable tests and package smoke
-- added compact package-smoke coverage for the new invariant diagnostics
-- bumped package metadata to `0.13.0`
-- updated README and changelog for `v0.13`
-- added `docs/releases/V0_13_RELEASE_READINESS.md`
-- updated publishing docs to keep `v0.13.0` Git-tag-only
-- moved `v0.13` into completed release context in `ROADMAP.md`
+- added compact package-smoke coverage for the new workflow/orbit reports
+- bumped package metadata to `0.14.0`
+- updated README and changelog for `v0.14`
+- added `docs/releases/V0_14_RELEASE_READINESS.md`
+- updated publishing docs to keep `v0.14.0` Git-tag-only
+- moved `v0.14` into completed release context in `ROADMAP.md`
 - kept PyPI/TestPyPI deferred until `v1.0` or later
 
 ### Direct Tag Path
 
-Before tagging `v0.13.0`:
+Before tagging `v0.14.0`:
 
 - run full local tests
 - build sdist and wheel
 - run clean wheel smoke
-- run Heat, KdV, and orbit/coverage example modules
+- run Heat, KdV, orbit/coverage, and invariant-workflow example modules
 - confirm CI checks pass:
-  - `v0_13-release-gate`
+  - `v0_14-release-gate`
   - `editable-tests`
   - `package-smoke`
-- tag the merged main commit as `v0.13.0`
+- tag the merged main commit as `v0.14.0`
 - do not publish to TestPyPI
 - do not publish to PyPI
 
@@ -256,25 +244,26 @@ Before tagging `v0.13.0`:
 
 ## Explicit Non-goals Preserved
 
-`v0.13` did not add:
+`v0.14` did not add:
 
-- a new PDE
-- stable KS generator/residual/example APIs
+- new PDE support
+- stable KS runtime support
 - weak KS
-- public augmentation utilities
-- public orbit-view builders
-- broad dataset adapters
-- multidimensional or nonuniform grids
+- broad adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid expansion
 - operator-facing APIs
-- private-paper experiment policy
-- manuscript-specific thresholds, tables, figures, or labels
+- public augmentation utilities
+- orbit dataset builders
+- transformed `FieldBatch` collections from reporting helpers
+- train-augmentation policy
+- time-translation APIs
 - root runtime exports
 
 ---
 
-## Status
+## Status Checklist
 
-- `v0.12`: COMPLETE as diagnostics/supportability hardening
 - Milestone 0: COMPLETE
 - Milestone 1: COMPLETE
 - Milestone 2: COMPLETE

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -453,6 +453,72 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.14` - Invariant workflow summaries and read-only orbit reports
+**Status:** Completed
+
+`v0.14` is the completed invariant workflow summary and orbit report release after the `v0.13` public orbit/coverage diagnostics release.
+
+Its purpose is:
+
+> combine coverage, consistency, fit, and verification diagnostics into reusable workflow summaries while keeping orbit handling read-only and report-only.
+
+Completed release definition:
+
+`FieldBatch + uniform x-translation shifts + optional windows + residual/fit/verification outputs -> read-only orbit report + combined invariant workflow summary`
+
+Completed scope:
+
+- `pdelie.reporting.summarize_invariant_workflow(...)`
+- `pdelie.invariants.summarize_uniform_translation_orbit(...)`
+- optional `source_field_id` provenance metadata
+- nested coverage, consistency, orbit, generator, fit-diagnostic, and verification summaries
+- Heat and KdV invariant workflow example
+- API/public-surface audit
+- compact current `v0_14-release-gate` readiness
+
+Release interpretation:
+
+- helpers return read-only runtime reports, not augmented datasets
+- no transformed `FieldBatch` collections are returned
+- no orbit dataset builder or train-augmentation policy is promoted
+- time-translation diagnostics remain deferred
+- `v0.14.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no new PDE
+- no stable KS generator or residual evaluator
+- no weak KS API
+- no broad dataset adapters
+- no PDEBench or The Well support
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no public augmentation utilities
+- no orbit dataset builders
+- no time-translation APIs
+- no root export expansion
+
+The authoritative `v0.14` scope freeze belongs in:
+
+- `V0_14_SCOPE.md`
+
+### Release Gate for `v0.14`
+
+`v0.14` is complete only if:
+
+- invariant workflow and orbit report helpers are documented and covered by tests
+- new APIs are importable from their submodules only
+- root `pdelie` remains unchanged
+- representative Heat and KdV invariant workflow reports are JSON-compatible
+- the invariant workflow example emits JSON only
+- no public augmentation, orbit dataset, time-translation, KS, weak KS, broad adapter, or operator API lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.13` - Public orbit and coverage diagnostics
 **Status:** Completed
 
@@ -644,18 +710,111 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
-### `v0.14+` - Later PDE, augmentation, and dataset coverage
+### `v0.15` - Materialized uniform translation orbit batches
 **Status:** Planned
 
-Later PDE, augmentation, and dataset coverage remains planned after the `v0.13` public orbit/coverage diagnostics release.
+`v0.15` is the planned next major direction after the `v0.14` invariant workflow summary release, but it is not yet the active committed release until a `v0.15` M0 scope freeze opens.
 
-Candidate directions:
+Planned theme:
 
-- public orbit-view or train-augmentation utilities only after an explicit API freeze
-- wave equation only after second-time-derivative semantics are frozen
-- reaction-diffusion systems after multivariable semantics are explicitly scoped
-- PDEBench / The Well adapters after generic ingestion and provenance policies are proven
-- multidimensional structured grids only after the 1D path is stable and supportable
+> promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
+
+Candidate API direction:
+
+- `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
+
+Scope to freeze before implementation:
+
+- augmentation appends along the batch dimension
+- duplicate shifts are preserved
+- source indices and shift indices are recorded as provenance/report metadata
+- masks are transformed and concatenated consistently with existing `InvariantApplier` behavior
+- preprocess logs append one orbit-materialization entry
+- metadata records group/action parameters
+- no train/test policy is applied
+- no split management or heldout-leakage detection is attempted
+- return shape is explicit, preferably `(FieldBatch, report)` or a named structured pair rather than a silent `FieldBatch`-only result
+
+Interpretation:
+
+- this would be the first truly user-facing data utility beyond diagnostics
+- it remains paper-agnostic
+- it does not add sparse-discovery branch policy or train/heldout management
+- it does not add time translation, a new PDE, or root exports
+
+The detailed strategy note belongs in:
+
+- `V0_15_PLUS_STRATEGY.md`
+
+### `v0.16` - External symmetry-candidate interop
+**Status:** Planned
+
+`v0.16` is planned as detector interop and validation, not sparse-discovery reporting and not detector training.
+
+Candidate API direction:
+
+- `pdelie.symmetry.validate_generator_candidate(...)`
+
+External methods may provide:
+
+- an existing `GeneratorFamily`
+- a finite-transform specification
+- a callable transform descriptor
+- a JSON-compatible symmetry-candidate report
+
+PDELie should validate those candidates using finite-transform consistency, residual preservation, span or closure diagnostics, provenance checks, and optional fit/verification summaries.
+
+Interpretation:
+
+- learned symmetry methods can slot in by exporting candidates
+- PDELie remains a validation/reporting substrate
+- PDELie does not train neural symmetry detectors
+- operator-facing APIs remain deferred unless separately frozen
+
+### `v0.17` - Formula-backed and non-polynomial generators
+**Status:** Planned
+
+`v0.17` is planned as the first careful step beyond the current polynomial/structured generator support.
+
+Recommended phasing:
+
+- formula-backed metadata first:
+  - affine generators
+  - trigonometric generators
+  - rational or simple analytic forms
+  - externally supplied symbolic references
+- callable or external generators second, treated as less stable unless paired with diagnostics
+- learned-generator interop third, as accepted outputs only
+
+Key freeze decision:
+
+- either introduce a new formula-backed generator record such as `FormulaGeneratorFamily`
+- or keep the first slice as runtime metadata until compatibility with existing `GeneratorFamily` semantics is proven
+
+The conservative default is formula-backed runtime records first, with no change to existing polynomial `GeneratorFamily` semantics until explicitly accepted.
+
+### `v0.18+` - Scoped PDE expansion
+**Status:** Planned
+
+`v0.18+` is the earliest planned point for another stable PDE expansion.
+
+Preferred stable direction:
+
+- advection-diffusion or reaction-diffusion, because these are more likely to fit the current scalar structured-data contracts cleanly
+
+Alternative scoped direction:
+
+- KS residual-only, but only if the public claim explicitly excludes direct residual-based fitting recovery
+
+Deferred until separately frozen:
+
+- broad PDE zoo expansion
+- PDEBench or The Well adapters
+- multidimensional grids
+- nonuniform grids
+- operator-facing APIs
+- weak KS
+- learned-generator training
 
 Each of these requires its own scope freeze before implementation.
 
@@ -702,9 +861,11 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_11_SCOPE.md` once frozen
 - `V0_12_SCOPE.md` once frozen
 - `V0_13_SCOPE.md` once frozen
+- `V0_14_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
+- `V0_15_PLUS_STRATEGY.md`
 - `../strategy/INTEROPERABILITY_AND_BENCHMARKING.md`
 - `LLM_CONTEXT.md`
 
@@ -739,6 +900,10 @@ It should **not** be edited every time a new idea appears.
 - `v0.11` = order-4 spectral derivatives and Kuramoto-Sivashinsky feasibility no-go/defer closeout
 - `v0.12` = diagnostics and supportability hardening for fitting, verification, reporting, and orbit/coverage diagnostics
 - `v0.13` = public orbit/coverage diagnostics under `pdelie.invariants`, without augmentation
-- `v0.14+` = augmentation, wave semantics, external benchmark adapters, and broader PDE coverage only after scope freezes
+- `v0.14` = invariant workflow summaries and read-only uniform translation orbit reports, without augmentation
+- `v0.15` = materialized uniform translation orbit batches after a dedicated scope freeze
+- `v0.16` = external symmetry-candidate interop and validation, not detector training
+- `v0.17` = formula-backed and non-polynomial generator support after schema semantics are frozen
+- `v0.18+` = scoped PDE expansion, with reaction/advection-diffusion preferred unless KS residual-only is deliberately scoped
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/V0_14_SCOPE.md
+++ b/docs/planning/V0_14_SCOPE.md
@@ -1,0 +1,193 @@
+# V0.14 Scope Freeze
+
+## Summary
+
+`v0.14` is the invariant workflow summary and read-only translation orbit report release.
+
+Stable release theme:
+
+> combine existing coverage, consistency, fit, and verification diagnostics into reusable runtime summaries while keeping orbit handling report-only.
+
+Stable path:
+
+`FieldBatch + uniform x-translation shifts + optional windows + residual/fit/verification outputs -> read-only orbit report + combined invariant workflow summary`
+
+These helpers support invariant and finite-transform workflows.
+They are read-only runtime reports, not augmented datasets, transformed `FieldBatch` collections, orbit datasets, or canonical objects.
+
+---
+
+## Stable Scope
+
+`v0.14` adds two runtime public APIs under submodules only:
+
+```python
+pdelie.invariants.summarize_uniform_translation_orbit(
+    field,
+    *,
+    shifts,
+    windows=None,
+    residual_evaluator=None,
+    source_field_id=None,
+) -> dict[str, Any]
+
+pdelie.reporting.summarize_invariant_workflow(
+    *,
+    orbit=None,
+    coverage=None,
+    consistency=None,
+    generator=None,
+    verification=None,
+    fit_diagnostics=None,
+    extra_metrics=None,
+) -> dict[str, Any]
+```
+
+Both helpers:
+
+- return JSON-compatible runtime report dicts
+- mutate no inputs
+- create no canonical objects
+- have no root `pdelie` exports
+- are supportability diagnostics, not manuscript schemas or sparse-discovery policy
+
+`source_field_id` is optional JSON-compatible provenance metadata only.
+It is not a canonical identity system.
+
+`v0.14` also adds:
+
+- `python -m pdelie.examples.invariant_workflow_summary`
+- `pdelie.examples.run_invariant_workflow_summary_example(...)`
+- compact `v0_14-release-gate` coverage
+
+The example output is a runtime smoke summary, not a canonical artifact schema.
+
+---
+
+## `summarize_uniform_translation_orbit(...)` Semantics
+
+Supported inputs:
+
+- canonical scalar 1D uniform periodic `FieldBatch`
+- non-empty finite uniform `x` shifts
+- optional periodic windows using the frozen `v0.13` coverage semantics
+- optional residual evaluator using the frozen `v0.13` consistency semantics
+- optional JSON-compatible `source_field_id`
+
+Report semantics:
+
+- uses existing `InvariantApplier` and uniform `x` translation
+- preserves raw shift order and duplicate shifts
+- includes normalized shifts
+- includes one transform spec and provenance summary per shift
+- includes optional coverage diagnostics when windows are supplied
+- includes uniform-translation consistency diagnostics for every shift
+- returns no transformed `FieldBatch` objects
+- constructs no augmented dataset or orbit dataset
+
+---
+
+## `summarize_invariant_workflow(...)` Semantics
+
+Supported inputs:
+
+- `periodic_window_coverage` reports
+- `uniform_translation_consistency` reports
+- `uniform_translation_orbit` reports
+- `GeneratorFamily` objects or `generator_family` summaries
+- `VerificationReport` objects or `verification_report` summaries
+- `GeneratorFamily` objects or `generator_fit_diagnostics` summaries for fit diagnostics
+- optional JSON-compatible extra metrics
+
+The helper nests existing summaries where canonical objects are supplied.
+It does not change the existing `v0.10` or `v0.12` reporting schemas.
+
+---
+
+## Non-goals
+
+`v0.14` explicitly does not include:
+
+- a new PDE
+- stable KS generator promotion
+- stable KS residual evaluator promotion
+- KS example or imported parity
+- weak KS
+- broad adapters
+- PDEBench or The Well support
+- multidimensional grids
+- nonuniform grids
+- multivariable systems
+- operator-facing symmetry APIs
+- public augmentation utilities
+- orbit dataset builders
+- transformed `FieldBatch` collections as reports
+- train-augmentation policy
+- sparse-discovery branch policy
+- private-paper experiment logic
+- manuscript-specific thresholds, tables, figures, or labels
+- root `pdelie` export expansion
+- time-translation APIs
+- `axis="time"` support in `InvariantApplier`
+- time-shift consistency diagnostics
+
+There is no time-translation API in `v0.14`.
+Time-translation diagnostics remain deferred until a separate semantics freeze decides finite-time boundary behavior, interpolation policy, and residual-invariance expectations.
+
+---
+
+## Milestones
+
+### Milestone 0 - Scope Freeze
+
+Freeze `v0.14` as invariant workflow summaries plus read-only uniform translation orbit reports.
+
+### Milestone 1 - API Semantics Freeze
+
+Freeze report schemas, `source_field_id` provenance behavior, and report-only orbit semantics.
+
+### Milestone 2 - Combined Invariant Workflow Summary
+
+Implement `pdelie.reporting.summarize_invariant_workflow(...)` and document it in `API_STABILITY.md`.
+
+### Milestone 3 - Uniform Translation Orbit Report
+
+Implement `pdelie.invariants.summarize_uniform_translation_orbit(...)` and document it in `API_STABILITY.md`.
+
+### Milestone 4 - Useful End-to-end Example
+
+Add `python -m pdelie.examples.invariant_workflow_summary` and `pdelie.examples.run_invariant_workflow_summary_example(...)`.
+
+### Milestone 5 - API / Public-surface Audit
+
+Confirm the new APIs are submodule-only and no augmentation, orbit dataset, time-translation, KS, weak KS, broad adapter, or operator API landed.
+
+### Milestone 6 - Release Gate and Readiness
+
+Add `tests/test_v0_14_release_gate.py`, update CI, bump package metadata to `0.14.0`, and align release-facing docs.
+
+---
+
+## Release-gate Expectations
+
+Expected gate coverage:
+
+- `summarize_invariant_workflow(...)` is documented and submodule-only
+- `summarize_uniform_translation_orbit(...)` is documented and submodule-only
+- representative Heat and KdV invariant workflow summaries are JSON-compatible
+- orbit reports return no transformed `FieldBatch` objects
+- root `pdelie` remains unchanged
+- no public augmentation, orbit dataset, time-translation, KS, weak KS, broad adapter, or operator API lands
+- current CI uses `v0_14-release-gate` plus full editable tests and package smoke
+
+---
+
+## Status
+
+- Milestone 0: COMPLETE
+- Milestone 1: COMPLETE
+- Milestone 2: COMPLETE
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
+- Milestone 6: COMPLETE

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -1,0 +1,197 @@
+# V0.15+ Strategy
+
+This document records the planned post-`v0.14` direction.
+It is a strategy note, not an active scope freeze and not an API contract.
+
+The active execution record remains `PLAN.md`.
+Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
+
+## Summary
+
+After `v0.14`, the highest-ROI path is to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then non-polynomial generator support, then carefully scoped PDE expansion.
+
+Planned sequence:
+
+- `v0.15`: materialized uniform translation orbit batches
+- `v0.16`: external symmetry-candidate interop and validation
+- `v0.17`: formula-backed and non-polynomial generator families
+- `v0.18+`: scoped PDE expansion
+
+PDELie should remain a reusable library and validation/reporting substrate.
+It should not become a neural symmetry-detector training framework.
+
+---
+
+## V0.15 - Materialized Uniform Translation Orbit Batches
+
+Planned theme:
+
+> promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
+
+Candidate API direction:
+
+```python
+pdelie.invariants.build_uniform_translation_orbit_batch(
+    field,
+    *,
+    shifts,
+    keep_source_index=True,
+    keep_shift_index=True,
+    copy=True,
+)
+```
+
+`build_uniform_translation_orbit_batch(...)` is the preferred candidate name because it says the helper returns a batch-oriented data product.
+The exact name and return type must still be frozen in `v0.15` M1.
+
+Semantics to freeze before implementation:
+
+- augmentation appends along the batch dimension
+- output ordering is deterministic and preserves duplicate shifts
+- source indices and shift indices are recorded as provenance/report metadata
+- duplicate shifts are preserved rather than deduplicated
+- masks are transformed and concatenated consistently with existing `InvariantApplier` behavior
+- preprocess logs append one orbit-materialization entry
+- output metadata records group/action parameters, normalized shifts, and duplicate-shift policy
+- no train/test policy is applied
+- no split management or heldout-leakage detection is attempted
+- source IDs may be recorded, but the helper does not manage experimental partitions
+
+Return-shape policy to freeze:
+
+- prefer an explicit structured return such as `(FieldBatch, report)` or a named structured pair
+- avoid a silent `FieldBatch`-only return because users need source/shift provenance
+- avoid returning transformed fields inside a JSON report
+
+Explicit non-goals:
+
+- no sparse-discovery branch policy
+- no train/heldout split management
+- no paper-specific augmentation recipe
+- no time translation
+- no new PDE
+- no root exports unless separately accepted
+
+This would be useful beyond PDELie itself: users could feed the materialized orbit batch into PySINDy, a neural solver, PDE-FIND-style code, or their own model while keeping provenance explicit.
+
+---
+
+## V0.16 - External Symmetry-candidate Interop
+
+Planned theme:
+
+> validate external symmetry candidates without training the detectors that produced them.
+
+Candidate API direction:
+
+```python
+pdelie.symmetry.validate_generator_candidate(
+    field,
+    candidate,
+    *,
+    residual_evaluator,
+    finite_transform_epsilons=None,
+) -> dict[str, Any]
+```
+
+External methods may provide:
+
+- an existing `GeneratorFamily`
+- a finite-transform specification
+- a callable transform descriptor
+- a JSON-compatible symmetry-candidate report
+
+PDELie should validate candidates using:
+
+- finite-transform consistency
+- residual preservation
+- span or closure diagnostics when applicable
+- provenance checks
+- optional fit and verification summaries
+
+Design boundary:
+
+- this is detector interop, not sparse-discovery reporting
+- this is validation/reporting, not neural-generator training
+- learned-generator methods may slot in by exporting candidates, but PDELie does not train those models
+- callable descriptors should remain less stable than JSON-compatible candidate records unless accompanied by diagnostic reports
+
+This keeps PDELie compatible with learned-generator or Lie-algebra-aware methods without becoming a neural symmetry-discovery framework.
+
+---
+
+## V0.17 - Formula-backed And Non-polynomial Generators
+
+Planned theme:
+
+> support richer generator descriptions without jumping directly to neural generator classes.
+
+Phase 1 should focus on formula-backed generator records for:
+
+- affine generators
+- trigonometric generators
+- rational or simple analytic forms
+- externally supplied symbolic references
+
+Required semantics to freeze:
+
+- JSON-serializable formula metadata
+- evaluation policy on canonical fields
+- finite-transform availability, or explicit `infinitesimal_only` status
+- validation diagnostics
+- compatibility with existing reporting helpers
+
+Phase 2 may allow callable or external generators, but those should be treated as less stable unless paired with diagnostic reports.
+
+Phase 3 may allow learned-generator interop through accepted outputs only.
+PDELie should validate such outputs; it should not train learned generators.
+
+Key design decision for `v0.17`:
+
+- decide whether formula-backed generators require a new canonical object such as `FormulaGeneratorFamily`
+- or whether a runtime metadata record is enough for the first stable slice
+
+The conservative default is a runtime formula-backed record first, with no change to existing polynomial `GeneratorFamily` semantics until the compatibility story is proven.
+
+---
+
+## V0.18+ - Scoped PDE Expansion
+
+Planned theme:
+
+> add another stable numerical axis only after the invariant/data-utility surface remains supportable.
+
+Preferred stable expansion:
+
+- advection-diffusion or reaction-diffusion, because they are likely to fit the current scalar/structured-data contracts with less ambiguity than KS promotion
+
+Alternative scoped expansion:
+
+- KS residual-only, but only if the public claim explicitly excludes direct residual-based fitting recovery
+
+Deferred until separately frozen:
+
+- broad PDE zoo expansion
+- PDEBench or The Well adapters
+- multidimensional grids
+- nonuniform grids
+- operator-facing APIs
+- weak KS
+- learned-generator training
+
+Each PDE expansion requires its own scope freeze and release-gate evidence.
+
+---
+
+## Relationship To V1.0
+
+These releases should move PDELie toward `v1.0` by improving supportability, provenance, and interoperability before increasing scientific scope too aggressively.
+
+The preferred sequence is:
+
+1. materialize finite translation orbits safely
+2. validate external symmetry candidates
+3. represent non-polynomial formulas
+4. only then widen stable PDE coverage
+
+Package-index publishing, broad adapters, and stable v1 API commitments remain deferred until a dedicated `v1.0` readiness milestone.

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.13.0`, release completion means:
+For the current `v0.x` series, including `v0.14.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.13.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.13`.
+`v0.14.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.14`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.
@@ -101,13 +101,16 @@ git clean -fdx
 python -m pytest
 python -m build --sdist --wheel
 python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
 ls -1 dist
 ~~~
 
 Expected local checks:
 
 - the package builds successfully
-- the stable example still runs
+- the stable examples still run
 - `dist/` contains the expected `sdist` and wheel for the release version
 
 For a stricter local smoke pass, install the wheel into a clean virtual environment before publishing.

--- a/docs/releases/V0_14_RELEASE_READINESS.md
+++ b/docs/releases/V0_14_RELEASE_READINESS.md
@@ -1,0 +1,121 @@
+# V0.14 Release Readiness
+
+## Summary
+
+- package version: `0.14.0`
+- git tag: `v0.14.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.14.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.14`.
+
+Release claim:
+
+> invariant workflow summaries and read-only uniform translation orbit reports, without augmentation or new numerical scope.
+
+---
+
+## M0-M6 Outcome
+
+- M0 froze `v0.14` as invariant workflow summaries plus read-only translation orbit reports.
+- M1 froze report schemas, `source_field_id` provenance behavior, and report-only orbit semantics.
+- M2 added `pdelie.reporting.summarize_invariant_workflow(...)`.
+- M3 added `pdelie.invariants.summarize_uniform_translation_orbit(...)`.
+- M4 added `python -m pdelie.examples.invariant_workflow_summary`.
+- M5 audited public exports and deferred surfaces.
+- M6 aligned release gate, CI, docs, metadata, and direct tag readiness.
+
+## Public API Notes
+
+New public submodule APIs:
+
+- `pdelie.reporting.summarize_invariant_workflow(...)`
+- `pdelie.invariants.summarize_uniform_translation_orbit(...)`
+- `pdelie.examples.run_invariant_workflow_summary_example(...)`
+
+No root `pdelie` exports were added.
+
+These APIs return runtime JSON-compatible reports.
+They do not create canonical objects, transformed `FieldBatch` objects, augmented datasets, orbit datasets, figures, or manuscript artifacts.
+
+## Representative Diagnostics
+
+Invariant workflow summary checks:
+
+- Heat and KdV examples include orbit, coverage, consistency, generator, fit-diagnostic, and verification summaries
+- summaries are JSON-compatible and use `summary_schema_version = "0.1"`
+- supplied `source_field_id` values are preserved as provenance metadata only
+
+Uniform translation orbit checks:
+
+- raw shift order and duplicate shifts are preserved
+- optional coverage diagnostics reuse the `v0.13` field-shift-then-fixed-window convention
+- optional residual evaluators reuse the `v0.13` consistency diagnostics
+- no transformed `FieldBatch` objects are returned
+- input fields are not mutated
+
+## Explicit Deferrals
+
+`v0.14` does not add:
+
+- a new PDE
+- stable KS generator/residual/example APIs
+- weak KS
+- public augmentation utilities
+- orbit dataset builders
+- transformed `FieldBatch` collections from reporting helpers
+- time-translation APIs
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid support
+- operator-facing APIs
+- private-paper experiment policy
+- manuscript-specific thresholds, tables, figures, or labels
+- root runtime exports
+
+## CI Expectations
+
+Required checks before tagging:
+
+- `v0_14-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+The explicit release gate is compact and representative.
+The full editable suite remains responsible for historical release gates and broader regression coverage.
+
+## Local Validation Checklist
+
+Before tagging:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+git diff --check
+```
+
+Clean wheel smoke should verify:
+
+- stable root imports
+- `pdelie.reporting.summarize_invariant_workflow`
+- `pdelie.invariants.summarize_uniform_translation_orbit`
+- one tiny weak Heat report
+- one tiny KdV strong-path residual
+- one tiny order-4 derivative smoke
+- one tiny generator-fit diagnostic summary
+- no root KS, orbit dataset, augmentation, time-translation, or weak KS exports
+
+## Direct Tag Checklist
+
+1. Create the release PR from the `v0.14` branch.
+2. Run the local validation checklist.
+3. Wait for required CI checks to pass.
+4. Merge only after CI is green.
+5. Tag the merged `main` commit as `v0.14.0`.
+6. Do not publish to TestPyPI.
+7. Do not publish to PyPI.
+8. Record package-index publishing as deferred until `v1.0` or later.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -159,6 +159,16 @@ Runtime public API for the frozen `v0.13` Milestone 2/M3 slice:
 - these APIs do not construct augmented datasets, orbit views, training branches, canonical artifacts, figures, or manuscript tables
 - these APIs have no root `pdelie` exports
 
+Runtime public API for the frozen `v0.14` Milestone 2/M3 slice:
+
+- `pdelie.reporting.summarize_invariant_workflow` for JSON-compatible runtime summaries that combine coverage, consistency, orbit, generator, fit-diagnostic, verification, and optional extra-metric reports
+- `pdelie.invariants.summarize_uniform_translation_orbit` for JSON-compatible read-only reports over finite uniform `x` translations of canonical scalar 1D periodic `FieldBatch` inputs
+- these APIs support invariant and finite-transform workflows by reporting combined workflow and orbit metadata only
+- these APIs do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections
+- `source_field_id` is optional JSON-compatible provenance metadata only, not a canonical identity system
+- time-translation diagnostics remain deferred; `InvariantApplier` still exposes only uniform periodic `x` translation in the stable runtime path
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,6 @@
 # Notebooks
 
-This directory contains tutorial notebooks for the shipped `v0.13` runtime surface.
+This directory contains tutorial notebooks for the shipped `v0.14` runtime surface.
 
 These notebooks are:
 
@@ -37,8 +37,8 @@ The ordering is progressive, but each notebook has a distinct theme.
 ## Notebook Index
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
-  - current `v0.13` tour despite the historical filename
-  - fields, derivatives, residuals, nested reports, KdV, weak reports, and invariant diagnostics
+  - current `v0.14` tour despite the historical filename
+  - fields, derivatives, residuals, nested reports, KdV, weak reports, invariant diagnostics, and workflow summaries
 - `01_raw_vs_translation_canonical_discovery.ipynb`
   - raw versus translation-canonical Heat discovery inputs
   - visualizes batch-alignment effects and connects them to coverage diagnostics
@@ -51,7 +51,7 @@ The ordering is progressive, but each notebook has a distinct theme.
 - `05_closure_algebra_diagnostics.ipynb`
   - algebraic closure and span diagnostics on small hand-built polynomial families
 - `06_orbit_coverage_diagnostics.ipynb`
-  - dedicated `v0.13` feature notebook for public orbit/coverage diagnostics under `pdelie.invariants`
+  - dedicated invariant-diagnostics notebook for public orbit/coverage diagnostics and read-only workflow summaries
 
 ## Running From VS Code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.13.0"
-description = "V0.13 public orbit and coverage diagnostics for invariant and finite-transform workflows over the Heat/Burgers/weak-report/KdV engine"
+version = "0.14.0"
+description = "V0.14 invariant workflow summaries and read-only uniform translation orbit reports over the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "run_heat_vertical_slice_example",
+    "run_invariant_workflow_summary_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
 ]
@@ -7,6 +8,12 @@ __all__ = [
 
 def run_heat_vertical_slice_example() -> dict[str, object]:
     from pdelie.examples.heat_vertical_slice import run_heat_vertical_slice_example as _impl
+
+    return _impl()
+
+
+def run_invariant_workflow_summary_example() -> dict[str, object]:
+    from pdelie.examples.invariant_workflow_summary import run_invariant_workflow_summary_example as _impl
 
     return _impl()
 

--- a/src/pdelie/examples/invariant_workflow_summary.py
+++ b/src/pdelie/examples/invariant_workflow_summary.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch, split_batch_train_heldout
+from pdelie.invariants import summarize_uniform_translation_orbit
+from pdelie.reporting import summarize_invariant_workflow
+from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_DOMAIN_LENGTH = 2.0 * np.pi
+_GRID_POINTS = 64
+_SHIFTS = (0.0, _DOMAIN_LENGTH / _GRID_POINTS, _DOMAIN_LENGTH / 8.0, -_DOMAIN_LENGTH / 8.0, _DOMAIN_LENGTH)
+_WINDOWS = ({"start": 0.0, "width": _DOMAIN_LENGTH / 4.0},)
+
+
+def _heat_workflow() -> dict[str, object]:
+    training = generate_heat_1d_field_batch(batch_size=4, num_times=33, num_points=_GRID_POINTS, seed=1401)
+    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=_GRID_POINTS, seed=1402)
+    evaluator = HeatResidualEvaluator()
+    generator = fit_translation_generator(training, evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, evaluator)
+    orbit = summarize_uniform_translation_orbit(
+        training,
+        shifts=_SHIFTS,
+        windows=_WINDOWS,
+        residual_evaluator=evaluator,
+        source_field_id="heat_training_seed_1401",
+    )
+    return summarize_invariant_workflow(
+        orbit=orbit,
+        coverage=orbit["coverage"],
+        consistency=orbit["consistency"],
+        generator=generator,
+        verification=verification,
+        extra_metrics={"case_name": "heat", "equation": "heat_1d"},
+    )
+
+
+def _kdv_workflow() -> dict[str, object]:
+    field = generate_kdv_1d_field_batch(seed=9001, batch_size=5)
+    training, heldout = split_batch_train_heldout(field, train_size=2, seed=9002)
+    evaluator = KdVResidualEvaluator()
+    generator = fit_translation_generator(training, evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, evaluator)
+    orbit = summarize_uniform_translation_orbit(
+        training,
+        shifts=_SHIFTS,
+        windows=_WINDOWS,
+        residual_evaluator=evaluator,
+        source_field_id="kdv_training_seed_9001_split_9002",
+    )
+    return summarize_invariant_workflow(
+        orbit=orbit,
+        coverage=orbit["coverage"],
+        consistency=orbit["consistency"],
+        generator=generator,
+        verification=verification,
+        extra_metrics={"case_name": "kdv", "equation": "kdv_normalized"},
+    )
+
+
+def run_invariant_workflow_summary_example() -> dict[str, object]:
+    return {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": "invariant_workflow_summary_example",
+        "workflows": [_heat_workflow(), _kdv_workflow()],
+        "extra_metrics": {
+            "example_name": "invariant_workflow_summary",
+            "shifts": list(_SHIFTS),
+            "windows": list(_WINDOWS),
+        },
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_invariant_workflow_summary_example(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/invariants/__init__.py
+++ b/src/pdelie/invariants/__init__.py
@@ -2,10 +2,12 @@ from pdelie.invariants.apply import InvariantApplier
 from pdelie.invariants.diagnostics import (
     compute_periodic_window_coverage,
     diagnose_uniform_translation_consistency,
+    summarize_uniform_translation_orbit,
 )
 
 __all__ = [
     "InvariantApplier",
     "compute_periodic_window_coverage",
     "diagnose_uniform_translation_consistency",
+    "summarize_uniform_translation_orbit",
 ]

--- a/src/pdelie/invariants/diagnostics.py
+++ b/src/pdelie/invariants/diagnostics.py
@@ -222,6 +222,11 @@ def compute_periodic_window_coverage(
     )
 
 
+def _json_compatible_value(value: Any, *, name: str) -> Any:
+    safe_payload = _validate_json_compatible({"value": value}, name=name)
+    return safe_payload["value"]
+
+
 def _translation_generator() -> GeneratorFamily:
     return GeneratorFamily(
         parameterization="polynomial_translation_affine",
@@ -373,4 +378,84 @@ def diagnose_uniform_translation_consistency(
             "shift_reports": shift_reports,
         },
         name="uniform_translation_consistency summary",
+    )
+
+
+def summarize_uniform_translation_orbit(
+    field: FieldBatch,
+    *,
+    shifts: Any,
+    windows: Any | None = None,
+    residual_evaluator: ResidualEvaluator | None = None,
+    source_field_id: Any | None = None,
+) -> dict[str, Any]:
+    dx, domain_length = _validate_consistency_field(field)
+    raw_shifts = _finite_sequence(shifts, name="shifts")
+    normalized_shifts = [float(shift % domain_length) for shift in raw_shifts]
+    normalized_source_field_id = _json_compatible_value(source_field_id, name="source_field_id")
+
+    consistency = diagnose_uniform_translation_consistency(
+        field,
+        shifts=raw_shifts,
+        residual_evaluator=residual_evaluator,
+    )
+    coverage = (
+        None
+        if windows is None
+        else compute_periodic_window_coverage(
+            x=field.coords["x"],
+            windows=windows,
+            shifts=raw_shifts,
+            domain_length=domain_length,
+        )
+    )
+
+    orbit_reports: list[dict[str, Any]] = []
+    for index, (raw_shift, normalized_shift, consistency_report) in enumerate(
+        zip(raw_shifts, normalized_shifts, consistency["shift_reports"], strict=True)
+    ):
+        residual_stability = consistency_report["residual_stability_passed"]
+        orbit_reports.append(
+            {
+                "index": index,
+                "shift": raw_shift,
+                "normalized_shift": normalized_shift,
+                "transform_spec": _translation_spec(raw_shift).to_dict(),
+                "provenance_operation": consistency_report["provenance_operation"],
+                "provenance_construction_method": consistency_report["provenance_construction_method"],
+                "provenance_axis": consistency_report["provenance_axis"],
+                "provenance_shift": consistency_report["provenance_shift"],
+                "inverse_passed": consistency_report["inverse_passed"],
+                "period_wrap_passed": consistency_report["period_wrap_passed"],
+                "residual_stability_passed": residual_stability,
+                "consistency_passed": (
+                    consistency_report["inverse_passed"] is True
+                    and consistency_report["period_wrap_passed"] is True
+                    and residual_stability is not False
+                ),
+            }
+        )
+
+    orbit_passed = all(report["consistency_passed"] for report in orbit_reports)
+    return _validate_json_compatible(
+        {
+            "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+            "summary_type": "uniform_translation_orbit",
+            "source_field_id": normalized_source_field_id,
+            "field_dims": field.dims,
+            "field_shape": list(field.values.shape),
+            "equation": field.metadata["parameter_tags"].get("equation"),
+            "domain_length": domain_length,
+            "dx": dx,
+            "raw_shifts": raw_shifts,
+            "normalized_shifts": normalized_shifts,
+            "transform_axis": "x",
+            "construction_method": "uniform_translation",
+            "transform_count": len(raw_shifts),
+            "coverage": coverage,
+            "consistency": consistency,
+            "orbit_reports": orbit_reports,
+            "orbit_passed": orbit_passed,
+        },
+        name="uniform_translation_orbit summary",
     )

--- a/src/pdelie/reporting/__init__.py
+++ b/src/pdelie/reporting/__init__.py
@@ -1,6 +1,7 @@
 from pdelie.reporting.summaries import (
     summarize_generator_fit_diagnostics,
     summarize_generator_family,
+    summarize_invariant_workflow,
     summarize_residual_batch,
     summarize_verification_report,
     summarize_vertical_slice,
@@ -10,6 +11,7 @@ from pdelie.reporting.summaries import (
 __all__ = [
     "summarize_generator_fit_diagnostics",
     "summarize_generator_family",
+    "summarize_invariant_workflow",
     "summarize_residual_batch",
     "summarize_verification_report",
     "summarize_vertical_slice",

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -35,15 +35,6 @@ _WEAK_REPORT_KEYS = frozenset(
     }
 )
 
-_INVARIANT_REPORT_SUMMARY_TYPES = frozenset(
-    {
-        "periodic_window_coverage",
-        "uniform_translation_consistency",
-        "uniform_translation_orbit",
-    }
-)
-
-
 def _json_safe(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return value.tolist()

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -32,6 +32,14 @@ _WEAK_REPORT_KEYS = frozenset(
         "x_window_centers",
         "normalization",
         "diagnostics",
+    }
+)
+
+_INVARIANT_REPORT_SUMMARY_TYPES = frozenset(
+    {
+        "periodic_window_coverage",
+        "uniform_translation_consistency",
+        "uniform_translation_orbit",
     }
 )
 
@@ -114,6 +122,63 @@ def _summary_payload(summary_type: str, **items: Any) -> dict[str, Any]:
         **items,
     }
     return _validate_json_compatible(payload, name=f"{summary_type} summary")
+
+
+def _runtime_report(
+    value: Any,
+    *,
+    name: str,
+    expected_summary_types: set[str] | frozenset[str],
+) -> dict[str, Any]:
+    report = _require_mapping(value, name=name)
+    summary_type = report.get("summary_type")
+    if summary_type not in expected_summary_types:
+        raise SchemaValidationError(
+            f"{name} must have summary_type in {sorted(expected_summary_types)}."
+        )
+    return _validate_json_compatible(dict(report), name=name)
+
+
+def _runtime_report_or_list(
+    value: Any,
+    *,
+    name: str,
+    expected_summary_types: set[str] | frozenset[str],
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return _runtime_report(value, name=name, expected_summary_types=expected_summary_types)
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise SchemaValidationError(f"{name} must be a report mapping or sequence of report mappings.")
+    return [
+        _runtime_report(item, name=f"{name}[{index}]", expected_summary_types=expected_summary_types)
+        for index, item in enumerate(value)
+    ]
+
+
+def _generator_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, GeneratorFamily):
+        return summarize_generator_family(value)
+    return _runtime_report(value, name=name, expected_summary_types={"generator_family"})
+
+
+def _fit_diagnostic_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, GeneratorFamily):
+        return summarize_generator_fit_diagnostics(value)
+    return _runtime_report(value, name=name, expected_summary_types={"generator_fit_diagnostics"})
+
+
+def _verification_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, VerificationReport):
+        return summarize_verification_report(value)
+    return _runtime_report(value, name=name, expected_summary_types={"verification_report"})
 
 
 def summarize_residual_batch(residual: ResidualBatch) -> dict[str, Any]:
@@ -317,5 +382,50 @@ def summarize_vertical_slice(
         residual=summarize_residual_batch(residual),
         generator=summarize_generator_family(generator),
         verification=summarize_verification_report(verification),
+        extra_metrics=normalized_extra_metrics,
+    )
+
+
+def summarize_invariant_workflow(
+    *,
+    orbit: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+    coverage: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+    consistency: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+    generator: GeneratorFamily | Mapping[str, Any] | None = None,
+    verification: VerificationReport | Mapping[str, Any] | None = None,
+    fit_diagnostics: GeneratorFamily | Mapping[str, Any] | None = None,
+    extra_metrics: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if extra_metrics is None:
+        normalized_extra_metrics: Mapping[str, Any] = {}
+    else:
+        normalized_extra_metrics = _require_mapping(extra_metrics, name="extra_metrics")
+
+    generator_summary = _generator_summary_or_none(generator, name="generator")
+    if fit_diagnostics is None and isinstance(generator, GeneratorFamily):
+        fit_summary = summarize_generator_fit_diagnostics(generator)
+    else:
+        fit_summary = _fit_diagnostic_summary_or_none(fit_diagnostics, name="fit_diagnostics")
+
+    return _summary_payload(
+        "invariant_workflow",
+        orbit=_runtime_report_or_list(
+            orbit,
+            name="orbit",
+            expected_summary_types={"uniform_translation_orbit"},
+        ),
+        coverage=_runtime_report_or_list(
+            coverage,
+            name="coverage",
+            expected_summary_types={"periodic_window_coverage"},
+        ),
+        consistency=_runtime_report_or_list(
+            consistency,
+            name="consistency",
+            expected_summary_types={"uniform_translation_consistency"},
+        ),
+        generator=generator_summary,
+        fit_diagnostics=fit_summary,
+        verification=_verification_summary_or_none(verification, name="verification"),
         extra_metrics=normalized_extra_metrics,
     )

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -16,6 +16,7 @@ _ROOT_RUNTIME_NAMES = {
     "compute_spectral_fd_derivatives",
     "diagnose_generator_family_closure",
     "diagnose_uniform_translation_consistency",
+    "diagnose_time_translation_consistency",
     "evaluate_discovery_recovery",
     "evaluate_weak_burgers_residual",
     "evaluate_weak_heat_residual",
@@ -37,16 +38,19 @@ _ROOT_RUNTIME_NAMES = {
     "run_heat_vertical_slice_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
+    "run_invariant_workflow_summary_example",
     "split_batch_train_heldout",
     "subsample_time",
     "subsample_x",
     "summarize_generator_fit_diagnostics",
     "summarize_generator_family",
+    "summarize_invariant_workflow",
     "summarize_recovery_grid",
     "summarize_residual_batch",
     "summarize_verification_report",
     "summarize_vertical_slice",
     "summarize_weak_residual_report",
+    "summarize_uniform_translation_orbit",
     "to_pysindy_trajectories",
     "to_sympy_component_expressions",
 }
@@ -59,6 +63,7 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "WeakHeatResidualEvaluator",
     "WeakKdVResidualEvaluator",
     "augment_translation_orbit",
+    "build_translation_orbit_dataset",
     "build_translation_orbit_views",
     "compute_coverage_diagnostics",
     "compute_weak_derivatives",
@@ -76,6 +81,7 @@ _DEFERRED_OR_PRIVATE_NAMES = {
 }
 _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.data.augment_translation_orbit",
+    "pdelie.data.build_translation_orbit_dataset",
     "pdelie.data.build_translation_orbit_views",
     "pdelie.data.compute_coverage_diagnostics",
     "pdelie.data.from_pdebench",
@@ -117,6 +123,10 @@ _V0_13_INVARIANT_APIS = {
     "pdelie.invariants.compute_periodic_window_coverage",
     "pdelie.invariants.diagnose_uniform_translation_consistency",
 }
+_V0_14_INVARIANT_WORKFLOW_APIS = {
+    "pdelie.invariants.summarize_uniform_translation_orbit",
+    "pdelie.reporting.summarize_invariant_workflow",
+}
 
 
 def _api_stability_text() -> str:
@@ -137,13 +147,15 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_11_DERIVATIVE_APIS
         | _V0_12_REPORTING_APIS
         | _V0_13_INVARIANT_APIS
+        | _V0_14_INVARIANT_WORKFLOW_APIS
     ):
         assert api_name in text
 
     assert "does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator" in text
     assert "these APIs have no root `pdelie` exports" in text
     assert "not canonical objects, artifact schemas, manuscript-table generators, or figure/rendering APIs" in text
-    assert "do not construct augmented datasets, orbit views, training branches" in text
+    assert "do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections" in text
+    assert "time-translation diagnostics remain deferred" in text
     assert "weak-form derivatives and weak-form methods beyond the frozen `v0.8` weak residual report slice" in text
     assert "operator symmetry" in text
 
@@ -160,6 +172,8 @@ def test_api_stability_doc_does_not_promote_deferred_v0_13_surfaces() -> None:
     assert "nonuniform grids" not in text
     assert "augment_translation_orbit" not in text
     assert "build_translation_orbit_views" not in text
+    assert "build_translation_orbit_dataset" not in text
+    assert "diagnose_time_translation_consistency" not in text
 
 
 def test_root_package_still_exposes_only_stable_canonical_surface() -> None:
@@ -190,6 +204,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
         },
         "pdelie.examples": {
             "run_heat_vertical_slice_example",
+            "run_invariant_workflow_summary_example",
             "run_kdv_vertical_slice_example",
             "run_orbit_coverage_diagnostics_example",
         },
@@ -197,6 +212,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "InvariantApplier",
             "compute_periodic_window_coverage",
             "diagnose_uniform_translation_consistency",
+            "summarize_uniform_translation_orbit",
         },
         "pdelie.portability": {
             "coerce_generator_family",
@@ -206,6 +222,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
         "pdelie.reporting": {
             "summarize_generator_fit_diagnostics",
             "summarize_generator_family",
+            "summarize_invariant_workflow",
             "summarize_residual_batch",
             "summarize_verification_report",
             "summarize_vertical_slice",
@@ -257,31 +274,31 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
             assert not hasattr(module, name), f"{module.__name__}.{name}"
 
 
-def test_v0_13_planning_docs_record_public_diagnostics_and_no_augmentation_scope() -> None:
+def test_v0_14_planning_docs_record_invariant_workflow_and_no_augmentation_scope() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_13_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_14_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
 
     assert "**Status:** COMPLETE" in plan
-    assert "Milestone 2 - Periodic Coverage Diagnostic" in plan
-    assert "pdelie.invariants.compute_periodic_window_coverage" in plan
-    assert "Milestone 3 - Translation Consistency Diagnostic" in plan
-    assert "pdelie.invariants.diagnose_uniform_translation_consistency" in plan
-    assert "diagnostics support invariant/finite-transform workflows but do not construct augmented datasets" in plan
+    assert "Milestone 2 - Combined Invariant Workflow Summary" in plan
+    assert "pdelie.reporting.summarize_invariant_workflow" in plan
+    assert "Milestone 3 - Uniform Translation Orbit Report" in plan
+    assert "pdelie.invariants.summarize_uniform_translation_orbit" in plan
+    assert "read-only runtime reports, not augmented datasets" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
     assert "no public augmentation utilities landed" in plan
     assert "## Milestone 6 - Release Gate and Readiness" in plan
-    assert "updated CI so the current explicit release gate is `v0_13-release-gate`" in plan
+    assert "updated CI so the current explicit release gate is `v0_14-release-gate`" in plan
     assert "- Milestone 6: COMPLETE" in plan
 
-    assert "diagnostics support invariant/finite-transform workflows but do not construct augmented datasets" in scope
-    assert "stable public augmentation utilities" in scope
-    assert "pdelie.invariants.compute_periodic_window_coverage" in scope
-    assert "pdelie.invariants.diagnose_uniform_translation_consistency" in scope
+    assert "read-only uniform translation orbit reports" in scope
+    assert "no time-translation API" in scope
+    assert "pdelie.reporting.summarize_invariant_workflow" in scope
+    assert "pdelie.invariants.summarize_uniform_translation_orbit" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
     assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.13` is the completed public orbit/coverage diagnostics release" in roadmap
-    assert "do not construct augmented datasets" in roadmap
+    assert "`v0.14` is the completed invariant workflow summary and orbit report release" in roadmap
+    assert "read-only runtime reports, not augmented datasets" in roadmap
     assert "- no new PDE" in roadmap

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,7 @@ import numpy as np
 import pdelie
 from pdelie.examples import (
     run_heat_vertical_slice_example,
+    run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
     run_orbit_coverage_diagnostics_example,
 )
@@ -161,3 +162,38 @@ def test_orbit_coverage_diagnostics_module_prints_json_only() -> None:
     assert parsed["summary_type"] == "orbit_coverage_diagnostics_example"
     np.testing.assert_allclose(parsed["coverage_cases"][0]["coverage_fraction"], 0.5)
     np.testing.assert_allclose(parsed["coverage_cases"][1]["coverage_fraction"], 1.0)
+
+
+def test_invariant_workflow_summary_example_runs_end_to_end() -> None:
+    result = run_invariant_workflow_summary_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "invariant_workflow_summary_example"
+    assert result["extra_metrics"]["example_name"] == "invariant_workflow_summary"
+    assert len(result["workflows"]) == 2
+    cases = {workflow["extra_metrics"]["case_name"]: workflow for workflow in result["workflows"]}
+    assert set(cases) == {"heat", "kdv"}
+    for workflow in cases.values():
+        assert workflow["summary_type"] == "invariant_workflow"
+        assert workflow["orbit"]["summary_type"] == "uniform_translation_orbit"
+        assert workflow["orbit"]["orbit_passed"] is True
+        assert workflow["coverage"]["summary_type"] == "periodic_window_coverage"
+        assert workflow["consistency"]["summary_type"] == "uniform_translation_consistency"
+        assert workflow["generator"]["summary_type"] == "generator_family"
+        assert workflow["fit_diagnostics"]["summary_type"] == "generator_fit_diagnostics"
+        assert workflow["verification"]["summary_type"] == "verification_report"
+        assert workflow["verification"]["classification"] != "failed"
+    assert cases["heat"]["verification"]["classification"] == "exact"
+    assert cases["kdv"]["fit_diagnostics"]["reference_fallback_used"] is False
+    assert not hasattr(pdelie, "run_invariant_workflow_summary_example")
+
+
+def test_invariant_workflow_summary_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.invariant_workflow_summary")
+
+    assert parsed["summary_type"] == "invariant_workflow_summary_example"
+    assert len(parsed["workflows"]) == 2
+    for workflow in parsed["workflows"]:
+        assert workflow["summary_type"] == "invariant_workflow"
+        assert workflow["orbit"]["orbit_passed"] is True

--- a/tests/test_invariant_diagnostics.py
+++ b/tests/test_invariant_diagnostics.py
@@ -9,7 +9,11 @@ import pytest
 from pdelie.contracts import FieldBatch
 from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
 from pdelie.errors import SchemaValidationError, ScopeValidationError
-from pdelie.invariants import compute_periodic_window_coverage, diagnose_uniform_translation_consistency
+from pdelie.invariants import (
+    compute_periodic_window_coverage,
+    diagnose_uniform_translation_consistency,
+    summarize_uniform_translation_orbit,
+)
 from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator
 
 
@@ -206,6 +210,76 @@ def test_uniform_translation_consistency_without_residual_evaluator_omits_residu
     assert report["residual_absolute_rms_delta"] is None
     assert report["residual_relative_rms_delta"] is None
     assert report["residual_stability_passed"] is None
+
+
+def test_uniform_translation_orbit_report_combines_coverage_consistency_and_provenance() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=64, seed=14011)
+    snapshot = field.to_dict()
+    shifts = [0.0, DOMAIN_LENGTH / 64.0, DOMAIN_LENGTH / 8.0, DOMAIN_LENGTH / 8.0, DOMAIN_LENGTH]
+    windows = [{"start": 0.0, "width": DOMAIN_LENGTH / 4.0}]
+
+    summary = summarize_uniform_translation_orbit(
+        field,
+        shifts=shifts,
+        windows=windows,
+        residual_evaluator=HeatResidualEvaluator(),
+        source_field_id="heat-orbit-fixture",
+    )
+
+    assert json.loads(json.dumps(summary)) == summary
+    _assert_json_plain(summary)
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "uniform_translation_orbit"
+    assert summary["source_field_id"] == "heat-orbit-fixture"
+    assert summary["field_dims"] == list(field.dims)
+    assert summary["field_shape"] == list(field.values.shape)
+    assert summary["equation"] is None
+    assert summary["raw_shifts"] == pytest.approx(shifts)
+    assert summary["normalized_shifts"] == pytest.approx([shift % DOMAIN_LENGTH for shift in shifts])
+    assert summary["transform_axis"] == "x"
+    assert summary["construction_method"] == "uniform_translation"
+    assert summary["transform_count"] == len(shifts)
+    assert summary["coverage"]["summary_type"] == "periodic_window_coverage"
+    assert summary["consistency"]["summary_type"] == "uniform_translation_consistency"
+    assert len(summary["orbit_reports"]) == len(shifts)
+    assert summary["orbit_passed"] is True
+    assert [report["shift"] for report in summary["orbit_reports"]] == pytest.approx(shifts)
+    for report in summary["orbit_reports"]:
+        assert report["transform_spec"]["construction_method"] == "uniform_translation"
+        assert report["transform_spec"]["parameters"]["axis"] == "x"
+        assert report["inverse_passed"] is True
+        assert report["period_wrap_passed"] is True
+        assert report["residual_stability_passed"] is True
+        assert report["consistency_passed"] is True
+        assert report["provenance_operation"] == "invariant_apply"
+        assert report["provenance_construction_method"] == "uniform_translation"
+    assert field.to_dict() == snapshot
+
+
+def test_uniform_translation_orbit_report_allows_report_only_minimal_mode() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=14012)
+
+    summary = summarize_uniform_translation_orbit(
+        field,
+        shifts=[0.0, DOMAIN_LENGTH],
+        source_field_id={"dataset": "synthetic", "index": 1},
+    )
+
+    assert summary["coverage"] is None
+    assert summary["source_field_id"] == {"dataset": "synthetic", "index": 1}
+    assert summary["orbit_passed"] is True
+    for report in summary["orbit_reports"]:
+        assert report["residual_stability_passed"] is None
+        assert report["consistency_passed"] is True
+    for report in summary["consistency"]["shift_reports"]:
+        assert report["residual_rms_before"] is None
+
+
+def test_uniform_translation_orbit_report_rejects_non_json_source_field_id() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=14013)
+
+    with pytest.raises(SchemaValidationError, match="source_field_id"):
+        summarize_uniform_translation_orbit(field, shifts=[0.0], source_field_id=object())
 
 
 def test_uniform_translation_consistency_rejects_unsupported_inputs() -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -49,6 +49,7 @@ def test_runtime_package_api_is_importable() -> None:
         InvariantApplier,
         compute_periodic_window_coverage,
         diagnose_uniform_translation_consistency,
+        summarize_uniform_translation_orbit,
     )
     from pdelie.portability import (
         coerce_generator_family,
@@ -59,6 +60,7 @@ def test_runtime_package_api_is_importable() -> None:
     from pdelie.reporting import (
         summarize_generator_fit_diagnostics,
         summarize_generator_family,
+        summarize_invariant_workflow,
         summarize_residual_batch,
         summarize_verification_report,
         summarize_vertical_slice,
@@ -88,11 +90,13 @@ def test_runtime_package_api_is_importable() -> None:
     assert InvariantApplier is not None
     assert compute_periodic_window_coverage is not None
     assert diagnose_uniform_translation_consistency is not None
+    assert summarize_uniform_translation_orbit is not None
     assert KdVResidualEvaluator is not None
     assert evaluate_weak_burgers_residual is not None
     assert evaluate_weak_heat_residual is not None
     assert summarize_generator_fit_diagnostics is not None
     assert summarize_generator_family is not None
+    assert summarize_invariant_workflow is not None
     assert summarize_residual_batch is not None
     assert summarize_verification_report is not None
     assert summarize_vertical_slice is not None
@@ -120,12 +124,15 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
     assert not hasattr(pdelie, "add_gaussian_noise")
     assert not hasattr(pdelie, "build_translation_canonical_discovery_inputs")
+    assert not hasattr(pdelie, "build_translation_orbit_dataset")
     assert not hasattr(pdelie, "build_translation_orbit_views")
     assert not hasattr(pdelie, "augment_translation_orbit")
     assert not hasattr(pdelie, "compute_periodic_window_coverage")
     assert not hasattr(pdelie, "compute_weak_derivatives")
     assert not hasattr(pdelie, "compute_coverage_diagnostics")
     assert not hasattr(pdelie, "diagnose_uniform_translation_consistency")
+    assert not hasattr(pdelie, "diagnose_time_translation_consistency")
+    assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
     assert not hasattr(pdelie, "evaluate_weak_burgers_residual")
     assert not hasattr(pdelie, "evaluate_weak_heat_residual")
     assert not hasattr(pdelie, "evaluate_weak_ks_residual")
@@ -141,6 +148,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "summarize_recovery_grid")
     assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
     assert not hasattr(pdelie, "summarize_generator_family")
+    assert not hasattr(pdelie, "summarize_invariant_workflow")
     assert not hasattr(pdelie, "summarize_orbit_coverage")
     assert not hasattr(pdelie, "summarize_orbit_coverage_feasibility")
     assert not hasattr(pdelie, "summarize_residual_batch")
@@ -159,6 +167,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(pdelie, "WeakKSResidualEvaluator")
     assert not hasattr(pdelie, "OperatorSymmetry")
+    assert not hasattr(pdelie, "run_invariant_workflow_summary_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(pdelie, "sample_kdv_mode_coefficients")
@@ -179,8 +188,11 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
     assert hasattr(invariants_module, "InvariantApplier")
     assert hasattr(invariants_module, "compute_periodic_window_coverage")
     assert hasattr(invariants_module, "diagnose_uniform_translation_consistency")
+    assert hasattr(invariants_module, "summarize_uniform_translation_orbit")
     assert not hasattr(invariants_module, "augment_translation_orbit")
+    assert not hasattr(invariants_module, "build_translation_orbit_dataset")
     assert not hasattr(invariants_module, "build_translation_orbit_views")
+    assert not hasattr(invariants_module, "diagnose_time_translation_consistency")
     assert not hasattr(invariants_module, "InvariantMapSpec")
 
 
@@ -234,6 +246,7 @@ def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
 
     assert hasattr(reporting_module, "summarize_generator_fit_diagnostics")
     assert hasattr(reporting_module, "summarize_generator_family")
+    assert hasattr(reporting_module, "summarize_invariant_workflow")
     assert not hasattr(reporting_module, "summarize_orbit_coverage")
     assert not hasattr(reporting_module, "summarize_orbit_coverage_feasibility")
     assert hasattr(reporting_module, "summarize_residual_batch")
@@ -246,6 +259,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     examples_module = importlib.import_module("pdelie.examples")
 
     assert hasattr(examples_module, "run_heat_vertical_slice_example")
+    assert hasattr(examples_module, "run_invariant_workflow_summary_example")
     assert hasattr(examples_module, "run_kdv_vertical_slice_example")
     assert hasattr(examples_module, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(examples_module, "run_ks_vertical_slice_example")

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -13,6 +13,7 @@ from pdelie.errors import SchemaValidationError, ScopeValidationError
 from pdelie.reporting import (
     summarize_generator_fit_diagnostics,
     summarize_generator_family,
+    summarize_invariant_workflow,
     summarize_residual_batch,
     summarize_verification_report,
     summarize_vertical_slice,
@@ -23,6 +24,11 @@ from pdelie.residuals import (
     HeatResidualEvaluator,
     evaluate_weak_burgers_residual,
     evaluate_weak_heat_residual,
+)
+from pdelie.invariants import (
+    compute_periodic_window_coverage,
+    diagnose_uniform_translation_consistency,
+    summarize_uniform_translation_orbit,
 )
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.symmetry.parameterization import translation_span_distance
@@ -353,6 +359,96 @@ def test_summarize_vertical_slice_defaults_extra_metrics_to_empty_mapping(heat_a
     )
 
     assert summary["extra_metrics"] == {}
+
+
+def test_summarize_invariant_workflow_combines_reports_and_canonical_objects(
+    heat_artifacts: dict[str, object],
+) -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=14020)
+    domain_length = 2.0 * np.pi
+    shifts = [0.0, domain_length / 16.0, domain_length]
+    coverage = compute_periodic_window_coverage(
+        x=field.coords["x"],
+        windows=[{"start": 0.0, "width": domain_length / 4.0}],
+        shifts=shifts,
+        domain_length=domain_length,
+    )
+    consistency = diagnose_uniform_translation_consistency(
+        field,
+        shifts=shifts,
+        residual_evaluator=HeatResidualEvaluator(),
+    )
+    orbit = summarize_uniform_translation_orbit(
+        field,
+        shifts=shifts,
+        windows=[{"start": 0.0, "width": domain_length / 4.0}],
+        residual_evaluator=HeatResidualEvaluator(),
+        source_field_id="heat-reporting-fixture",
+    )
+
+    summary = summarize_invariant_workflow(
+        orbit=orbit,
+        coverage=[coverage],
+        consistency=consistency,
+        generator=heat_artifacts["generator"],
+        verification=heat_artifacts["verification"],
+        extra_metrics={"numpy_array": np.asarray([1.0, 2.0])},
+    )
+
+    assert set(summary) == _SUMMARY_PREFIX_KEYS | {
+        "orbit",
+        "coverage",
+        "consistency",
+        "generator",
+        "fit_diagnostics",
+        "verification",
+        "extra_metrics",
+    }
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "invariant_workflow"
+    assert summary["orbit"]["summary_type"] == "uniform_translation_orbit"
+    assert summary["coverage"][0]["summary_type"] == "periodic_window_coverage"
+    assert summary["consistency"]["summary_type"] == "uniform_translation_consistency"
+    assert summary["generator"]["summary_type"] == "generator_family"
+    assert summary["fit_diagnostics"]["summary_type"] == "generator_fit_diagnostics"
+    assert summary["verification"]["summary_type"] == "verification_report"
+    assert summary["extra_metrics"] == {"numpy_array": [1.0, 2.0]}
+    _assert_json_serializable(summary)
+
+
+def test_summarize_invariant_workflow_accepts_precomputed_fit_summary(
+    heat_artifacts: dict[str, object],
+) -> None:
+    fit_summary = summarize_generator_fit_diagnostics(heat_artifacts["generator"])
+    verification_summary = summarize_verification_report(heat_artifacts["verification"])
+
+    summary = summarize_invariant_workflow(
+        fit_diagnostics=fit_summary,
+        verification=verification_summary,
+    )
+
+    assert summary["orbit"] is None
+    assert summary["coverage"] is None
+    assert summary["consistency"] is None
+    assert summary["generator"] is None
+    assert summary["fit_diagnostics"] == fit_summary
+    assert summary["verification"] == verification_summary
+    assert summary["extra_metrics"] == {}
+    _assert_json_serializable(summary)
+
+
+def test_summarize_invariant_workflow_rejects_malformed_reports() -> None:
+    with pytest.raises(SchemaValidationError, match="orbit"):
+        summarize_invariant_workflow(orbit={"summary_type": "periodic_window_coverage"})
+
+    with pytest.raises(SchemaValidationError, match="coverage"):
+        summarize_invariant_workflow(coverage={"summary_type": "uniform_translation_orbit"})
+
+    with pytest.raises(SchemaValidationError, match="report mapping"):
+        summarize_invariant_workflow(consistency=object())
+
+    with pytest.raises(SchemaValidationError, match="extra_metrics"):
+        summarize_invariant_workflow(extra_metrics=["not", "a", "mapping"])  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_13-release-gate"]
-    assert "python -m pytest tests/test_v0_13_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_14-release-gate"]
+    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
     for historical_job in range(4, 13):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_13-release-gate"]
-    assert "python -m pytest tests/test_v0_13_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_14-release-gate"]
+    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.13" in readme
+    assert "V0.14" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.13.0`" in publishing
+    assert "including `v0.14.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -56,18 +56,18 @@ def test_v0_12_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.13.0"
-    assert release_gate_jobs == ["v0_13-release-gate"]
-    assert "python -m pytest tests/test_v0_13_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.14.0"
+    assert release_gate_jobs == ["v0_14-release-gate"]
+    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
 
     assert "## 0.12.0" in changelog
-    assert "V0.13" in readme
+    assert "V0.14" in readme
     assert "summarize_generator_fit_diagnostics" in readme
     assert "package version: `0.12.0`" in readiness
     assert "git tag: `v0.12.0`" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.12`" in readiness
-    assert "including `v0.13.0`" in publishing
+    assert "including `v0.14.0`" in publishing
     assert "v0.12` is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.12` - Diagnostics and supportability hardening" in roadmap

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_13_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_14_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.13.0"
-    assert release_gate_jobs == ["v0_13-release-gate"]
-    assert "python -m pytest tests/test_v0_13_release_gate.py" in workflow
-    assert "v0_12-release-gate" not in workflow
+    assert pyproject["project"]["version"] == "0.14.0"
+    assert release_gate_jobs == ["v0_14-release-gate"]
+    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.13" in readme
+    assert "V0.14" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.13.0`" in readiness
-    assert "git tag: `v0.13.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.13`" in readiness
-    assert "including `v0.13.0`" in publishing
-    assert "Milestone 6: COMPLETE" in plan
+    assert "package version: `0.14.0`" in readiness
+    assert "git tag: `v0.14.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.14`" in readiness
+    assert "including `v0.14.0`" in publishing
+    assert "v0.13` is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.invariants import summarize_uniform_translation_orbit
+from pdelie.reporting import summarize_invariant_workflow
+from pdelie.residuals import HeatResidualEvaluator
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_14_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_14_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.14.0"
+    assert release_gate_jobs == ["v0_14-release-gate"]
+    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert "v0_13-release-gate" not in workflow
+
+    assert "## 0.14.0" in changelog
+    assert "V0.14" in readme
+    assert "summarize_invariant_workflow" in readme
+    assert "summarize_uniform_translation_orbit" in readme
+    assert "package version: `0.14.0`" in readiness
+    assert "git tag: `v0.14.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.14`" in readiness
+    assert "including `v0.14.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap
+    assert "**Status:** Completed" in roadmap
+
+
+def test_v0_14_release_gate_new_helpers_are_documented_and_submodule_only() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    invariants_module = importlib.import_module("pdelie.invariants")
+    reporting_module = importlib.import_module("pdelie.reporting")
+
+    assert hasattr(invariants_module, "summarize_uniform_translation_orbit")
+    assert hasattr(reporting_module, "summarize_invariant_workflow")
+    assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
+    assert not hasattr(pdelie, "summarize_invariant_workflow")
+    assert "pdelie.invariants.summarize_uniform_translation_orbit" in api_stability
+    assert "pdelie.reporting.summarize_invariant_workflow" in api_stability
+    assert "do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections" in api_stability
+    assert "time-translation diagnostics remain deferred" in api_stability
+
+
+def test_v0_14_release_gate_representative_invariant_workflow_summary() -> None:
+    domain_length = 2.0 * np.pi
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=14014)
+    orbit = summarize_uniform_translation_orbit(
+        field,
+        shifts=[0.0, domain_length / 16.0, domain_length],
+        windows=[{"start": 0.0, "width": domain_length / 4.0}],
+        residual_evaluator=HeatResidualEvaluator(),
+        source_field_id="v0_14_release_gate_heat",
+    )
+    workflow = summarize_invariant_workflow(
+        orbit=orbit,
+        coverage=orbit["coverage"],
+        consistency=orbit["consistency"],
+        extra_metrics={"release_gate": "v0.14"},
+    )
+
+    assert json.loads(json.dumps(workflow)) == workflow
+    assert orbit["summary_type"] == "uniform_translation_orbit"
+    assert orbit["source_field_id"] == "v0_14_release_gate_heat"
+    assert orbit["orbit_passed"] is True
+    assert orbit["coverage"]["summary_type"] == "periodic_window_coverage"
+    assert orbit["consistency"]["summary_type"] == "uniform_translation_consistency"
+    assert len(orbit["orbit_reports"]) == 3
+    assert [report["shift"] for report in orbit["orbit_reports"]] == [0.0, domain_length / 16.0, domain_length]
+    for report in orbit["orbit_reports"]:
+        assert report["transform_spec"]["construction_method"] == "uniform_translation"
+        assert report["inverse_passed"] is True
+        assert report["period_wrap_passed"] is True
+        assert report["residual_stability_passed"] is True
+        assert "FieldBatch" not in repr(report)
+
+    assert workflow["summary_schema_version"] == "0.1"
+    assert workflow["summary_type"] == "invariant_workflow"
+    assert workflow["orbit"]["summary_type"] == "uniform_translation_orbit"
+    assert workflow["coverage"]["summary_type"] == "periodic_window_coverage"
+    assert workflow["consistency"]["summary_type"] == "uniform_translation_consistency"
+    assert workflow["extra_metrics"] == {"release_gate": "v0.14"}
+
+
+def test_v0_14_release_gate_no_deferred_surface_leaked() -> None:
+    modules = [
+        pdelie,
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.invariants"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.examples"),
+        importlib.import_module("pdelie.discovery"),
+    ]
+    forbidden_names = {
+        "augment_translation_orbit",
+        "build_translation_orbit_dataset",
+        "build_translation_orbit_views",
+        "compute_coverage_diagnostics",
+        "compute_weak_derivatives",
+        "diagnose_time_translation_consistency",
+        "evaluate_weak_ks_residual",
+        "from_pdebench",
+        "from_the_well",
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "load_pdebench",
+        "load_the_well",
+        "run_ks_vertical_slice_example",
+        "WeakKSResidualEvaluator",
+    }
+
+    for module in modules:
+        for name in sorted(forbidden_names):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"


### PR DESCRIPTION
## Summary

This PR completes `v0.14.0` as a narrow invariant-workflow supportability release.

It adds two submodule-only public APIs:

- `pdelie.invariants.summarize_uniform_translation_orbit(...)`
- `pdelie.reporting.summarize_invariant_workflow(...)`

These combine the existing coverage, consistency, fit, and verification diagnostics into reusable JSON-compatible runtime reports while keeping orbit handling read-only and report-only.

## Scope

`v0.14` supports:

- read-only uniform translation orbit reports
- optional `source_field_id` provenance
- combined invariant workflow summaries
- Heat/KdV end-to-end invariant workflow example:
  - `python -m pdelie.examples.invariant_workflow_summary`

This release does **not** add augmented datasets, transformed `FieldBatch` collections, orbit dataset builders, train/test policy, time translation, new PDEs, KS promotion, weak KS, broad adapters, operator APIs, or root exports.

## Validation

- `python -m pytest`: passed
- targeted v0.14/public/API/reporting/example suites: passed
- `python -m build --sdist --wheel`: built `pdelie-0.14.0`
- clean wheel smoke: passed
- examples passed:
  - `python -m pdelie.examples.heat_vertical_slice`
  - `python -m pdelie.examples.kdv_vertical_slice`
  - `python -m pdelie.examples.orbit_coverage_diagnostics`
  - `python -m pdelie.examples.invariant_workflow_summary`
- `git diff --check`: clean