### PR TITLE
Implement v0.15 translation orbit batch materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_14-release-gate:
+  v0_15-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.14 release gate
-        run: python -m pytest tests/test_v0_14_release_gate.py
+      - name: Run V0.15 release gate
+        run: python -m pytest tests/test_v0_15_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +69,7 @@ jobs:
           python -m pdelie.examples.kdv_vertical_slice
           python -m pdelie.examples.orbit_coverage_diagnostics
           python -m pdelie.examples.invariant_workflow_summary
+          python -m pdelie.examples.translation_orbit_batch
   package-smoke:
     runs-on: ubuntu-latest
     steps:
@@ -124,6 +125,8 @@ jobs:
 
           from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport
           from pdelie.invariants import (
+              OrbitBatchResult,
+              build_uniform_translation_orbit_batch,
               compute_periodic_window_coverage,
               diagnose_uniform_translation_consistency,
               summarize_uniform_translation_orbit,
@@ -144,6 +147,8 @@ jobs:
           assert ResidualEvaluator is not None
           assert GeneratorFamily is not None
           assert VerificationReport is not None
+          assert OrbitBatchResult is not None
+          assert build_uniform_translation_orbit_batch is not None
           assert compute_periodic_window_coverage is not None
           assert diagnose_uniform_translation_consistency is not None
           assert summarize_uniform_translation_orbit is not None
@@ -160,6 +165,8 @@ jobs:
           assert not hasattr(pdelie, "diagnose_uniform_translation_consistency")
           assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
           assert not hasattr(pdelie, "summarize_invariant_workflow")
+          assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
+          assert not hasattr(pdelie, "OrbitBatchResult")
           print("stable-import-ok")
           PY
       - name: Invariant diagnostics smoke
@@ -171,6 +178,7 @@ jobs:
 
           from pdelie.data import generate_heat_1d_field_batch
           from pdelie.invariants import (
+              build_uniform_translation_orbit_batch,
               compute_periodic_window_coverage,
               diagnose_uniform_translation_consistency,
               summarize_uniform_translation_orbit,
@@ -191,6 +199,17 @@ jobs:
           assert coverage["coverage_fraction"] == 0.5
 
           field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=13013)
+          orbit_batch = build_uniform_translation_orbit_batch(
+              field,
+              shifts=[0.0, domain_length],
+              source_field_id="package-smoke-heat",
+          )
+          json.dumps(orbit_batch.report)
+          assert orbit_batch.report["summary_type"] == "uniform_translation_orbit_batch"
+          assert orbit_batch.field.values.shape[0] == 2
+          assert orbit_batch.report["source_batch_indices"] == [0, 0]
+          assert orbit_batch.report["shift_indices"] == [0, 1]
+
           consistency = diagnose_uniform_translation_consistency(
               field,
               shifts=[0.0, domain_length],
@@ -221,6 +240,8 @@ jobs:
           assert not hasattr(pdelie, "diagnose_uniform_translation_consistency")
           assert not hasattr(pdelie, "summarize_uniform_translation_orbit")
           assert not hasattr(pdelie, "summarize_invariant_workflow")
+          assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
+          assert not hasattr(pdelie, "OrbitBatchResult")
           assert not hasattr(pdelie, "augment_translation_orbit")
           assert not hasattr(pdelie, "build_translation_orbit_dataset")
           print("invariant-diagnostics-smoke-ok")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.15.0
+
+First final release for the frozen V0.15 materialized uniform translation orbit batch slice.
+
+- adds `pdelie.invariants.build_uniform_translation_orbit_batch(...)` for materializing finite uniform `x`-translation orbit batches from canonical scalar 1D periodic `FieldBatch` inputs
+- adds `pdelie.invariants.OrbitBatchResult` as a runtime-only structured result containing the materialized `FieldBatch` and a JSON-compatible provenance report
+- preserves raw shift order and duplicate shifts, appends along the batch dimension in shift-major order, and records optional source/shift indices
+- records aggregate orbit-materialization metadata and one aggregate preprocess-log entry on the output field
+- adds `python -m pdelie.examples.translation_orbit_batch` and `pdelie.examples.run_translation_orbit_batch_example(...)` as runtime smoke examples for Heat and KdV orbit batches
+- documents the new helper in `API_STABILITY.md` as a submodule-only runtime API with no root exports
+- tightens public-surface guards so train/test policy, split management, time translation, KS APIs, weak KS, broad adapters, and root runtime exports remain absent
+- updates CI to the compact current `v0_15-release-gate` while preserving full editable tests and package smoke
+- preserves the prior Heat/Burgers strong paths, `v0.8` weak residual report APIs, `v0.9` normalized periodic KdV strong path, `v0.10` reporting helpers, `v0.11` order-4 derivatives, `v0.12` fit diagnostics, `v0.13` orbit/coverage diagnostics, and `v0.14` invariant workflow summaries
+
+Explicitly deferred for this final release:
+
+- train/test policy, split management, or heldout-leakage detection
+- sparse-discovery branch policy or private-paper augmentation recipes
+- time-translation APIs or `axis="time"` support
+- new PDE support
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak API, or root KS exports
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.14.0
 
 First final release for the frozen V0.14 invariant workflow summary and read-only translation orbit report slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.14 invariant workflow summary and read-only translation orbit report slice for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.15 materialized uniform translation orbit batch slice for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -18,6 +18,7 @@ The current repository implements the frozen V0.14 invariant workflow summary an
 - public orbit/coverage diagnostics under `pdelie.invariants`
 - invariant workflow summaries under `pdelie.reporting.summarize_invariant_workflow`
 - read-only uniform translation orbit reports under `pdelie.invariants.summarize_uniform_translation_orbit`
+- materialized uniform translation orbit batches under `pdelie.invariants.build_uniform_translation_orbit_batch`
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -32,7 +33,7 @@ The current repository implements the frozen V0.14 invariant workflow summary an
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_14-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_15-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -81,7 +82,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.14`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.15`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -103,6 +104,7 @@ python -m pdelie.examples.heat_vertical_slice
 python -m pdelie.examples.kdv_vertical_slice
 python -m pdelie.examples.orbit_coverage_diagnostics
 python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
 ```
 
 Those commands are validated in CI after editable install.
@@ -138,6 +140,13 @@ The invariant workflow summary example demonstrates:
 3. generator fit diagnostics and finite-transform verification summaries
 4. report-only provenance through optional `source_field_id` values
 
+The translation orbit batch example demonstrates:
+
+1. materialized uniform translation orbit batches for Heat and KdV fixtures
+2. shift-major batch growth with duplicate shifts preserved
+3. source/shift provenance in a JSON-compatible report
+4. residual sanity on the materialized `FieldBatch` outputs
+
 You can also call the examples programmatically.
 They return JSON-compatible runtime summaries, not canonical artifact schemas.
 The Heat and KdV examples return nested `vertical_slice` summaries; the invariant examples return diagnostic/workflow summaries:
@@ -148,6 +157,7 @@ from pdelie.examples import (
     run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
     run_orbit_coverage_diagnostics_example,
+    run_translation_orbit_batch_example,
 )
 
 result = run_kdv_vertical_slice_example()
@@ -158,6 +168,9 @@ print(coverage["coverage_cases"][0]["coverage_fraction"])
 
 workflow = run_invariant_workflow_summary_example()
 print(workflow["workflows"][0]["summary_type"])
+
+orbit_batch = run_translation_orbit_batch_example()
+print(orbit_batch["cases"][0]["orbit_report"]["output_batch_size"])
 ```
 
 ## Current Scope
@@ -183,8 +196,9 @@ Included in the current stable core:
 - KS remains internal feasibility/no-go evidence from `v0.11` plus internal diagnostic sweep evidence in `v0.12`; no stable KS runtime API is promoted
 - orbit/coverage diagnostics from `v0.13` are public under `pdelie.invariants`; they report coverage and consistency but do not construct augmented datasets
 - invariant workflow summaries and uniform translation orbit reports in `v0.14` are read-only runtime reports; they do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections
+- materialized uniform translation orbit batches in `v0.15` are conservative data utilities; they append along batch and record provenance, but do not manage train/test splits or leakage policy
 
-Runtime-level public APIs in the frozen V0.14 slice:
+Runtime-level public APIs in the frozen V0.15 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -205,8 +219,11 @@ Runtime-level public APIs in the frozen V0.14 slice:
 - `pdelie.invariants.compute_periodic_window_coverage` for JSON-compatible grid-point coverage diagnostics over endpoint-excluded periodic 1D grids, half-open windows, and uniform translation shifts
 - `pdelie.invariants.diagnose_uniform_translation_consistency` for JSON-compatible diagnostics of uniform-translation structure, inverse/period-wrap consistency, provenance, and optional residual stability
 - `pdelie.invariants.summarize_uniform_translation_orbit` for read-only uniform `x`-translation orbit reports over canonical scalar 1D periodic `FieldBatch` inputs
+- `pdelie.invariants.build_uniform_translation_orbit_batch` for materialized uniform `x`-translation orbit batches with provenance reports
+- `pdelie.invariants.OrbitBatchResult` as a runtime-only structured result containing the materialized `FieldBatch` and report
 - `pdelie.examples.run_orbit_coverage_diagnostics_example` for a runtime smoke example of the public orbit/coverage diagnostics, not a canonical report schema
 - `pdelie.examples.run_invariant_workflow_summary_example` for a runtime smoke example combining Heat, KdV, coverage, orbit, fit, and verification summaries
+- `pdelie.examples.run_translation_orbit_batch_example` for a runtime smoke example of materialized orbit batches, not a canonical report schema
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
 - `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support/coefficient recovery metrics over caller-supplied canonical term strings
 - `pdelie.discovery.fit_pysindy_discovery` for a runtime-only backend-native PySINDy fit adapter
@@ -223,7 +240,7 @@ Runtime-level public APIs in the frozen V0.14 slice:
 
 The degraded weak-path release wins in `v0.8` are frozen as representative contract-stability signals. They are fallback-backed release checks, not a general weak-superiority claim.
 
-The KdV support retained through `v0.13` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+The KdV support retained through `v0.15` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
 
 The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 
@@ -234,6 +251,8 @@ The `v0.12` diagnostics work hardens supportability without changing numerical s
 The `v0.13` diagnostics work promotes only the reusable orbit/coverage reporting layer under `pdelie.invariants`. These diagnostics support invariant and finite-transform workflows but do not construct augmented datasets, orbit views, train branches, or manuscript artifacts.
 
 The `v0.14` workflow work adds read-only orbit reports and combined invariant workflow summaries. These helpers combine existing reports and canonical objects into JSON-compatible runtime summaries; they do not construct augmented datasets, orbit datasets, transformed `FieldBatch` collections, or time-translation APIs.
+
+The `v0.15` data-utility work adds materialized uniform translation orbit batches. This is the first conservative user-facing data utility beyond diagnostics: it returns a `FieldBatch` plus provenance report, preserves duplicate shifts, and records source/shift indices when requested. It still does not manage train/test splits, leakage policy, or downstream experiment design.
 
 Explicitly deferred:
 - stable multi-generator PDE fitting
@@ -249,7 +268,8 @@ Explicitly deferred:
 - custom KdV initial conditions or configurable KdV coefficients
 - general KdV support outside the frozen normalized periodic short-horizon regime
 - stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export
-- public orbit-view builders or augmentation utilities
-- orbit dataset builders or transformed `FieldBatch` collections from reporting helpers
+- public orbit-view builders beyond the frozen materialized uniform translation orbit batch helper
+- train/test split management, heldout-leakage detection, or downstream augmentation policy
+- transformed `FieldBatch` collections from reporting helpers
 - time-translation APIs or `axis="time"` support
 - broad adapters and interoperability work

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,18 +1,18 @@
-# PDELie - Execution Plan (V0.14)
+# PDELie - Execution Plan (V0.15)
 
 ## Current Release Status
 
-**V0.14 is complete as invariant workflow summaries and read-only translation orbit reports**
+**V0.15 is complete as materialized uniform translation orbit batches**
 
-This file is the completed execution record for the `v0.14` release series.
+This file is the completed execution record for the `v0.15` release series.
 
 Committed release theme:
 
-`FieldBatch + uniform x-translation shifts + optional windows + residual/fit/verification outputs -> read-only orbit report + combined invariant workflow summary`
+`canonical scalar 1D periodic FieldBatch + finite uniform x-shifts -> materialized orbit FieldBatch + JSON-compatible provenance report`
 
 The important release boundary is:
 
-> v0.14 adds read-only runtime reports, not augmented datasets, transformed FieldBatch collections, orbit datasets, or time-translation support.
+> v0.15 adds one conservative data utility for materializing uniform translation orbit batches. It does not add train/test policy, split management, time translation, new PDEs, KS promotion, weak KS, broad adapters, operator APIs, or root exports.
 
 This file should not redefine package contracts.
 Contracts and stable behavior belong in:
@@ -21,28 +21,26 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_14_SCOPE.md`
+- `docs/planning/V0_15_SCOPE.md`
 
-`API_STABILITY.md` was updated when the two public `v0.14` reporting/invariant helpers landed.
+`API_STABILITY.md` was updated when the public `v0.15` orbit-batch helper landed.
 
 ---
 
-## V0.13 Closeout
+## V0.14 Closeout
 
-`v0.12` is complete as diagnostics and supportability hardening.
-
-`v0.13` is complete as public orbit and coverage diagnostics.
+`v0.14` is complete as invariant workflow summaries and read-only uniform translation orbit reports.
 
 Completed outcome:
 
-- public `pdelie.invariants.compute_periodic_window_coverage(...)`
-- public `pdelie.invariants.diagnose_uniform_translation_consistency(...)`
-- JSON-only orbit/coverage diagnostics example
-- no public augmentation utilities or orbit-view builders
-- compact `v0_13-release-gate`
+- public `pdelie.reporting.summarize_invariant_workflow(...)`
+- public `pdelie.invariants.summarize_uniform_translation_orbit(...)`
+- JSON-only invariant workflow summary example
+- no augmented datasets or transformed `FieldBatch` collections from reporting helpers
+- compact `v0_14-release-gate`
 
-`v0.14` begins from that diagnostic evidence and promotes only read-only workflow summaries and orbit reports.
-It does not promote augmentation policy, transformed datasets, time translation, or KS runtime APIs.
+`v0.15` begins from that read-only diagnostic/reporting surface and promotes only a narrow, provenance-rich materialization helper.
+It does not promote train/test policy, split management, time translation, or KS runtime APIs.
 
 ---
 
@@ -52,17 +50,17 @@ It does not promote augmentation policy, transformed datasets, time translation,
 
 ### Goal
 
-Freeze `v0.14` as invariant workflow summaries plus read-only uniform translation orbit reports.
+Freeze `v0.15` as materialized uniform translation orbit batches.
 
 ### Completed Outcome
 
-- added `docs/planning/V0_14_SCOPE.md`
-- reset `PLAN.md` as the active `v0.14` execution record
-- updated `ROADMAP.md` to record `v0.14` as the current completed supportability release
+- added `docs/planning/V0_15_SCOPE.md`
+- reset `PLAN.md` as the active `v0.15` execution record
+- updated `ROADMAP.md` to record `v0.15` as the current completed data-utility release
 - recorded explicit non-goals:
-  - no augmented datasets
-  - no transformed `FieldBatch` collections
-  - no orbit dataset builders
+  - no train/test policy
+  - no split management
+  - no heldout-leakage detection
   - no time-translation API
   - no KS promotion
   - no new PDE
@@ -77,104 +75,97 @@ Freeze `v0.14` as invariant workflow summaries plus read-only uniform translatio
 
 ### Goal
 
-Freeze report schemas and semantics before implementation.
+Freeze materialization semantics before implementation.
 
 ### Completed Outcome
 
-For `summarize_uniform_translation_orbit(...)`, M1 froze:
+M1 froze:
 
+- public submodule-only API name:
+  - `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
+- runtime-only structured return:
+  - `pdelie.invariants.OrbitBatchResult`
+- `OrbitBatchResult` is not a canonical object and has no schema migration policy
 - canonical scalar 1D uniform periodic `FieldBatch` scope
-- read-only report output
-- no returned transformed `FieldBatch` objects
-- no input mutation
-- raw shift order and duplicate shifts are preserved
-- optional `source_field_id` is JSON-compatible provenance metadata only
-- optional windows reuse `v0.13` periodic-window coverage semantics
-- optional residual evaluator reuses `v0.13` translation-consistency semantics
-- per-shift transform spec and provenance summaries are reported
-
-For `summarize_invariant_workflow(...)`, M1 froze:
-
-- JSON-compatible runtime summary output
-- nested coverage, consistency, orbit, generator, fit, and verification summaries
-- canonical `GeneratorFamily` and `VerificationReport` inputs are summarized through existing reporting helpers
-- existing `v0.10` and `v0.12` reporting schemas remain unchanged
-
-Time translation remains deferred.
+- non-empty finite shift sequence
+- shift-major output ordering
+- duplicate-shift preservation
+- output batch size equals `source_batch_size * len(shifts)`
+- optional `source_field_id` as JSON-compatible provenance metadata only
+- optional source and shift index recording
+- mask concatenation along batch
+- one aggregate `materialize_uniform_translation_orbit_batch` preprocess entry
+- `orbit_materialization` metadata on the output field
+- `copy=False` may avoid extra coordinate or mask copies where safe, but inputs are never mutated
 
 ---
 
-## Milestone 2 - Combined Invariant Workflow Summary
+## Milestone 2 - Orbit Batch Implementation
 
 **Status:** COMPLETE
 
 ### Goal
 
-Add the combined workflow report helper under `pdelie.reporting`.
+Add the materialized uniform translation orbit batch helper under `pdelie.invariants`.
 
 ### Completed Outcome
 
 - added public submodule-only helper:
-  - `pdelie.reporting.summarize_invariant_workflow(...)`
-- supports:
-  - `periodic_window_coverage` reports
-  - `uniform_translation_consistency` reports
-  - `uniform_translation_orbit` reports
-  - `GeneratorFamily` objects or `generator_family` summaries
-  - `VerificationReport` objects or `verification_report` summaries
-  - `GeneratorFamily` objects or `generator_fit_diagnostics` summaries for fit diagnostics
-  - optional extra metrics
-- returns `summary_type = "invariant_workflow"`
-- creates no canonical object and mutates no inputs
-- documented the API in `docs/specs/API_STABILITY.md`
-
----
-
-## Milestone 3 - Uniform Translation Orbit Report
-
-**Status:** COMPLETE
-
-### Goal
-
-Add the read-only uniform translation orbit report under `pdelie.invariants`.
-
-### Completed Outcome
-
-- added public submodule-only helper:
-  - `pdelie.invariants.summarize_uniform_translation_orbit(...)`
-- returns `summary_type = "uniform_translation_orbit"`
-- includes:
-  - optional `source_field_id`
-  - field shape and equation metadata
+  - `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
+- added runtime-only structured return:
+  - `pdelie.invariants.OrbitBatchResult`
+- implementation reuses existing `InvariantApplier`
+- output `FieldBatch` appends along batch in shift-major order
+- report records:
+  - source/output shapes
   - raw and normalized shifts
-  - one transform spec and provenance summary per shift
-  - optional coverage diagnostics
-  - translation consistency diagnostics
-  - orbit-level pass flags
-- returns no transformed `FieldBatch` objects
-- constructs no augmented dataset or orbit dataset
+  - source/shift indices when requested
+  - batch records
+  - transform specs
+  - metadata/preprocess provenance
 - documented the API in `docs/specs/API_STABILITY.md`
 
 ---
 
-## Milestone 4 - Useful End-to-end Example
+## Milestone 3 - Compatibility And Diagnostics
 
 **Status:** COMPLETE
 
 ### Goal
 
-Add a compact JSON-only example that combines the new report surfaces.
+Verify materialized orbit batches remain compatible with existing stable numerical paths.
 
 ### Completed Outcome
 
-- added `python -m pdelie.examples.invariant_workflow_summary`
-- added `pdelie.examples.run_invariant_workflow_summary_example(...)`
-- example combines:
-  - Heat orbit/coverage/consistency diagnostics
-  - KdV orbit/coverage/consistency diagnostics
-  - generator fit diagnostics
-  - verification summaries
-  - combined invariant workflow summaries
+- verified materialized Heat orbit batches validate as `FieldBatch` objects
+- verified materialized KdV orbit batches validate as `FieldBatch` objects
+- verified derivatives run on representative materialized Heat and KdV batches
+- verified Heat and KdV residual diagnostics remain finite
+- verified duplicate shifts remain traceable through provenance
+- verified input fields are not mutated
+- verified masks are concatenated consistently with transformed fields
+
+---
+
+## Milestone 4 - Example
+
+**Status:** COMPLETE
+
+### Goal
+
+Add a compact JSON-only example for materialized orbit batches.
+
+### Completed Outcome
+
+- added `python -m pdelie.examples.translation_orbit_batch`
+- added `pdelie.examples.run_translation_orbit_batch_example(...)`
+- example demonstrates:
+  - Heat orbit batch materialization
+  - KdV orbit batch materialization
+  - source/output shape growth
+  - duplicate-shift preservation
+  - source/shift provenance
+  - residual sanity on the materialized batches
 - example output remains a runtime smoke summary, not a canonical artifact schema
 - root `pdelie` remains unchanged
 
@@ -186,20 +177,20 @@ Add a compact JSON-only example that combines the new report surfaces.
 
 ### Goal
 
-Verify public surface and documentation match the frozen `v0.14` scope.
+Verify public surface and documentation match the frozen `v0.15` scope.
 
 ### Completed Outcome
 
-- confirmed `pdelie.reporting.summarize_invariant_workflow(...)` is submodule-only
-- confirmed `pdelie.invariants.summarize_uniform_translation_orbit(...)` is submodule-only
+- confirmed `pdelie.invariants.build_uniform_translation_orbit_batch(...)` is submodule-only
+- confirmed `pdelie.invariants.OrbitBatchResult` is submodule-only
 - confirmed root `pdelie` exports remain unchanged
-- confirmed no public augmentation utilities landed
-- confirmed no orbit dataset builder landed
+- confirmed no train/test policy landed
+- confirmed no split-management or leakage-detection helper landed
 - confirmed no time-translation API landed
 - confirmed public KS generator/residual/example APIs remain absent
 - confirmed weak KS remains absent
 - confirmed broad adapters remain absent
-- confirmed `API_STABILITY.md` documents the new helpers and does not document augmentation or time-translation APIs
+- confirmed `API_STABILITY.md` documents the new helper and does not document deferred surfaces
 
 ---
 
@@ -213,30 +204,30 @@ Close the release with compact gate coverage, metadata, docs, and direct Git-tag
 
 ### Completed Outcome
 
-- added compact `tests/test_v0_14_release_gate.py`
-- updated CI so the current explicit release gate is `v0_14-release-gate`
+- added compact `tests/test_v0_15_release_gate.py`
+- updated CI so the current explicit release gate is `v0_15-release-gate`
 - retained full editable tests and package smoke
-- added compact package-smoke coverage for the new workflow/orbit reports
-- bumped package metadata to `0.14.0`
-- updated README and changelog for `v0.14`
-- added `docs/releases/V0_14_RELEASE_READINESS.md`
-- updated publishing docs to keep `v0.14.0` Git-tag-only
-- moved `v0.14` into completed release context in `ROADMAP.md`
+- added compact package-smoke coverage for the new orbit-batch helper
+- bumped package metadata to `0.15.0`
+- updated README and changelog for `v0.15`
+- added `docs/releases/V0_15_RELEASE_READINESS.md`
+- updated publishing docs to keep `v0.15.0` Git-tag-only
+- moved `v0.15` into completed release context in `ROADMAP.md`
 - kept PyPI/TestPyPI deferred until `v1.0` or later
 
 ### Direct Tag Path
 
-Before tagging `v0.14.0`:
+Before tagging `v0.15.0`:
 
 - run full local tests
 - build sdist and wheel
 - run clean wheel smoke
-- run Heat, KdV, orbit/coverage, and invariant-workflow example modules
+- run Heat, KdV, orbit/coverage, invariant-workflow, and translation-orbit-batch example modules
 - confirm CI checks pass:
-  - `v0_14-release-gate`
+  - `v0_15-release-gate`
   - `editable-tests`
   - `package-smoke`
-- tag the merged main commit as `v0.14.0`
+- tag the merged main commit as `v0.15.0`
 - do not publish to TestPyPI
 - do not publish to PyPI
 
@@ -244,8 +235,14 @@ Before tagging `v0.14.0`:
 
 ## Explicit Non-goals Preserved
 
-`v0.14` did not add:
+`v0.15` did not add:
 
+- train/test policy
+- split management
+- heldout-leakage detection
+- sparse-discovery branch policy
+- private-paper augmentation recipes
+- time-translation APIs
 - new PDE support
 - stable KS runtime support
 - weak KS
@@ -253,11 +250,6 @@ Before tagging `v0.14.0`:
 - PDEBench or The Well support
 - multidimensional, multivariable, or nonuniform-grid expansion
 - operator-facing APIs
-- public augmentation utilities
-- orbit dataset builders
-- transformed `FieldBatch` collections from reporting helpers
-- train-augmentation policy
-- time-translation APIs
 - root runtime exports
 
 ---

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -453,6 +453,81 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.15` - Materialized uniform translation orbit batches
+**Status:** Completed
+
+`v0.15` is the completed materialized translation orbit batch release after the `v0.14` invariant workflow summary release.
+
+Its purpose is:
+
+> promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
+
+Completed release definition:
+
+`canonical scalar 1D periodic FieldBatch + finite uniform x-shifts -> materialized orbit FieldBatch + JSON-compatible provenance report`
+
+Completed scope:
+
+- `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
+- `pdelie.invariants.OrbitBatchResult`
+- shift-major batch materialization
+- duplicate-shift preservation
+- optional `source_field_id` provenance metadata
+- optional source and shift index reporting
+- aggregate orbit-materialization metadata and preprocess provenance
+- Heat and KdV translation orbit batch example
+- API/public-surface audit
+- compact current `v0_15-release-gate` readiness
+
+Release interpretation:
+
+- this is the first conservative user-facing data utility beyond diagnostics
+- it materializes a `FieldBatch`, but does not manage experimental partitions
+- no train/test policy, split management, or heldout-leakage detection is promoted
+- time-translation diagnostics remain deferred
+- `v0.15.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no train/test policy
+- no split management
+- no heldout-leakage detection
+- no sparse-discovery branch policy
+- no private-paper augmentation recipe
+- no time-translation APIs
+- no new PDE
+- no stable KS generator or residual evaluator
+- no weak KS API
+- no broad dataset adapters
+- no PDEBench or The Well support
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no root export expansion
+
+The authoritative `v0.15` scope freeze belongs in:
+
+- `V0_15_SCOPE.md`
+
+### Release Gate for `v0.15`
+
+`v0.15` is complete only if:
+
+- orbit-batch materialization is documented and covered by tests
+- new APIs are importable from `pdelie.invariants` only
+- root `pdelie` remains unchanged
+- representative Heat and KdV orbit batches validate as `FieldBatch` objects
+- output shape and provenance follow the frozen shift-major ordering
+- duplicate shifts remain traceable
+- residual diagnostics remain finite on representative materialized batches
+- the translation-orbit-batch example emits JSON only
+- no public train/test policy, split management, time-translation, KS, weak KS, broad adapter, or operator API lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.14` - Invariant workflow summaries and read-only orbit reports
 **Status:** Completed
 
@@ -710,42 +785,6 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
-### `v0.15` - Materialized uniform translation orbit batches
-**Status:** Planned
-
-`v0.15` is the planned next major direction after the `v0.14` invariant workflow summary release, but it is not yet the active committed release until a `v0.15` M0 scope freeze opens.
-
-Planned theme:
-
-> promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
-
-Candidate API direction:
-
-- `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
-
-Scope to freeze before implementation:
-
-- augmentation appends along the batch dimension
-- duplicate shifts are preserved
-- source indices and shift indices are recorded as provenance/report metadata
-- masks are transformed and concatenated consistently with existing `InvariantApplier` behavior
-- preprocess logs append one orbit-materialization entry
-- metadata records group/action parameters
-- no train/test policy is applied
-- no split management or heldout-leakage detection is attempted
-- return shape is explicit, preferably `(FieldBatch, report)` or a named structured pair rather than a silent `FieldBatch`-only result
-
-Interpretation:
-
-- this would be the first truly user-facing data utility beyond diagnostics
-- it remains paper-agnostic
-- it does not add sparse-discovery branch policy or train/heldout management
-- it does not add time translation, a new PDE, or root exports
-
-The detailed strategy note belongs in:
-
-- `V0_15_PLUS_STRATEGY.md`
-
 ### `v0.16` - External symmetry-candidate interop
 **Status:** Planned
 
@@ -862,6 +901,7 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_12_SCOPE.md` once frozen
 - `V0_13_SCOPE.md` once frozen
 - `V0_14_SCOPE.md` once frozen
+- `V0_15_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -901,7 +941,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.12` = diagnostics and supportability hardening for fitting, verification, reporting, and orbit/coverage diagnostics
 - `v0.13` = public orbit/coverage diagnostics under `pdelie.invariants`, without augmentation
 - `v0.14` = invariant workflow summaries and read-only uniform translation orbit reports, without augmentation
-- `v0.15` = materialized uniform translation orbit batches after a dedicated scope freeze
+- `v0.15` = materialized uniform translation orbit batches under `pdelie.invariants`
 - `v0.16` = external symmetry-candidate interop and validation, not detector training
 - `v0.17` = formula-backed and non-polynomial generator support after schema semantics are frozen
 - `v0.18+` = scoped PDE expansion, with reaction/advection-diffusion preferred unless KS residual-only is deliberately scoped

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -1,6 +1,6 @@
 # V0.15+ Strategy
 
-This document records the planned post-`v0.14` direction.
+This document records the staged post-`v0.14` direction.
 It is a strategy note, not an active scope freeze and not an API contract.
 
 The active execution record remains `PLAN.md`.
@@ -10,7 +10,7 @@ Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
 
 After `v0.14`, the highest-ROI path is to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then non-polynomial generator support, then carefully scoped PDE expansion.
 
-Planned sequence:
+Staged sequence:
 
 - `v0.15`: materialized uniform translation orbit batches
 - `v0.16`: external symmetry-candidate interop and validation
@@ -24,11 +24,11 @@ It should not become a neural symmetry-detector training framework.
 
 ## V0.15 - Materialized Uniform Translation Orbit Batches
 
-Planned theme:
+Completed theme:
 
 > promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
 
-Candidate API direction:
+Implemented API direction:
 
 ```python
 pdelie.invariants.build_uniform_translation_orbit_batch(
@@ -41,10 +41,10 @@ pdelie.invariants.build_uniform_translation_orbit_batch(
 )
 ```
 
-`build_uniform_translation_orbit_batch(...)` is the preferred candidate name because it says the helper returns a batch-oriented data product.
-The exact name and return type must still be frozen in `v0.15` M1.
+`build_uniform_translation_orbit_batch(...)` is the selected public name because it says the helper returns a batch-oriented data product.
+The completed scope freeze belongs in `V0_15_SCOPE.md`.
 
-Semantics to freeze before implementation:
+Completed semantics:
 
 - augmentation appends along the batch dimension
 - output ordering is deterministic and preserves duplicate shifts
@@ -57,9 +57,9 @@ Semantics to freeze before implementation:
 - no split management or heldout-leakage detection is attempted
 - source IDs may be recorded, but the helper does not manage experimental partitions
 
-Return-shape policy to freeze:
+Return-shape policy:
 
-- prefer an explicit structured return such as `(FieldBatch, report)` or a named structured pair
+- use `OrbitBatchResult(field, report)` as an explicit structured return
 - avoid a silent `FieldBatch`-only return because users need source/shift provenance
 - avoid returning transformed fields inside a JSON report
 

--- a/docs/planning/V0_15_SCOPE.md
+++ b/docs/planning/V0_15_SCOPE.md
@@ -1,0 +1,174 @@
+# V0.15 Scope Freeze
+
+## Summary
+
+`v0.15` is the materialized uniform translation orbit batch release.
+
+Stable release theme:
+
+> promote the first conservative user-facing data utility for materializing finite uniform translation orbits from canonical `FieldBatch` inputs.
+
+Stable path:
+
+`canonical scalar 1D periodic FieldBatch + finite uniform x-shifts -> materialized orbit FieldBatch + JSON-compatible provenance report`
+
+This release turns the `v0.13` and `v0.14` diagnostic evidence into one narrow data utility.
+It remains paper-agnostic and does not add train/test policy, split management, time translation, new PDEs, KS promotion, weak KS, broad adapters, operator APIs, or root exports.
+
+---
+
+## Stable Scope
+
+`v0.15` adds one runtime public API and one runtime-only structured return under `pdelie.invariants`:
+
+```python
+pdelie.invariants.build_uniform_translation_orbit_batch(
+    field,
+    *,
+    shifts,
+    keep_source_index=True,
+    keep_shift_index=True,
+    source_field_id=None,
+    copy=True,
+) -> OrbitBatchResult
+
+pdelie.invariants.OrbitBatchResult(
+    field: FieldBatch,
+    report: dict[str, Any],
+)
+```
+
+`OrbitBatchResult` is not a canonical object.
+It has no schema migration policy and no `.to_dict()` / `.from_dict()` contract.
+
+The helper:
+
+- supports canonical scalar 1D uniform periodic `FieldBatch` inputs only
+- uses existing `InvariantApplier` uniform `x` translation
+- returns a materialized `FieldBatch` plus a JSON-compatible provenance report
+- mutates no inputs
+- has no root `pdelie` export
+
+---
+
+## Materialization Semantics
+
+Shift semantics:
+
+- `shifts` must be a non-empty sequence of finite floats
+- raw shift order is preserved
+- duplicate shifts are preserved
+- normalized shifts are recorded modulo the inferred periodic domain length
+
+Batch semantics:
+
+- materialization appends along the `batch` dimension
+- output ordering is `shift_major`
+- for each raw shift in input order, all source batch rows appear in original source-batch order
+- output batch size is `source_batch_size * len(shifts)`
+
+Provenance semantics:
+
+- optional `source_field_id` is JSON-compatible provenance metadata only
+- `source_field_id` is not a canonical identity system
+- source batch indices are included when `keep_source_index=True`
+- shift indices are included when `keep_shift_index=True`
+- duplicate shifts remain traceable through shift indices and batch records
+- output metadata records an `orbit_materialization` entry
+- output preprocess log appends one aggregate `materialize_uniform_translation_orbit_batch` entry
+
+Mask and copy semantics:
+
+- `mask=None` remains `None`
+- non-`None` masks are taken from transformed fields and concatenated along batch
+- transformed values are always newly computed through `InvariantApplier`
+- `copy=True` is the conservative default
+- `copy=False` may avoid extra coordinate or mask copies where safe, but the helper still mutates no inputs
+
+---
+
+## Non-goals
+
+`v0.15` explicitly does not include:
+
+- train/test policy
+- train/heldout split management
+- heldout-leakage detection
+- sparse-discovery branch policy
+- private-paper augmentation recipes
+- time-translation APIs
+- no time-translation APIs are included in this release
+- `axis="time"` support in `InvariantApplier`
+- new PDE support
+- stable KS generator promotion
+- stable KS residual evaluator promotion
+- weak KS
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional grids
+- nonuniform grids
+- multivariable systems
+- operator-facing symmetry APIs
+- root `pdelie` export expansion
+
+---
+
+## Milestones
+
+### Milestone 0 - Scope Freeze
+
+Freeze `v0.15` as materialized uniform translation orbit batches.
+
+### Milestone 1 - API Semantics Freeze
+
+Freeze API name, `OrbitBatchResult` status, batch ordering, provenance fields, mask behavior, metadata/preprocess composition, and copy semantics.
+
+### Milestone 2 - Orbit Batch Implementation
+
+Implement `pdelie.invariants.build_uniform_translation_orbit_batch(...)` and `pdelie.invariants.OrbitBatchResult`.
+Document both in `API_STABILITY.md`.
+
+### Milestone 3 - Compatibility And Diagnostics
+
+Verify materialized Heat and KdV orbit batches remain valid `FieldBatch` objects and remain compatible with derivatives, residual evaluators, and reporting helpers.
+
+### Milestone 4 - Example
+
+Add `python -m pdelie.examples.translation_orbit_batch` and `pdelie.examples.run_translation_orbit_batch_example(...)`.
+
+### Milestone 5 - API / Public-surface Audit
+
+Confirm the new API remains submodule-only and no train/test policy, time translation, KS runtime, weak KS, broad adapter, or operator API landed.
+
+### Milestone 6 - Release Gate and Readiness
+
+Add `tests/test_v0_15_release_gate.py`, update CI, bump package metadata to `0.15.0`, and align release-facing docs.
+
+---
+
+## Release-gate Expectations
+
+Expected gate coverage:
+
+- `build_uniform_translation_orbit_batch(...)` is documented and submodule-only
+- `OrbitBatchResult` is documented and submodule-only
+- representative Heat and KdV orbit batches validate as `FieldBatch` objects
+- output batch shape follows shift-major ordering
+- duplicate shifts are preserved
+- source/shift provenance is traceable
+- residual diagnostics remain finite on representative materialized batches
+- root `pdelie` remains unchanged
+- no train/test policy, time translation, KS runtime, weak KS, broad adapter, or operator API lands
+- current CI uses `v0_15-release-gate` plus full editable tests and package smoke
+
+---
+
+## Status
+
+- Milestone 0: COMPLETE
+- Milestone 1: COMPLETE
+- Milestone 2: COMPLETE
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
+- Milestone 6: COMPLETE

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.14.0`, release completion means:
+For the current `v0.x` series, including `v0.15.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.14.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.14`.
+`v0.15.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.15`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_15_RELEASE_READINESS.md
+++ b/docs/releases/V0_15_RELEASE_READINESS.md
@@ -1,0 +1,123 @@
+# V0.15 Release Readiness
+
+## Summary
+
+- package version: `0.15.0`
+- git tag: `v0.15.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.15.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.15`.
+
+Release claim:
+
+> materialized uniform translation orbit batches with explicit provenance, without train/test policy or new numerical scope.
+
+---
+
+## M0-M6 Outcome
+
+- M0 froze `v0.15` as materialized uniform translation orbit batches.
+- M1 froze API name, `OrbitBatchResult` status, batch ordering, provenance, mask behavior, metadata/preprocess composition, and copy semantics.
+- M2 added `pdelie.invariants.build_uniform_translation_orbit_batch(...)` and `pdelie.invariants.OrbitBatchResult`.
+- M3 verified Heat and KdV compatibility with derivatives, residual evaluators, and provenance tracing.
+- M4 added `python -m pdelie.examples.translation_orbit_batch`.
+- M5 audited public exports and deferred surfaces.
+- M6 aligned release gate, CI, docs, metadata, and direct tag readiness.
+
+## Public API Notes
+
+New public submodule APIs:
+
+- `pdelie.invariants.build_uniform_translation_orbit_batch(...)`
+- `pdelie.invariants.OrbitBatchResult`
+- `pdelie.examples.run_translation_orbit_batch_example(...)`
+
+No root `pdelie` exports were added.
+
+`OrbitBatchResult` is runtime-only.
+It is not a canonical object, has no schema migration policy, and does not change the `FieldBatch` contract.
+
+## Representative Diagnostics
+
+Orbit batch checks:
+
+- output appends along batch in shift-major order
+- output batch size equals `source_batch_size * len(shifts)`
+- duplicate shifts are preserved
+- source and shift indices are recorded when requested
+- optional `source_field_id` is preserved as JSON-compatible provenance metadata
+- output metadata records `orbit_materialization`
+- output preprocess log appends one aggregate `materialize_uniform_translation_orbit_batch` entry
+- `mask=None` remains `None`
+- non-`None` masks concatenate along batch consistently with transformed fields
+- Heat and KdV materialized batches validate as `FieldBatch` objects
+- derivatives and residual evaluators run on representative materialized Heat and KdV batches
+
+## Explicit Deferrals
+
+`v0.15` does not add:
+
+- train/test policy
+- split management
+- heldout-leakage detection
+- sparse-discovery branch policy
+- private-paper augmentation recipes
+- time-translation APIs
+- a new PDE
+- stable KS generator/residual/example APIs
+- weak KS
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid support
+- operator-facing APIs
+- root runtime exports
+
+## CI Expectations
+
+Required checks before tagging:
+
+- `v0_15-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+The explicit release gate is compact and representative.
+The full editable suite remains responsible for historical release gates and broader regression coverage.
+
+## Local Validation Checklist
+
+Before tagging:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
+git diff --check
+```
+
+Clean wheel smoke should verify:
+
+- stable root imports
+- `pdelie.invariants.build_uniform_translation_orbit_batch`
+- `pdelie.invariants.OrbitBatchResult`
+- one tiny materialized Heat orbit batch
+- one tiny weak Heat report
+- one tiny KdV strong-path residual
+- one tiny order-4 derivative smoke
+- one tiny generator-fit diagnostic summary
+- no root KS, train/test policy, split-management, time-translation, or weak KS exports
+
+## Direct Tag Checklist
+
+1. Create the release PR from the `v0.15` branch.
+2. Run the local validation checklist.
+3. Wait for required CI checks to pass.
+4. Merge only after CI is green.
+5. Tag the merged `main` commit as `v0.15.0`.
+6. Do not publish to TestPyPI.
+7. Do not publish to PyPI.
+8. Record package-index publishing as deferred until `v1.0` or later.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -169,6 +169,17 @@ Runtime public API for the frozen `v0.14` Milestone 2/M3 slice:
 - time-translation diagnostics remain deferred; `InvariantApplier` still exposes only uniform periodic `x` translation in the stable runtime path
 - these APIs have no root `pdelie` exports
 
+Runtime public API for the frozen `v0.15` Milestone 2 slice:
+
+- `pdelie.invariants.build_uniform_translation_orbit_batch` for materializing finite uniform `x`-translation orbit batches from canonical scalar 1D periodic `FieldBatch` inputs
+- `pdelie.invariants.OrbitBatchResult` as a runtime-only structured result containing the materialized `FieldBatch` and a JSON-compatible provenance report
+- the materialized output appends along the batch dimension, preserves raw shift order and duplicate shifts, and records optional source/shift indices in the report
+- the helper reuses `InvariantApplier` uniform translation and does not introduce a second translation implementation
+- the helper records orbit-materialization metadata and appends one aggregate preprocess-log entry
+- this API is a conservative data utility, not a train/test splitter, split-management helper, leakage detector, sparse-discovery branch policy, canonical object, figure/rendering API, or manuscript artifact schema
+- time-translation, public KS runtime APIs, weak KS, broad adapters, and operator-facing APIs remain deferred
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.14.0"
-description = "V0.14 invariant workflow summaries and read-only uniform translation orbit reports over the Heat/Burgers/weak-report/KdV engine"
+version = "0.15.0"
+description = "V0.15 materialized uniform translation orbit batches with provenance over the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "run_invariant_workflow_summary_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
+    "run_translation_orbit_batch_example",
 ]
 
 
@@ -26,5 +27,11 @@ def run_kdv_vertical_slice_example() -> dict[str, object]:
 
 def run_orbit_coverage_diagnostics_example() -> dict[str, object]:
     from pdelie.examples.orbit_coverage_diagnostics import run_orbit_coverage_diagnostics_example as _impl
+
+    return _impl()
+
+
+def run_translation_orbit_batch_example() -> dict[str, object]:
+    from pdelie.examples.translation_orbit_batch import run_translation_orbit_batch_example as _impl
 
     return _impl()

--- a/src/pdelie/examples/translation_orbit_batch.py
+++ b/src/pdelie/examples/translation_orbit_batch.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.invariants import build_uniform_translation_orbit_batch
+from pdelie.reporting import summarize_residual_batch
+from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_DOMAIN_LENGTH = 2.0 * np.pi
+_SHIFTS = (0.0, _DOMAIN_LENGTH / 32.0, _DOMAIN_LENGTH / 8.0, _DOMAIN_LENGTH / 8.0, _DOMAIN_LENGTH)
+
+
+def _heat_case() -> dict[str, object]:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=9, num_points=32, seed=15011)
+    result = build_uniform_translation_orbit_batch(
+        field,
+        shifts=_SHIFTS,
+        source_field_id="heat_seed_15011",
+    )
+    residual = HeatResidualEvaluator().evaluate(
+        result.field,
+        compute_spectral_fd_derivatives(result.field),
+    )
+    return {
+        "case_name": "heat",
+        "equation": "heat_1d",
+        "source_shape": list(field.values.shape),
+        "orbit_shape": list(result.field.values.shape),
+        "orbit_report": result.report,
+        "residual": summarize_residual_batch(residual),
+    }
+
+
+def _kdv_case() -> dict[str, object]:
+    field = generate_kdv_1d_field_batch(batch_size=2, num_times=9, num_points=32, num_modes=1, seed=15012)
+    result = build_uniform_translation_orbit_batch(
+        field,
+        shifts=_SHIFTS,
+        source_field_id="kdv_seed_15012",
+    )
+    residual = KdVResidualEvaluator().evaluate(
+        result.field,
+        compute_spectral_fd_derivatives(result.field, max_spatial_order=3),
+    )
+    return {
+        "case_name": "kdv",
+        "equation": "kdv_normalized",
+        "source_shape": list(field.values.shape),
+        "orbit_shape": list(result.field.values.shape),
+        "orbit_report": result.report,
+        "residual": summarize_residual_batch(residual),
+    }
+
+
+def run_translation_orbit_batch_example() -> dict[str, object]:
+    return {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": "translation_orbit_batch_example",
+        "cases": [_heat_case(), _kdv_case()],
+        "extra_metrics": {
+            "example_name": "translation_orbit_batch",
+            "shifts": list(_SHIFTS),
+            "duplicate_shift_preserved": True,
+            "ordering": "shift_major",
+        },
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_translation_orbit_batch_example(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/examples/translation_orbit_batch.py
+++ b/src/pdelie/examples/translation_orbit_batch.py
@@ -66,7 +66,7 @@ def run_translation_orbit_batch_example() -> dict[str, object]:
         "extra_metrics": {
             "example_name": "translation_orbit_batch",
             "shifts": list(_SHIFTS),
-            "duplicate_shift_preserved": True,
+            "duplicate_shifts_preserved": True,
             "ordering": "shift_major",
         },
     }

--- a/src/pdelie/invariants/__init__.py
+++ b/src/pdelie/invariants/__init__.py
@@ -1,5 +1,7 @@
 from pdelie.invariants.apply import InvariantApplier
 from pdelie.invariants.diagnostics import (
+    OrbitBatchResult,
+    build_uniform_translation_orbit_batch,
     compute_periodic_window_coverage,
     diagnose_uniform_translation_consistency,
     summarize_uniform_translation_orbit,
@@ -7,6 +9,8 @@ from pdelie.invariants.diagnostics import (
 
 __all__ = [
     "InvariantApplier",
+    "OrbitBatchResult",
+    "build_uniform_translation_orbit_batch",
     "compute_periodic_window_coverage",
     "diagnose_uniform_translation_consistency",
     "summarize_uniform_translation_orbit",

--- a/src/pdelie/invariants/diagnostics.py
+++ b/src/pdelie/invariants/diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass
 import json
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -22,6 +23,14 @@ _SUMMARY_SCHEMA_VERSION = "0.1"
 _RELATIVE_L2_EPS = 1e-12
 _RESIDUAL_ABSOLUTE_TOLERANCE = 1e-8
 _RESIDUAL_RELATIVE_TOLERANCE = 1e-6
+
+
+@dataclass(slots=True)
+class OrbitBatchResult:
+    """Runtime-only result for materialized uniform translation orbit batches."""
+
+    field: FieldBatch
+    report: dict[str, Any]
 
 
 def _json_safe(value: Any) -> Any:
@@ -62,6 +71,12 @@ def _finite_sequence(value: Any, *, name: str) -> list[float]:
     if not normalized:
         raise SchemaValidationError(f"{name} must be non-empty.")
     return normalized
+
+
+def _require_bool(value: Any, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise SchemaValidationError(f"{name} must be a boolean.")
+    return value
 
 
 def _normalize_periodic_grid(
@@ -459,3 +474,120 @@ def summarize_uniform_translation_orbit(
         },
         name="uniform_translation_orbit summary",
     )
+
+
+def build_uniform_translation_orbit_batch(
+    field: FieldBatch,
+    *,
+    shifts: Any,
+    keep_source_index: bool = True,
+    keep_shift_index: bool = True,
+    source_field_id: Any | None = None,
+    copy: bool = True,
+) -> OrbitBatchResult:
+    dx, domain_length = _validate_consistency_field(field)
+    raw_shifts = _finite_sequence(shifts, name="shifts")
+    keep_source_index = _require_bool(keep_source_index, name="keep_source_index")
+    keep_shift_index = _require_bool(keep_shift_index, name="keep_shift_index")
+    copy = _require_bool(copy, name="copy")
+    normalized_source_field_id = _json_compatible_value(source_field_id, name="source_field_id")
+    normalized_shifts = [float(shift % domain_length) for shift in raw_shifts]
+
+    source_batch_size = int(field.values.shape[field.dims.index("batch")])
+    applier = InvariantApplier()
+    transformed_fields = [applier.apply(field, _translation_spec(raw_shift)) for raw_shift in raw_shifts]
+    values = np.concatenate([transformed.values for transformed in transformed_fields], axis=0)
+    if field.mask is None:
+        mask = None
+    else:
+        masks = [transformed.mask for transformed in transformed_fields]
+        if any(mask_item is None for mask_item in masks):
+            raise ScopeValidationError("InvariantApplier returned inconsistent mask state.")
+        mask = np.concatenate([np.asarray(mask_item, dtype=bool) for mask_item in masks], axis=0)
+
+    source_indices = np.tile(np.arange(source_batch_size, dtype=int), len(raw_shifts)).tolist()
+    shift_indices = np.repeat(np.arange(len(raw_shifts), dtype=int), source_batch_size).tolist()
+    output_batch_size = int(values.shape[0])
+    transform_specs = [_translation_spec(raw_shift).to_dict() for raw_shift in raw_shifts]
+    batch_records: list[dict[str, Any]] = []
+    for output_batch_index, (source_batch_index, shift_index) in enumerate(
+        zip(source_indices, shift_indices, strict=True)
+    ):
+        record: dict[str, Any] = {
+            "output_batch_index": output_batch_index,
+            "shift": raw_shifts[shift_index],
+            "normalized_shift": normalized_shifts[shift_index],
+        }
+        if keep_source_index:
+            record["source_batch_index"] = source_batch_index
+        if keep_shift_index:
+            record["shift_index"] = shift_index
+        batch_records.append(record)
+
+    materialization_metadata = {
+        "operation": "materialize_uniform_translation_orbit_batch",
+        "construction_method": "uniform_translation",
+        "transform_axis": "x",
+        "ordering": "shift_major",
+        "raw_shifts": raw_shifts,
+        "normalized_shifts": normalized_shifts,
+        "shift_count": len(raw_shifts),
+        "source_batch_size": source_batch_size,
+        "output_batch_size": output_batch_size,
+        "duplicate_shifts_preserved": True,
+        "source_field_id": normalized_source_field_id,
+        "keep_source_index": keep_source_index,
+        "keep_shift_index": keep_shift_index,
+        "copy": copy,
+    }
+    metadata = deepcopy(field.metadata)
+    metadata["orbit_materialization"] = deepcopy(materialization_metadata)
+    preprocess_entry = {
+        **deepcopy(materialization_metadata),
+        "transform_specs": transform_specs,
+    }
+    coords = {
+        name: coord.copy() if copy else coord
+        for name, coord in field.coords.items()
+    }
+
+    orbit_field = FieldBatch(
+        values=values.copy() if copy else values,
+        dims=field.dims,
+        coords=coords,
+        var_names=list(field.var_names),
+        metadata=metadata,
+        preprocess_log=[*field.preprocess_log, preprocess_entry],
+        mask=None if mask is None else (mask.copy() if copy else mask),
+    )
+
+    report = _validate_json_compatible(
+        {
+            "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+            "summary_type": "uniform_translation_orbit_batch",
+            "source_field_id": normalized_source_field_id,
+            "field_dims": field.dims,
+            "source_field_shape": list(field.values.shape),
+            "output_field_shape": list(orbit_field.values.shape),
+            "source_batch_size": source_batch_size,
+            "shift_count": len(raw_shifts),
+            "output_batch_size": output_batch_size,
+            "ordering": "shift_major",
+            "transform_axis": "x",
+            "construction_method": "uniform_translation",
+            "domain_length": domain_length,
+            "dx": dx,
+            "raw_shifts": raw_shifts,
+            "normalized_shifts": normalized_shifts,
+            "duplicate_shifts_preserved": True,
+            "source_batch_indices": source_indices if keep_source_index else None,
+            "shift_indices": shift_indices if keep_shift_index else None,
+            "batch_records": batch_records,
+            "metadata_key": "orbit_materialization",
+            "preprocess_operation": "materialize_uniform_translation_orbit_batch",
+            "preprocess_log_length_delta": len(orbit_field.preprocess_log) - len(field.preprocess_log),
+            "transform_specs": transform_specs,
+        },
+        name="uniform_translation_orbit_batch report",
+    )
+    return OrbitBatchResult(field=orbit_field, report=report)

--- a/src/pdelie/invariants/diagnostics.py
+++ b/src/pdelie/invariants/diagnostics.py
@@ -280,16 +280,20 @@ def _residual_rms(field: FieldBatch, evaluator: ResidualEvaluator) -> float:
     return float(np.sqrt(np.mean(np.square(normalized))))
 
 
-def _validate_consistency_field(field: FieldBatch) -> tuple[float, float]:
+def _validate_consistency_field(
+    field: FieldBatch,
+    *,
+    api_name: str = "diagnose_uniform_translation_consistency",
+) -> tuple[float, float]:
     if not isinstance(field, FieldBatch):
         raise SchemaValidationError("field must be a FieldBatch.")
     field.validate()
     if field.dims != ("batch", "time", "x", "var"):
-        raise ScopeValidationError("diagnose_uniform_translation_consistency requires dims ('batch', 'time', 'x', 'var').")
+        raise ScopeValidationError(f"{api_name} requires dims ('batch', 'time', 'x', 'var').")
     if len(field.var_names) != 1:
-        raise ScopeValidationError("diagnose_uniform_translation_consistency requires a scalar field.")
+        raise ScopeValidationError(f"{api_name} requires a scalar field.")
     if field.metadata["boundary_conditions"].get("x") != "periodic":
-        raise ScopeValidationError("diagnose_uniform_translation_consistency requires periodic x boundary conditions.")
+        raise ScopeValidationError(f"{api_name} requires periodic x boundary conditions.")
     _, dx, domain_length, _ = _normalize_periodic_grid(field.coords["x"], domain_length=None)
     return dx, domain_length
 
@@ -404,7 +408,10 @@ def summarize_uniform_translation_orbit(
     residual_evaluator: ResidualEvaluator | None = None,
     source_field_id: Any | None = None,
 ) -> dict[str, Any]:
-    dx, domain_length = _validate_consistency_field(field)
+    dx, domain_length = _validate_consistency_field(
+        field,
+        api_name="summarize_uniform_translation_orbit",
+    )
     raw_shifts = _finite_sequence(shifts, name="shifts")
     normalized_shifts = [float(shift % domain_length) for shift in raw_shifts]
     normalized_source_field_id = _json_compatible_value(source_field_id, name="source_field_id")
@@ -485,7 +492,10 @@ def build_uniform_translation_orbit_batch(
     source_field_id: Any | None = None,
     copy: bool = True,
 ) -> OrbitBatchResult:
-    dx, domain_length = _validate_consistency_field(field)
+    dx, domain_length = _validate_consistency_field(
+        field,
+        api_name="build_uniform_translation_orbit_batch",
+    )
     raw_shifts = _finite_sequence(shifts, name="shifts")
     keep_source_index = _require_bool(keep_source_index, name="keep_source_index")
     keep_shift_index = _require_bool(keep_shift_index, name="keep_shift_index")
@@ -495,7 +505,8 @@ def build_uniform_translation_orbit_batch(
 
     source_batch_size = int(field.values.shape[field.dims.index("batch")])
     applier = InvariantApplier()
-    transformed_fields = [applier.apply(field, _translation_spec(raw_shift)) for raw_shift in raw_shifts]
+    translation_specs = [_translation_spec(raw_shift) for raw_shift in raw_shifts]
+    transformed_fields = [applier.apply(field, spec) for spec in translation_specs]
     values = np.concatenate([transformed.values for transformed in transformed_fields], axis=0)
     if field.mask is None:
         mask = None
@@ -508,7 +519,7 @@ def build_uniform_translation_orbit_batch(
     source_indices = np.tile(np.arange(source_batch_size, dtype=int), len(raw_shifts)).tolist()
     shift_indices = np.repeat(np.arange(len(raw_shifts), dtype=int), source_batch_size).tolist()
     output_batch_size = int(values.shape[0])
-    transform_specs = [_translation_spec(raw_shift).to_dict() for raw_shift in raw_shifts]
+    transform_specs = [spec.to_dict() for spec in translation_specs]
     batch_records: list[dict[str, Any]] = []
     for output_batch_index, (source_batch_index, shift_index) in enumerate(
         zip(source_indices, shift_indices, strict=True)
@@ -552,13 +563,13 @@ def build_uniform_translation_orbit_batch(
     }
 
     orbit_field = FieldBatch(
-        values=values.copy() if copy else values,
+        values=values,
         dims=field.dims,
         coords=coords,
         var_names=list(field.var_names),
         metadata=metadata,
         preprocess_log=[*field.preprocess_log, preprocess_entry],
-        mask=None if mask is None else (mask.copy() if copy else mask),
+        mask=mask,
     )
 
     report = _validate_json_compatible(

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -9,6 +9,7 @@ import pdelie
 _ROOT_RUNTIME_NAMES = {
     "InvariantApplier",
     "add_gaussian_noise",
+    "build_uniform_translation_orbit_batch",
     "build_translation_canonical_discovery_inputs",
     "coerce_generator_family",
     "compare_generator_spans",
@@ -39,6 +40,7 @@ _ROOT_RUNTIME_NAMES = {
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
     "run_invariant_workflow_summary_example",
+    "run_translation_orbit_batch_example",
     "split_batch_train_heldout",
     "subsample_time",
     "subsample_x",
@@ -75,9 +77,12 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "generate_ks_feasibility_field_batch",
     "load_pdebench",
     "load_the_well",
+    "materialize_uniform_translation_orbit",
     "sample_kdv_mode_coefficients",
+    "split_orbit_train_heldout",
     "summarize_orbit_coverage",
     "summarize_orbit_coverage_feasibility",
+    "train_test_translation_orbit_split",
 }
 _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.data.augment_translation_orbit",
@@ -127,6 +132,10 @@ _V0_14_INVARIANT_WORKFLOW_APIS = {
     "pdelie.invariants.summarize_uniform_translation_orbit",
     "pdelie.reporting.summarize_invariant_workflow",
 }
+_V0_15_ORBIT_BATCH_APIS = {
+    "pdelie.invariants.build_uniform_translation_orbit_batch",
+    "pdelie.invariants.OrbitBatchResult",
+}
 
 
 def _api_stability_text() -> str:
@@ -148,6 +157,7 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_12_REPORTING_APIS
         | _V0_13_INVARIANT_APIS
         | _V0_14_INVARIANT_WORKFLOW_APIS
+        | _V0_15_ORBIT_BATCH_APIS
     ):
         assert api_name in text
 
@@ -207,9 +217,12 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "run_invariant_workflow_summary_example",
             "run_kdv_vertical_slice_example",
             "run_orbit_coverage_diagnostics_example",
+            "run_translation_orbit_batch_example",
         },
         "pdelie.invariants": {
             "InvariantApplier",
+            "OrbitBatchResult",
+            "build_uniform_translation_orbit_batch",
             "compute_periodic_window_coverage",
             "diagnose_uniform_translation_consistency",
             "summarize_uniform_translation_orbit",
@@ -274,31 +287,32 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
             assert not hasattr(module, name), f"{module.__name__}.{name}"
 
 
-def test_v0_14_planning_docs_record_invariant_workflow_and_no_augmentation_scope() -> None:
+def test_v0_15_planning_docs_record_orbit_batch_and_no_split_policy_scope() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_14_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_15_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
 
     assert "**Status:** COMPLETE" in plan
-    assert "Milestone 2 - Combined Invariant Workflow Summary" in plan
-    assert "pdelie.reporting.summarize_invariant_workflow" in plan
-    assert "Milestone 3 - Uniform Translation Orbit Report" in plan
-    assert "pdelie.invariants.summarize_uniform_translation_orbit" in plan
-    assert "read-only runtime reports, not augmented datasets" in plan
+    assert "Milestone 2 - Orbit Batch Implementation" in plan
+    assert "pdelie.invariants.build_uniform_translation_orbit_batch" in plan
+    assert "pdelie.invariants.OrbitBatchResult" in plan
+    assert "Milestone 3 - Compatibility And Diagnostics" in plan
+    assert "shift-major" in plan
+    assert "no split-management or leakage-detection helper landed" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
-    assert "no public augmentation utilities landed" in plan
     assert "## Milestone 6 - Release Gate and Readiness" in plan
-    assert "updated CI so the current explicit release gate is `v0_14-release-gate`" in plan
+    assert "updated CI so the current explicit release gate is `v0_15-release-gate`" in plan
     assert "- Milestone 6: COMPLETE" in plan
 
-    assert "read-only uniform translation orbit reports" in scope
-    assert "no time-translation API" in scope
-    assert "pdelie.reporting.summarize_invariant_workflow" in scope
-    assert "pdelie.invariants.summarize_uniform_translation_orbit" in scope
+    assert "materialized uniform translation orbit batches" in scope
+    assert "no train/test policy" in scope
+    assert "no time-translation APIs" in scope
+    assert "pdelie.invariants.build_uniform_translation_orbit_batch" in scope
+    assert "pdelie.invariants.OrbitBatchResult" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
     assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.14` is the completed invariant workflow summary and orbit report release" in roadmap
-    assert "read-only runtime reports, not augmented datasets" in roadmap
+    assert "`v0.15` is the completed materialized translation orbit batch release" in roadmap
+    assert "no train/test policy, split management, or heldout-leakage detection is promoted" in roadmap
     assert "- no new PDE" in roadmap

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -207,7 +207,7 @@ def test_translation_orbit_batch_example_runs_end_to_end() -> None:
     assert result["summary_schema_version"] == "0.1"
     assert result["summary_type"] == "translation_orbit_batch_example"
     assert result["extra_metrics"]["example_name"] == "translation_orbit_batch"
-    assert result["extra_metrics"]["duplicate_shift_preserved"] is True
+    assert result["extra_metrics"]["duplicate_shifts_preserved"] is True
     assert result["extra_metrics"]["ordering"] == "shift_major"
     assert len(result["cases"]) == 2
     cases = {case["case_name"]: case for case in result["cases"]}

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,6 +12,7 @@ from pdelie.examples import (
     run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
     run_orbit_coverage_diagnostics_example,
+    run_translation_orbit_batch_example,
 )
 
 
@@ -197,3 +198,36 @@ def test_invariant_workflow_summary_module_prints_json_only() -> None:
     for workflow in parsed["workflows"]:
         assert workflow["summary_type"] == "invariant_workflow"
         assert workflow["orbit"]["orbit_passed"] is True
+
+
+def test_translation_orbit_batch_example_runs_end_to_end() -> None:
+    result = run_translation_orbit_batch_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "translation_orbit_batch_example"
+    assert result["extra_metrics"]["example_name"] == "translation_orbit_batch"
+    assert result["extra_metrics"]["duplicate_shift_preserved"] is True
+    assert result["extra_metrics"]["ordering"] == "shift_major"
+    assert len(result["cases"]) == 2
+    cases = {case["case_name"]: case for case in result["cases"]}
+    assert set(cases) == {"heat", "kdv"}
+    for case in cases.values():
+        assert case["orbit_shape"][0] == case["source_shape"][0] * len(result["extra_metrics"]["shifts"])
+        assert case["orbit_report"]["summary_type"] == "uniform_translation_orbit_batch"
+        assert case["orbit_report"]["duplicate_shifts_preserved"] is True
+        assert case["orbit_report"]["ordering"] == "shift_major"
+        assert case["orbit_report"]["source_batch_indices"] == [0, 1] * len(result["extra_metrics"]["shifts"])
+        assert case["residual"]["summary_type"] == "residual_batch"
+        assert np.isfinite(float(case["residual"]["max_abs_residual"]))
+    assert cases["kdv"]["orbit_report"]["source_field_id"] == "kdv_seed_15012"
+    assert not hasattr(pdelie, "run_translation_orbit_batch_example")
+
+
+def test_translation_orbit_batch_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.translation_orbit_batch")
+
+    assert parsed["summary_type"] == "translation_orbit_batch_example"
+    assert len(parsed["cases"]) == 2
+    for case in parsed["cases"]:
+        assert case["orbit_report"]["summary_type"] == "uniform_translation_orbit_batch"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -47,6 +47,8 @@ def test_runtime_package_api_is_importable() -> None:
     )
     from pdelie.invariants import (
         InvariantApplier,
+        OrbitBatchResult,
+        build_uniform_translation_orbit_batch,
         compute_periodic_window_coverage,
         diagnose_uniform_translation_consistency,
         summarize_uniform_translation_orbit,
@@ -88,6 +90,8 @@ def test_runtime_package_api_is_importable() -> None:
     assert subsample_time is not None
     assert subsample_x is not None
     assert InvariantApplier is not None
+    assert OrbitBatchResult is not None
+    assert build_uniform_translation_orbit_batch is not None
     assert compute_periodic_window_coverage is not None
     assert diagnose_uniform_translation_consistency is not None
     assert summarize_uniform_translation_orbit is not None
@@ -122,7 +126,9 @@ def test_runtime_package_api_is_importable() -> None:
 
 def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "InvariantApplier")
+    assert not hasattr(pdelie, "OrbitBatchResult")
     assert not hasattr(pdelie, "add_gaussian_noise")
+    assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
     assert not hasattr(pdelie, "build_translation_canonical_discovery_inputs")
     assert not hasattr(pdelie, "build_translation_orbit_dataset")
     assert not hasattr(pdelie, "build_translation_orbit_views")
@@ -165,11 +171,15 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "generate_ks_feasibility_field_batch")
     assert not hasattr(pdelie, "KSResidualEvaluator")
     assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
+    assert not hasattr(pdelie, "materialize_uniform_translation_orbit")
+    assert not hasattr(pdelie, "split_orbit_train_heldout")
+    assert not hasattr(pdelie, "train_test_translation_orbit_split")
     assert not hasattr(pdelie, "WeakKSResidualEvaluator")
     assert not hasattr(pdelie, "OperatorSymmetry")
     assert not hasattr(pdelie, "run_invariant_workflow_summary_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
+    assert not hasattr(pdelie, "run_translation_orbit_batch_example")
     assert not hasattr(pdelie, "sample_kdv_mode_coefficients")
     assert not hasattr(pdelie, "compare_generator_spans")
     assert not hasattr(pdelie, "diagnose_generator_family_closure")
@@ -186,6 +196,8 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
     invariants_module = importlib.import_module("pdelie.invariants")
 
     assert hasattr(invariants_module, "InvariantApplier")
+    assert hasattr(invariants_module, "OrbitBatchResult")
+    assert hasattr(invariants_module, "build_uniform_translation_orbit_batch")
     assert hasattr(invariants_module, "compute_periodic_window_coverage")
     assert hasattr(invariants_module, "diagnose_uniform_translation_consistency")
     assert hasattr(invariants_module, "summarize_uniform_translation_orbit")
@@ -194,6 +206,9 @@ def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> No
     assert not hasattr(invariants_module, "build_translation_orbit_views")
     assert not hasattr(invariants_module, "diagnose_time_translation_consistency")
     assert not hasattr(invariants_module, "InvariantMapSpec")
+    assert not hasattr(invariants_module, "materialize_uniform_translation_orbit")
+    assert not hasattr(invariants_module, "split_orbit_train_heldout")
+    assert not hasattr(invariants_module, "train_test_translation_orbit_split")
 
 
 def test_data_package_runtime_api_matches_current_frozen_surface() -> None:
@@ -262,6 +277,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(examples_module, "run_invariant_workflow_summary_example")
     assert hasattr(examples_module, "run_kdv_vertical_slice_example")
     assert hasattr(examples_module, "run_orbit_coverage_diagnostics_example")
+    assert hasattr(examples_module, "run_translation_orbit_batch_example")
     assert not hasattr(examples_module, "run_ks_vertical_slice_example")
     assert not hasattr(examples_module, "run_orbit_coverage_feasibility")
 

--- a/tests/test_translation_orbit_batch.py
+++ b/tests/test_translation_orbit_batch.py
@@ -173,5 +173,5 @@ def test_build_uniform_translation_orbit_batch_rejects_unsupported_fields() -> N
         preprocess_log=field.preprocess_log,
     )
 
-    with pytest.raises(ScopeValidationError, match="periodic"):
+    with pytest.raises(ScopeValidationError, match="build_uniform_translation_orbit_batch.*periodic"):
         build_uniform_translation_orbit_batch(nonperiodic, shifts=[0.0])

--- a/tests/test_translation_orbit_batch.py
+++ b/tests/test_translation_orbit_batch.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import pdelie
+from pdelie.contracts import FieldBatch
+from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.invariants import OrbitBatchResult, build_uniform_translation_orbit_batch
+from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator
+
+
+DOMAIN_LENGTH = 2.0 * np.pi
+
+
+def _assert_json_plain(value: object) -> None:
+    assert not isinstance(value, (np.ndarray, np.generic, FieldBatch))
+    if isinstance(value, dict):
+        for key, item in value.items():
+            assert isinstance(key, str)
+            _assert_json_plain(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_json_plain(item)
+    else:
+        assert value is None or isinstance(value, (str, bool, int, float))
+
+
+def test_build_uniform_translation_orbit_batch_materializes_shift_major_batch() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=7, num_points=16, seed=1501)
+    snapshot = field.to_dict()
+    shifts = [0.0, DOMAIN_LENGTH / 16.0, DOMAIN_LENGTH / 16.0, DOMAIN_LENGTH]
+
+    result = build_uniform_translation_orbit_batch(
+        field,
+        shifts=shifts,
+        source_field_id={"fixture": "heat", "seed": 1501},
+    )
+
+    assert isinstance(result, OrbitBatchResult)
+    assert result.field.dims == field.dims
+    assert result.field.values.shape[0] == field.values.shape[0] * len(shifts)
+    assert result.field.values.shape[1:] == field.values.shape[1:]
+    result.field.validate()
+
+    assert np.allclose(result.field.values[0:2], field.values)
+    assert np.allclose(result.field.values[2:4], result.field.values[4:6])
+    assert np.allclose(result.field.values[6:8], field.values, atol=1e-10)
+
+    report = result.report
+    assert json.loads(json.dumps(report)) == report
+    _assert_json_plain(report)
+    assert report["summary_schema_version"] == "0.1"
+    assert report["summary_type"] == "uniform_translation_orbit_batch"
+    assert report["source_field_id"] == {"fixture": "heat", "seed": 1501}
+    assert report["source_field_shape"] == list(field.values.shape)
+    assert report["output_field_shape"] == list(result.field.values.shape)
+    assert report["source_batch_size"] == 2
+    assert report["shift_count"] == len(shifts)
+    assert report["output_batch_size"] == 8
+    assert report["ordering"] == "shift_major"
+    assert report["raw_shifts"] == pytest.approx(shifts)
+    assert report["normalized_shifts"] == pytest.approx([shift % DOMAIN_LENGTH for shift in shifts])
+    assert report["duplicate_shifts_preserved"] is True
+    assert report["source_batch_indices"] == [0, 1, 0, 1, 0, 1, 0, 1]
+    assert report["shift_indices"] == [0, 0, 1, 1, 2, 2, 3, 3]
+    assert [record["output_batch_index"] for record in report["batch_records"]] == list(range(8))
+    assert [record["source_batch_index"] for record in report["batch_records"]] == report["source_batch_indices"]
+    assert [record["shift_index"] for record in report["batch_records"]] == report["shift_indices"]
+
+    metadata = result.field.metadata["orbit_materialization"]
+    assert metadata["operation"] == "materialize_uniform_translation_orbit_batch"
+    assert metadata["construction_method"] == "uniform_translation"
+    assert metadata["ordering"] == "shift_major"
+    assert metadata["source_field_id"] == {"fixture": "heat", "seed": 1501}
+    assert result.field.preprocess_log[-1]["operation"] == "materialize_uniform_translation_orbit_batch"
+    assert len(result.field.preprocess_log) == len(field.preprocess_log) + 1
+    assert field.to_dict() == snapshot
+    assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
+    assert not hasattr(pdelie, "OrbitBatchResult")
+
+
+def test_build_uniform_translation_orbit_batch_preserves_optional_index_policy() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=1502)
+
+    result = build_uniform_translation_orbit_batch(
+        field,
+        shifts=[0.0, DOMAIN_LENGTH],
+        keep_source_index=False,
+        keep_shift_index=False,
+    )
+
+    assert result.report["source_batch_indices"] is None
+    assert result.report["shift_indices"] is None
+    for record in result.report["batch_records"]:
+        assert "source_batch_index" not in record
+        assert "shift_index" not in record
+        assert "shift" in record
+        assert "normalized_shift" in record
+
+
+def test_build_uniform_translation_orbit_batch_concatenates_masks() -> None:
+    base = generate_heat_1d_field_batch(batch_size=2, num_times=5, num_points=8, seed=1503)
+    mask = np.zeros_like(base.values, dtype=bool)
+    mask[1, :, ::2, :] = True
+    field = FieldBatch(
+        values=base.values,
+        dims=base.dims,
+        coords=base.coords,
+        var_names=base.var_names,
+        metadata=base.metadata,
+        preprocess_log=base.preprocess_log,
+        mask=mask,
+    )
+
+    result = build_uniform_translation_orbit_batch(field, shifts=[0.0, DOMAIN_LENGTH / 8.0, DOMAIN_LENGTH / 8.0])
+
+    assert result.field.mask is not None
+    expected = np.concatenate([mask, mask, mask], axis=0)
+    assert np.array_equal(result.field.mask, expected)
+    assert np.array_equal(result.field.mask[2:4], result.field.mask[4:6])
+
+
+def test_materialized_heat_and_kdv_batches_support_derivatives_and_residuals() -> None:
+    heat = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=1504)
+    heat_orbit = build_uniform_translation_orbit_batch(heat, shifts=[0.0, DOMAIN_LENGTH / 16.0]).field
+    heat_derivatives = compute_spectral_fd_derivatives(heat_orbit)
+    heat_residual = HeatResidualEvaluator().evaluate(heat_orbit, heat_derivatives)
+    assert np.isfinite(float(heat_residual.diagnostics["max_abs_residual"]))
+
+    kdv = generate_kdv_1d_field_batch(batch_size=1, num_times=9, num_points=16, num_modes=1, seed=1505)
+    kdv_orbit = build_uniform_translation_orbit_batch(kdv, shifts=[0.0, DOMAIN_LENGTH / 16.0]).field
+    kdv_derivatives = compute_spectral_fd_derivatives(kdv_orbit, max_spatial_order=3)
+    kdv_residual = KdVResidualEvaluator().evaluate(kdv_orbit, kdv_derivatives)
+    assert np.isfinite(float(kdv_residual.diagnostics["max_abs_residual"]))
+    assert np.isfinite(float(kdv_residual.diagnostics["rms_residual"]))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type", "match"),
+    [
+        ({"shifts": []}, SchemaValidationError, "non-empty"),
+        ({"shifts": [np.nan]}, SchemaValidationError, "finite"),
+        ({"shifts": [0.0], "keep_source_index": 1}, SchemaValidationError, "keep_source_index"),
+        ({"shifts": [0.0], "keep_shift_index": 0}, SchemaValidationError, "keep_shift_index"),
+        ({"shifts": [0.0], "copy": 1}, SchemaValidationError, "copy"),
+        ({"shifts": [0.0], "source_field_id": object()}, SchemaValidationError, "source_field_id"),
+    ],
+)
+def test_build_uniform_translation_orbit_batch_rejects_invalid_inputs(
+    kwargs: dict[str, object],
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=1506)
+
+    with pytest.raises(error_type, match=match):
+        build_uniform_translation_orbit_batch(field, **kwargs)
+
+
+def test_build_uniform_translation_orbit_batch_rejects_unsupported_fields() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=1507)
+    nonperiodic = FieldBatch(
+        values=field.values,
+        dims=field.dims,
+        coords=field.coords,
+        var_names=field.var_names,
+        metadata={**field.metadata, "boundary_conditions": {"x": "dirichlet"}},
+        preprocess_log=field.preprocess_log,
+    )
+
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        build_uniform_translation_orbit_batch(nonperiodic, shifts=[0.0])

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_14-release-gate"]
-    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
-    for historical_job in range(4, 13):
+    for historical_job in range(4, 15):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_14-release-gate"]
-    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.14" in readme
+    assert "V0.15" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.14.0`" in publishing
+    assert "including `v0.15.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -56,19 +56,19 @@ def test_v0_12_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.14.0"
-    assert release_gate_jobs == ["v0_14-release-gate"]
-    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.15.0"
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
 
     assert "## 0.12.0" in changelog
-    assert "V0.14" in readme
+    assert "V0.15" in readme
     assert "summarize_generator_fit_diagnostics" in readme
     assert "package version: `0.12.0`" in readiness
     assert "git tag: `v0.12.0`" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.12`" in readiness
-    assert "including `v0.14.0`" in publishing
-    assert "v0.12` is complete" in plan
+    assert "including `v0.15.0`" in publishing
+    assert "V0.15 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.12` - Diagnostics and supportability hardening" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_14_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_15_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.14.0"
-    assert release_gate_jobs == ["v0_14-release-gate"]
-    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.15.0"
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.14" in readme
+    assert "V0.15" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.14.0`" in readiness
-    assert "git tag: `v0.14.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.14`" in readiness
-    assert "including `v0.14.0`" in publishing
-    assert "v0.13` is complete" in plan
+    assert "package version: `0.15.0`" in readiness
+    assert "git tag: `v0.15.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.15`" in readiness
+    assert "including `v0.15.0`" in publishing
+    assert "V0.15 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_14_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_15_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.14.0"
-    assert release_gate_jobs == ["v0_14-release-gate"]
-    assert "python -m pytest tests/test_v0_14_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.15.0"
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.14.0" in changelog
-    assert "V0.14" in readme
+    assert "V0.15" in readme
     assert "summarize_invariant_workflow" in readme
     assert "summarize_uniform_translation_orbit" in readme
-    assert "package version: `0.14.0`" in readiness
-    assert "git tag: `v0.14.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.14`" in readiness
-    assert "including `v0.14.0`" in publishing
+    assert "package version: `0.15.0`" in readiness
+    assert "git tag: `v0.15.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.15`" in readiness
+    assert "including `v0.15.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap

--- a/tests/test_v0_15_release_gate.py
+++ b/tests/test_v0_15_release_gate.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.invariants import build_uniform_translation_orbit_batch
+from pdelie.residuals import HeatResidualEvaluator
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_15_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_15_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.15.0"
+    assert release_gate_jobs == ["v0_15-release-gate"]
+    assert "python -m pytest tests/test_v0_15_release_gate.py" in workflow
+    assert "v0_14-release-gate" not in workflow
+
+    assert "## 0.15.0" in changelog
+    assert "V0.15" in readme
+    assert "build_uniform_translation_orbit_batch" in readme
+    assert "OrbitBatchResult" in readme
+    assert "package version: `0.15.0`" in readiness
+    assert "git tag: `v0.15.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.15`" in readiness
+    assert "including `v0.15.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.15` - Materialized uniform translation orbit batches" in roadmap
+    assert "**Status:** Completed" in roadmap
+
+
+def test_v0_15_release_gate_orbit_batch_api_is_documented_and_submodule_only() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    invariants_module = importlib.import_module("pdelie.invariants")
+
+    assert hasattr(invariants_module, "build_uniform_translation_orbit_batch")
+    assert hasattr(invariants_module, "OrbitBatchResult")
+    assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
+    assert not hasattr(pdelie, "OrbitBatchResult")
+    assert "pdelie.invariants.build_uniform_translation_orbit_batch" in api_stability
+    assert "pdelie.invariants.OrbitBatchResult" in api_stability
+    assert "not a train/test splitter" in api_stability
+    assert "these APIs have no root `pdelie` exports" in api_stability
+
+
+def test_v0_15_release_gate_representative_orbit_batch_is_valid_and_traceable() -> None:
+    domain_length = 2.0 * np.pi
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=7, num_points=16, seed=15015)
+    shifts = [0.0, domain_length / 16.0, domain_length / 16.0, domain_length]
+    result = build_uniform_translation_orbit_batch(
+        field,
+        shifts=shifts,
+        source_field_id="v0_15_release_gate_heat",
+    )
+
+    result.field.validate()
+    assert result.field.values.shape[0] == field.values.shape[0] * len(shifts)
+    assert np.allclose(result.field.values[0:2], field.values)
+    assert np.allclose(result.field.values[2:4], result.field.values[4:6])
+    assert np.allclose(result.field.values[6:8], field.values, atol=1e-10)
+
+    report = result.report
+    assert json.loads(json.dumps(report)) == report
+    assert report["summary_type"] == "uniform_translation_orbit_batch"
+    assert report["source_field_id"] == "v0_15_release_gate_heat"
+    assert report["ordering"] == "shift_major"
+    assert report["duplicate_shifts_preserved"] is True
+    assert report["source_batch_indices"] == [0, 1, 0, 1, 0, 1, 0, 1]
+    assert report["shift_indices"] == [0, 0, 1, 1, 2, 2, 3, 3]
+    assert result.field.metadata["orbit_materialization"]["operation"] == "materialize_uniform_translation_orbit_batch"
+    assert result.field.preprocess_log[-1]["operation"] == "materialize_uniform_translation_orbit_batch"
+
+    derivatives = compute_spectral_fd_derivatives(result.field)
+    residual = HeatResidualEvaluator().evaluate(result.field, derivatives)
+    assert np.isfinite(float(residual.diagnostics["max_abs_residual"]))
+
+
+def test_v0_15_release_gate_no_deferred_surface_leaked() -> None:
+    modules = [
+        pdelie,
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.invariants"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.examples"),
+        importlib.import_module("pdelie.discovery"),
+    ]
+    forbidden_names = {
+        "augment_translation_orbit",
+        "build_translation_orbit_dataset",
+        "build_translation_orbit_views",
+        "compute_coverage_diagnostics",
+        "compute_weak_derivatives",
+        "diagnose_time_translation_consistency",
+        "evaluate_weak_ks_residual",
+        "from_pdebench",
+        "from_the_well",
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "load_pdebench",
+        "load_the_well",
+        "materialize_uniform_translation_orbit",
+        "run_ks_vertical_slice_example",
+        "split_orbit_train_heldout",
+        "train_test_translation_orbit_split",
+        "WeakKSResidualEvaluator",
+    }
+
+    for module in modules:
+        for name in sorted(forbidden_names):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"


### PR DESCRIPTION
## Summary

This PR completes `v0.15.0` as the first conservative user-facing data utility release after the read-only invariant diagnostics work in `v0.13`/`v0.14`.

The new public surface adds materialized uniform translation orbit batches under `pdelie.invariants`:

- `build_uniform_translation_orbit_batch(...)`
- `OrbitBatchResult(field, report)`

This lets users take a canonical scalar 1D periodic `FieldBatch`, apply finite uniform x-translations through the existing `InvariantApplier`, and receive a larger materialized `FieldBatch` plus a JSON-compatible provenance report.

## Scope

`v0.15.0` supports:

- shift-major orbit materialization along the batch dimension
- order-preserving and duplicate-preserving shifts
- source/shift index provenance
- optional `source_field_id`
- mask concatenation
- orbit-materialization metadata and preprocess-log provenance
- Heat/KdV compatibility with derivatives, residuals, reporting, and examples

It does **not** add train/test split policy, leakage detection, time translation, broad augmentation recipes, new PDEs, KS runtime promotion, weak KS, broad adapters, operator APIs, or root exports.

## User-Facing Additions

New API:

```python
from pdelie.invariants import build_uniform_translation_orbit_batch

result = build_uniform_translation_orbit_batch(
    field,
    shifts=[0.0, dx, 2 * dx],
    source_field_id="example-field",
)

orbit_field = result.field
report = result.report
```

New example:

```bash
python -m pdelie.examples.translation_orbit_batch
```

## Validation

- `python -m pytest`: `644 passed, 2 skipped`
- `python -m build --sdist --wheel`: built `pdelie-0.15.0`
- clean wheel smoke on Python 3.11: passed
- `python -m pdelie.examples.heat_vertical_slice`: passed
- `python -m pdelie.examples.kdv_vertical_slice`: passed
- `python -m pdelie.examples.orbit_coverage_diagnostics`: passed
- `python -m pdelie.examples.invariant_workflow_summary`: passed
- `python -m pdelie.examples.translation_orbit_batch`: passed
- `git diff --check`: clean