### PR TITLE
Implement v0.17 formula-backed generator validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_16-release-gate:
+  v0_17-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.16 release gate
-        run: python -m pytest tests/test_v0_16_release_gate.py
+      - name: Run V0.17 release gate
+        run: python -m pytest tests/test_v0_17_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -71,6 +71,7 @@ jobs:
           python -m pdelie.examples.invariant_workflow_summary
           python -m pdelie.examples.translation_orbit_batch
           python -m pdelie.examples.symmetry_candidate_validation
+          python -m pdelie.examples.formula_generator_validation
   package-smoke:
     runs-on: ubuntu-latest
     steps:
@@ -133,6 +134,7 @@ jobs:
               summarize_uniform_translation_orbit,
           )
           from pdelie.reporting import (
+              summarize_formula_generator_family,
               summarize_generator_fit_diagnostics,
               summarize_generator_family,
               summarize_invariant_workflow,
@@ -141,7 +143,7 @@ jobs:
               summarize_vertical_slice,
               summarize_weak_residual_report,
           )
-          from pdelie.symmetry import validate_symmetry_candidate
+          from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
 
           assert FieldBatch is not None
           assert DerivativeBatch is not None
@@ -155,6 +157,7 @@ jobs:
           assert diagnose_uniform_translation_consistency is not None
           assert summarize_uniform_translation_orbit is not None
           assert summarize_generator_fit_diagnostics is not None
+          assert summarize_formula_generator_family is not None
           assert summarize_generator_family is not None
           assert summarize_invariant_workflow is not None
           assert summarize_residual_batch is not None
@@ -162,6 +165,7 @@ jobs:
           assert summarize_vertical_slice is not None
           assert summarize_weak_residual_report is not None
           assert validate_symmetry_candidate is not None
+          assert FormulaGeneratorFamily is not None
           assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
           assert not hasattr(pdelie, "summarize_vertical_slice")
           assert not hasattr(pdelie, "compute_periodic_window_coverage")
@@ -171,7 +175,50 @@ jobs:
           assert not hasattr(pdelie, "build_uniform_translation_orbit_batch")
           assert not hasattr(pdelie, "OrbitBatchResult")
           assert not hasattr(pdelie, "validate_symmetry_candidate")
+          assert not hasattr(pdelie, "FormulaGeneratorFamily")
+          assert not hasattr(pdelie, "summarize_formula_generator_family")
           print("stable-import-ok")
+          PY
+      - name: Formula generator smoke
+        run: |
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import json
+
+          import pdelie
+          from pdelie.data import generate_heat_1d_field_batch
+          from pdelie.reporting import summarize_formula_generator_family
+          from pdelie.residuals import HeatResidualEvaluator
+          from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
+
+          formula = FormulaGeneratorFamily(
+              formula_generators=[
+                  {
+                      "name": "wheel_formula_translation",
+                      "components": {
+                          "tau": {"node": "const", "value": 0.0},
+                          "xi": {"node": "const", "value": 1.0},
+                          "phi": {"node": "const", "value": 0.0},
+                      },
+                  }
+              ]
+          )
+          summary = summarize_formula_generator_family(formula)
+          field = generate_heat_1d_field_batch(batch_size=2, num_times=7, num_points=16, seed=17017)
+          report = validate_symmetry_candidate(
+              field,
+              formula.to_dict(),
+              residual_evaluator=HeatResidualEvaluator(),
+              source_candidate_id="wheel-formula",
+          )
+          json.dumps(summary)
+          json.dumps(report)
+          assert summary["summary_type"] == "formula_generator_family"
+          assert report["candidate_kind"] == "formula_generator_family"
+          assert report["conclusion"] == "partially_validated"
+          assert not hasattr(pdelie, "FormulaGeneratorFamily")
+          assert not hasattr(pdelie, "summarize_formula_generator_family")
+          assert not hasattr(pdelie, "CallableGeneratorFamily")
+          print("formula-generator-smoke-ok")
           PY
       - name: Symmetry candidate validation smoke
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.17.0
+
+First final release for the frozen V0.17 formula-backed generator interoperability slice.
+
+- adds `pdelie.symmetry.FormulaGeneratorFamily` as a runtime-only structured record for formula-backed scalar 1D Lie-point generator families
+- adds `pdelie.reporting.summarize_formula_generator_family(...)` for JSON-compatible formula metadata summaries
+- extends `pdelie.symmetry.validate_symmetry_candidate(...)` to accept `FormulaGeneratorFamily` objects and strict current formula payload mappings
+- distinguishes formula candidates with `candidate_kind == "formula_generator_family"`
+- freezes a safe JSON expression AST with `const`, `var`, `add`, `mul`, integer `pow`, `sin`, `cos`, `reciprocal`, and metadata-only `symbolic_reference`
+- reports finite formula-evaluation diagnostics and denominator-floor failures without executing arbitrary strings or callables
+- reuses existing invariant-map residual/inverse validation when a supported finite-transform spec is attached
+- adds `python -m pdelie.examples.formula_generator_validation` and `pdelie.examples.run_formula_generator_validation_example(...)` as runtime smoke examples
+- documents the new APIs in `API_STABILITY.md` as submodule-only runtime APIs with no root exports
+- preserves existing polynomial `GeneratorFamily`, `GeneratorFamily`/`InvariantMapSpec` candidate validation, Heat/Burgers strong paths, weak residual reports, normalized periodic KdV, reporting helpers, orbit diagnostics, orbit batches, and external candidate validation
+
+Explicitly deferred for this final release:
+
+- Python callable generator APIs
+- arbitrary executable formula-string parsing
+- neural symmetry-detector training or learned-generator classes
+- formula-derived finite-flow integration for arbitrary infinitesimal formulas
+- canonical `GeneratorFamily` schema changes
+- train/test policy, split management, or heldout-leakage detection
+- time-translation APIs or `axis="time"` support
+- new PDE support
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak API, or root KS exports
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, nonuniform-grid, operator, or broad adapter expansion
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.16.0
 
 First final release for the frozen V0.16 external symmetry-candidate validation slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.16 external symmetry-candidate validation slice for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.17 formula-backed generator interoperability slice for the existing Heat/Burgers/weak-report/KdV engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -20,6 +20,9 @@ The current repository implements the frozen V0.16 external symmetry-candidate v
 - read-only uniform translation orbit reports under `pdelie.invariants.summarize_uniform_translation_orbit`
 - materialized uniform translation orbit batches under `pdelie.invariants.build_uniform_translation_orbit_batch`
 - empirical external symmetry-candidate validation reports under `pdelie.symmetry.validate_symmetry_candidate`
+- runtime-only formula-backed generator records under `pdelie.symmetry.FormulaGeneratorFamily`
+- formula generator summaries under `pdelie.reporting.summarize_formula_generator_family`
+- formula-backed candidate validation through `candidate_kind = "formula_generator_family"`
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -34,7 +37,7 @@ The current repository implements the frozen V0.16 external symmetry-candidate v
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_16-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_17-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -83,7 +86,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.16`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.17`:
 
 - `00_how_to_use_pdelie_v0_6.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -107,6 +110,7 @@ python -m pdelie.examples.orbit_coverage_diagnostics
 python -m pdelie.examples.invariant_workflow_summary
 python -m pdelie.examples.translation_orbit_batch
 python -m pdelie.examples.symmetry_candidate_validation
+python -m pdelie.examples.formula_generator_validation
 ```
 
 Those commands are validated in CI after editable install.
@@ -156,6 +160,13 @@ The symmetry candidate validation example demonstrates:
 3. a failed candidate for contrast
 4. the v0.16 interpretation that `validated` means configured empirical validation, not a mathematical proof
 
+The formula generator validation example demonstrates:
+
+1. affine, trigonometric, and rational formula-backed candidates
+2. safe JSON AST formula metadata, not executable formula strings
+3. a formula candidate with a supported uniform-translation finite-transform spec
+4. a failed denominator-floor case for contrast
+
 You can also call the examples programmatically.
 They return JSON-compatible runtime summaries, not canonical artifact schemas.
 The Heat and KdV examples return nested `vertical_slice` summaries; the invariant examples return diagnostic/workflow summaries:
@@ -163,6 +174,7 @@ The Heat and KdV examples return nested `vertical_slice` summaries; the invarian
 ```python
 from pdelie.examples import (
     run_heat_vertical_slice_example,
+    run_formula_generator_validation_example,
     run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
     run_orbit_coverage_diagnostics_example,
@@ -184,6 +196,9 @@ print(orbit_batch["cases"][0]["orbit_report"]["output_batch_size"])
 
 candidate_validation = run_symmetry_candidate_validation_example()
 print(candidate_validation["cases"][0]["report"]["conclusion"])
+
+formula_validation = run_formula_generator_validation_example()
+print(formula_validation["cases"][0]["report"]["candidate_kind"])
 ```
 
 ## Current Scope
@@ -211,8 +226,9 @@ Included in the current stable core:
 - invariant workflow summaries and uniform translation orbit reports in `v0.14` are read-only runtime reports; they do not construct augmented datasets, orbit datasets, or transformed `FieldBatch` collections
 - materialized uniform translation orbit batches in `v0.15` are conservative data utilities; they append along batch and record provenance, but do not manage train/test splits or leakage policy
 - external symmetry-candidate validation in `v0.16` accepts `GeneratorFamily` and `InvariantMapSpec` objects or strict payload mappings and returns empirical configured validation reports; it does not train detectors or accept callables
+- formula-backed generator support in `v0.17` adds safe runtime formula records, reporting, and empirical validation; it does not parse executable strings, accept callables, train learned generators, or change canonical polynomial `GeneratorFamily`
 
-Runtime-level public APIs in the frozen V0.16 slice:
+Runtime-level public APIs in the frozen V0.17 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -240,6 +256,9 @@ Runtime-level public APIs in the frozen V0.16 slice:
 - `pdelie.examples.run_translation_orbit_batch_example` for a runtime smoke example of materialized orbit batches, not a canonical report schema
 - `pdelie.symmetry.validate_symmetry_candidate` for empirical configured validation reports over externally supplied `GeneratorFamily` and `InvariantMapSpec` candidates
 - `pdelie.examples.run_symmetry_candidate_validation_example` for a runtime smoke example of external symmetry-candidate validation, not a canonical report schema
+- `pdelie.symmetry.FormulaGeneratorFamily` for runtime-only formula-backed scalar 1D Lie-point generator records
+- `pdelie.reporting.summarize_formula_generator_family` for JSON-compatible runtime summaries of formula-backed generator records
+- `pdelie.examples.run_formula_generator_validation_example` for a runtime smoke example of formula-backed candidate validation, not a canonical report schema
 - `pdelie.discovery.to_pysindy_trajectories` for the narrow backend-specific PySINDy bridge
 - `pdelie.discovery.evaluate_discovery_recovery` for runtime-only support/coefficient recovery metrics over caller-supplied canonical term strings
 - `pdelie.discovery.fit_pysindy_discovery` for a runtime-only backend-native PySINDy fit adapter
@@ -256,7 +275,7 @@ Runtime-level public APIs in the frozen V0.16 slice:
 
 The degraded weak-path release wins in `v0.8` are frozen as representative contract-stability signals. They are fallback-backed release checks, not a general weak-superiority claim.
 
-The KdV support retained through `v0.15` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+The KdV support retained through `v0.17` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
 
 The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,18 +1,18 @@
-# PDELie - Execution Plan (V0.16)
+# PDELie - Execution Plan (V0.17)
 
 ## Current Release Status
 
-**V0.16 is complete as external symmetry-candidate validation**
+**V0.17 is complete as formula-backed generator interoperability**
 
-This file is the completed execution record for the `v0.16` release series.
+This file is the completed execution record for the `v0.17` release series.
 
 Committed release theme:
 
-`canonical scalar 1D periodic FieldBatch + external candidate payload + residual evaluator -> empirical configured validation report`
+`canonical scalar 1D periodic FieldBatch + formula-backed generator candidate -> safe formula metadata/evaluation diagnostics -> empirical configured validation report`
 
 Important release boundary:
 
-> v0.16 adds one submodule-only validation/reporting helper for externally supplied `GeneratorFamily` and `InvariantMapSpec` candidates. It does not train detectors, accept callables, add formula-backed generators, add new PDEs, promote KS, add weak KS, broaden adapters, add operator APIs, or add root exports.
+> v0.17 adds runtime-only formula-backed generator records, reporting, and candidate validation. It does not change canonical polynomial `GeneratorFamily` semantics, train learned generators, accept Python callables, parse executable formula strings, add a new PDE, promote KS, add weak KS, broaden adapters, add operator APIs, or add root exports.
 
 Contracts and stable behavior belong in:
 
@@ -20,23 +20,33 @@ Contracts and stable behavior belong in:
 - `docs/specs/CONTRACTS_AND_DEFAULTS.md`
 - `docs/specs/API_STABILITY.md`
 - `docs/planning/ROADMAP.md`
-- `docs/planning/V0_16_SCOPE.md`
+- `docs/planning/V0_17_SCOPE.md`
 
-`API_STABILITY.md` was updated when the public `v0.16` helper landed.
+`API_STABILITY.md` was updated when the public `v0.17` formula-backed APIs landed.
+
+Milestone status summary:
+
+- Milestone 0: COMPLETE
+- Milestone 1: COMPLETE
+- Milestone 2: COMPLETE
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
+- Milestone 6: COMPLETE
 
 ---
 
-## V0.15 Closeout
+## V0.16 Closeout
 
-`v0.15` is complete as materialized uniform translation orbit batches.
+`v0.16` is complete as external symmetry-candidate validation.
 
 Carried-forward guardrails:
 
-- orbit batches construct orbit-expanded data
-- orbit batches do not decide train/heldout policy or leakage safety
-- serious workflows should keep source and shift indices enabled for auditability
+- `validated` means empirical configured validation, not a mathematical proof
+- candidate validation is reporting/interop, not detector training
+- callable descriptors and learned generators remain out of scope
 
-`v0.16` builds on the provenance/reporting direction without adding split policy or augmentation recipes.
+`v0.17` extends that interop surface to safe formula metadata without opening executable or learned-generator scope.
 
 ---
 
@@ -46,120 +56,115 @@ Carried-forward guardrails:
 
 ### Goal
 
-Freeze `v0.16` as external symmetry-candidate validation.
+Freeze `v0.17` as formula-backed generator interoperability.
 
 ### Completed Outcome
 
-- added `docs/planning/V0_16_SCOPE.md`
-- reset `PLAN.md` as the active `v0.16` execution record
-- updated `ROADMAP.md` to record `v0.16` as the current completed interoperability release
+- added `docs/planning/V0_17_SCOPE.md`
+- reset `PLAN.md` as the active `v0.17` execution record
+- updated `ROADMAP.md` to record `v0.17` as the current completed release
 - kept `API_STABILITY.md` unchanged until implementation landed
 - recorded explicit non-goals:
-  - no callable descriptors
-  - no neural detector training
-  - no formula-backed generator families
+  - no callable generator API
+  - no arbitrary formula-string evaluator
+  - no neural detector or learned-generator training
+  - no canonical `GeneratorFamily` semantic change
   - no KS promotion
   - no new PDE
+  - no weak KS
   - no broad adapters
   - no operator APIs
   - no root export expansion
 
 ---
 
-## Milestone 1 - API Semantics Freeze
+## Milestone 1 - Formula Schema and Validation Semantics Freeze
 
 **Status:** COMPLETE
 
 ### Goal
 
-Freeze the public helper semantics before implementation.
+Freeze the formula record, expression policy, and candidate-validation semantics before implementation.
 
 ### Completed Outcome
 
 M1 froze:
 
-- public submodule-only helper:
-  - `pdelie.symmetry.validate_symmetry_candidate(...)`
-- accepted candidate kinds:
-  - `GeneratorFamily`
-  - canonical `GeneratorFamily` payload mapping
-  - `InvariantMapSpec`
-  - canonical `InvariantMapSpec` payload mapping
-- strict payload policy:
-  - ambiguous mappings raise `SchemaValidationError`
-  - callable descriptors are rejected
-- report schema:
-  - `summary_schema_version = "0.1"`
-  - `summary_type = "symmetry_candidate_validation"`
-  - `candidate_kind`
-  - `source_candidate_id`
-  - configured validation checks
-  - check reports
-  - thresholds
-  - conclusion
-- conclusion labels:
-  - `validated`
-  - `partially_validated`
-  - `failed`
-- interpretation:
-  - `validated` means empirical configured validation, not a mathematical proof
-- thresholds:
-  - generator verification requires `classification != "failed"`
-  - invariant-map residual stability uses `absolute_delta <= 1e-8 or relative_delta <= 1e-6`
-  - inverse consistency uses relative L2 `<= 1e-8`
-  - span and closure diagnostics use `1e-8` thresholds
+- runtime-only public record:
+  - `pdelie.symmetry.FormulaGeneratorFamily`
+- runtime reporting helper:
+  - `pdelie.reporting.summarize_formula_generator_family(...)`
+- candidate-validation extension:
+  - `pdelie.symmetry.validate_symmetry_candidate(...)` accepts formula objects and strict current formula payloads
+- report discriminator:
+  - `candidate_kind = "formula_generator_family"`
+- supported formula components:
+  - `tau`
+  - `xi`
+  - `phi`
+- supported variables:
+  - `t`
+  - `x`
+  - `u`
+- safe JSON expression AST nodes:
+  - `const`
+  - `var`
+  - `add`
+  - `mul`
+  - integer `pow`
+  - `sin`
+  - `cos`
+  - `reciprocal`
+  - metadata-only `symbolic_reference`
+- formula validation interpretation:
+  - malformed formulas raise typed validation errors
+  - finite formula-evaluation failures return `conclusion = "failed"`
+  - symbolic-reference-only formulas remain reporting/schema results and do not pretend to evaluate
+  - formulas without finite transforms may be only partially validated
+  - formulas with supported passing finite-transform checks may be validated
 
 ---
 
-## Milestone 2 - GeneratorFamily Candidate Validation
+## Milestone 2 - Formula Record and Reporting Implementation
 
 **Status:** COMPLETE
 
 ### Goal
 
-Implement validation for `GeneratorFamily` objects and strict payload mappings.
+Implement the runtime-only formula record and reporting helper.
 
 ### Completed Outcome
 
-- implemented `pdelie.symmetry.validate_symmetry_candidate(...)`
-- accepted canonical `GeneratorFamily` objects and payload mappings
-- reused existing:
-  - `verify_translation_generator(...)`
-  - `compare_generator_spans(...)`
-  - `diagnose_generator_family_closure(...)`
-  - reporting summaries
-- single-row translation-compatible candidates run finite-transform verification
-- wrong-span candidates return `conclusion = "failed"` rather than raising
-- multi-generator families run closure diagnostics and do not force single-translation verification
-- optional `reference_generator` enables span comparison
-- documented the new API in `docs/specs/API_STABILITY.md`
+- implemented `pdelie.symmetry.FormulaGeneratorFamily`
+- implemented strict `.to_dict()` / `.from_dict()` JSON payload round trips
+- implemented safe expression normalization for the frozen AST
+- rejected invalid variables, components, expression nodes, nonfinite constants, arbitrary strings, and callables with typed validation errors
+- supported symbolic references as metadata-only expressions
+- supported optional `finite_transform_spec` as a canonical `InvariantMapSpec` payload
+- implemented `pdelie.reporting.summarize_formula_generator_family(...)`
+- documented the new APIs in `docs/specs/API_STABILITY.md`
 
 ---
 
-## Milestone 3 - InvariantMapSpec Candidate Validation
+## Milestone 3 - Formula Candidate Validation
 
 **Status:** COMPLETE
 
 ### Goal
 
-Extend the same helper to validate `InvariantMapSpec` objects and strict payload mappings.
+Extend empirical configured candidate validation to formula-backed generator families.
 
 ### Completed Outcome
 
-- accepted canonical `InvariantMapSpec` objects and payload mappings
-- supported only global `uniform_translation` specs over canonical scalar 1D periodic fields
-- reused existing `InvariantApplier`
-- reported:
-  - residual RMS before and after transform
-  - absolute and relative residual RMS deltas
-  - inverse consistency when `inverse_available` is true
-  - preprocess/provenance fields
-- rejected unsupported maps with typed validation errors:
-  - non-global specs
-  - approximate specs
-  - non-translation specs
-  - missing or nonfinite shifts
-  - unsupported axes
+- extended `validate_symmetry_candidate(...)` for:
+  - `FormulaGeneratorFamily` objects
+  - strict current formula payload mappings
+- added `candidate_kind = "formula_generator_family"`
+- added formula-evaluation diagnostics over canonical scalar 1D periodic `FieldBatch` inputs
+- reported component-level value shapes, max absolute values, RMS values, symbolic-reference unavailability, and denominator-floor failures
+- kept denominator-floor violations as failed empirical reports, not untyped exceptions
+- reused the existing invariant-map residual and inverse validation path when a supported finite-transform spec is attached
+- preserved existing `GeneratorFamily` and `InvariantMapSpec` validation behavior
 
 ---
 
@@ -169,17 +174,18 @@ Extend the same helper to validate `InvariantMapSpec` objects and strict payload
 
 ### Goal
 
-Add a compact JSON-only example for external symmetry-candidate validation.
+Add a compact JSON-only example for formula-backed candidate validation.
 
 ### Completed Outcome
 
-- added `python -m pdelie.examples.symmetry_candidate_validation`
-- added `pdelie.examples.run_symmetry_candidate_validation_example(...)`
+- added `python -m pdelie.examples.formula_generator_validation`
+- added `pdelie.examples.run_formula_generator_validation_example(...)`
 - example demonstrates:
-  - valid Heat `GeneratorFamily` candidate
-  - valid KdV `GeneratorFamily` candidate
-  - valid uniform-translation `InvariantMapSpec` payload candidate
-  - failed wrong-span generator candidate
+  - affine formula candidate
+  - trigonometric formula candidate
+  - rational formula candidate with finite diagnostics
+  - formula candidate with supported uniform-translation finite transform
+  - failed nonfinite formula candidate for contrast
 - example output remains runtime smoke/reporting, not a canonical artifact schema
 - root `pdelie` remains unchanged
 
@@ -191,15 +197,16 @@ Add a compact JSON-only example for external symmetry-candidate validation.
 
 ### Goal
 
-Verify public surface and documentation match the frozen `v0.16` scope.
+Verify public surface and documentation match the frozen `v0.17` scope.
 
 ### Completed Outcome
 
-- confirmed `pdelie.symmetry.validate_symmetry_candidate(...)` is submodule-only
+- confirmed `pdelie.symmetry.FormulaGeneratorFamily` is submodule-only
+- confirmed `pdelie.reporting.summarize_formula_generator_family(...)` is submodule-only
+- confirmed `validate_symmetry_candidate(...)` documents and reports formula candidates
 - confirmed root `pdelie` exports remain unchanged
-- confirmed `API_STABILITY.md` documents only the v0.16 validation helper
-- confirmed no callable descriptor API landed
-- confirmed no formula-backed generator object landed
+- confirmed no callable generator API landed
+- confirmed no arbitrary executable formula-string path landed
 - confirmed no neural detector API landed
 - confirmed no public KS generator/residual/example APIs landed
 - confirmed weak KS remains absent
@@ -217,67 +224,34 @@ Close the release with compact gate coverage, metadata, docs, and direct Git-tag
 
 ### Completed Outcome
 
-- added compact `tests/test_v0_16_release_gate.py`
-- updated CI so the current explicit release gate is `v0_16-release-gate`
-- retained full editable tests and package smoke
-- added compact package-smoke coverage for symmetry-candidate validation
-- bumped package metadata to `0.16.0`
-- updated README and changelog for `v0.16`
-- added `docs/releases/V0_16_RELEASE_READINESS.md`
-- updated publishing docs to keep `v0.16.0` Git-tag-only
-- moved `v0.16` into completed release context in `ROADMAP.md`
-- kept PyPI/TestPyPI deferred until `v1.0` or later
-
-### Direct Tag Path
-
-Before tagging `v0.16.0`:
-
-- run full local tests
-- build sdist and wheel
-- run clean wheel smoke
-- run Heat, KdV, orbit/coverage, invariant-workflow, translation-orbit-batch, and symmetry-candidate-validation example modules
-- confirm CI checks pass:
-  - `v0_16-release-gate`
-  - `editable-tests`
-  - `package-smoke`
-- tag the merged main commit as `v0.16.0`
-- do not publish to TestPyPI
-- do not publish to PyPI
+- added compact `tests/test_v0_17_release_gate.py`
+- updated CI so the current explicit release gate is `v0_17-release-gate`
+- kept full editable tests and package smoke
+- bumped package metadata to `0.17.0`
+- updated README, changelog, release readiness, publishing docs, roadmap, and plan
+- documented direct `v0.17.0` Git-tag release path
+- kept PyPI/TestPyPI publishing deferred until `v1.0` or later
 
 ---
 
-## Explicit Non-goals Preserved
+## Final Validation Checklist
 
-`v0.16` did not add:
+Required before tagging:
 
-- callable transform descriptors
-- arbitrary external executable candidate objects
-- neural symmetry-detector training
-- learned-generator classes
-- formula-backed or non-polynomial generator families
-- train/test policy
-- split management
-- heldout-leakage detection
-- sparse-discovery branch policy
-- private-paper augmentation recipes
-- time-translation APIs
-- new PDE support
-- stable KS runtime support
-- weak KS
-- broad adapters
-- PDEBench or The Well support
-- multidimensional, multivariable, or nonuniform-grid expansion
-- operator-facing APIs
-- root runtime exports
+- `python -m pytest`
+- `python -m build --sdist --wheel`
+- clean wheel smoke from `dist/pdelie-0.17.0-py3-none-any.whl`
+- `python -m pdelie.examples.heat_vertical_slice`
+- `python -m pdelie.examples.kdv_vertical_slice`
+- `python -m pdelie.examples.orbit_coverage_diagnostics`
+- `python -m pdelie.examples.invariant_workflow_summary`
+- `python -m pdelie.examples.translation_orbit_batch`
+- `python -m pdelie.examples.symmetry_candidate_validation`
+- `python -m pdelie.examples.formula_generator_validation`
+- `git diff --check`
 
----
+Required CI checks before tagging:
 
-## Status Checklist
-
-- Milestone 0: COMPLETE
-- Milestone 1: COMPLETE
-- Milestone 2: COMPLETE
-- Milestone 3: COMPLETE
-- Milestone 4: COMPLETE
-- Milestone 5: COMPLETE
-- Milestone 6: COMPLETE
+- `v0_17-release-gate`
+- `editable-tests`
+- `package-smoke`

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -453,6 +453,81 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.17` - Formula-backed generator families
+**Status:** Completed
+
+`v0.17` is the completed formula-backed generator interoperability release after the `v0.16` external symmetry-candidate validation release.
+
+Its purpose is:
+
+> accept safe formula-backed generator metadata and validate it empirically without turning PDELie into an executable formula parser or learned-generator framework.
+
+Completed release definition:
+
+`canonical scalar 1D periodic FieldBatch + formula-backed generator candidate -> safe formula metadata/evaluation diagnostics -> empirical configured validation report`
+
+Completed scope:
+
+- `pdelie.symmetry.FormulaGeneratorFamily`
+- `pdelie.reporting.summarize_formula_generator_family(...)`
+- `validate_symmetry_candidate(...)` support for `candidate_kind = "formula_generator_family"`
+- strict JSON-compatible formula payload round trips
+- safe formula AST nodes: `const`, `var`, `add`, `mul`, integer `pow`, `sin`, `cos`, `reciprocal`, and metadata-only `symbolic_reference`
+- finite formula-evaluation diagnostics over canonical scalar 1D periodic `FieldBatch` inputs
+- optional reuse of invariant-map validation when a supported finite-transform spec is attached
+- affine, trigonometric, rational, finite-transform-backed, and failed-formula example coverage
+- API/public-surface audit
+- compact current `v0_17-release-gate` readiness
+
+Release interpretation:
+
+- `validated` means configured empirical validation under supplied inputs, not a mathematical proof
+- this is formula metadata and empirical validation interop, not a mathematical proof of symmetry
+- formula records are runtime-only and do not change canonical polynomial `GeneratorFamily` semantics
+- symbolic references are metadata-only unless paired with supported finite-transform evidence
+- callable descriptors, arbitrary executable formula strings, and learned-generator training remain deferred
+- `v0.17.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no callable generator API
+- no arbitrary executable formula-string evaluator
+- no neural symmetry-detector training
+- no canonical `GeneratorFamily` schema change
+- no train/test policy
+- no split management
+- no new PDE
+- no stable KS generator or residual evaluator
+- no weak KS API
+- no broad dataset adapters
+- no PDEBench or The Well support
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no operator-facing symmetry work
+- no root export expansion
+
+The authoritative `v0.17` scope freeze belongs in:
+
+- `V0_17_SCOPE.md`
+
+### Release Gate for `v0.17`
+
+`v0.17` is complete only if:
+
+- formula-backed generator records are documented and covered by tests
+- new APIs are importable from their submodules only
+- root `pdelie` remains unchanged
+- formula candidates validate through the existing symmetry-candidate validator
+- finite formula diagnostics and denominator-floor failures are deterministic
+- supported finite-transform specs reuse existing invariant-map validation
+- formula validation example emits JSON only
+- no public callable, executable-string, neural-detector, KS, weak KS, broad adapter, split-policy, or operator API lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.16` - External symmetry-candidate validation
 **Status:** Completed
 
@@ -857,28 +932,6 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ## Medium-Term Horizon
 
-### `v0.17` - Formula-backed and non-polynomial generators
-**Status:** Planned
-
-`v0.17` is planned as the first careful step beyond the current polynomial/structured generator support.
-
-Recommended phasing:
-
-- formula-backed metadata first:
-  - affine generators
-  - trigonometric generators
-  - rational or simple analytic forms
-  - externally supplied symbolic references
-- callable or external generators second, treated as less stable unless paired with diagnostics
-- learned-generator interop third, as accepted outputs only
-
-Key freeze decision:
-
-- either introduce a new formula-backed generator record such as `FormulaGeneratorFamily`
-- or keep the first slice as runtime metadata until compatibility with existing `GeneratorFamily` semantics is proven
-
-The conservative default is formula-backed runtime records first, with no change to existing polynomial `GeneratorFamily` semantics until explicitly accepted.
-
 ### `v0.18+` - Scoped PDE expansion
 **Status:** Planned
 
@@ -991,7 +1044,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.14` = invariant workflow summaries and read-only uniform translation orbit reports, without augmentation
 - `v0.15` = materialized uniform translation orbit batches under `pdelie.invariants`
 - `v0.16` = external symmetry-candidate interop and validation, not detector training
-- `v0.17` = formula-backed and non-polynomial generator support after schema semantics are frozen
+- `v0.17` = formula-backed generator records and validation, without callables or learned-generator training
 - `v0.18+` = scoped PDE expansion, with reaction/advection-diffusion preferred unless KS residual-only is deliberately scoped
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -8,13 +8,13 @@ Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
 
 ## Summary
 
-After `v0.14`, the highest-ROI path is to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then non-polynomial generator support, then carefully scoped PDE expansion.
+After `v0.14`, the highest-ROI path has been to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then formula-backed generator support, then carefully scoped PDE expansion.
 
 Staged sequence:
 
 - `v0.15`: materialized uniform translation orbit batches
 - `v0.16`: external symmetry-candidate interop and validation
-- `v0.17`: formula-backed and non-polynomial generator families
+- `v0.17`: formula-backed generator families
 - `v0.18+`: scoped PDE expansion
 
 PDELie should remain a reusable library and validation/reporting substrate.
@@ -116,45 +116,54 @@ Design boundary:
 - this is detector interop, not sparse-discovery reporting
 - this is validation/reporting, not neural-generator training
 - learned-generator methods may slot in by exporting candidates, but PDELie does not train those models
-- callable descriptors remain deferred
-- formula-backed/non-polynomial generators remain deferred to `v0.17`
+- callable descriptors and learned-generator APIs remain deferred beyond `v0.17`
 
 This keeps PDELie compatible with learned-generator or Lie-algebra-aware methods without becoming a neural symmetry-discovery framework.
 
 ---
 
-## V0.17 - Formula-backed And Non-polynomial Generators
+## V0.17 - Formula-backed Generator Families
 
-Planned theme:
+Completed theme:
 
 > support richer generator descriptions without jumping directly to neural generator classes.
 
-Phase 1 should focus on formula-backed generator records for:
+Implemented API direction:
+
+```python
+pdelie.symmetry.FormulaGeneratorFamily
+pdelie.reporting.summarize_formula_generator_family(...)
+pdelie.symmetry.validate_symmetry_candidate(..., candidate=FormulaGeneratorFamily(...), ...)
+```
+
+The completed first phase focuses on formula-backed runtime records for:
 
 - affine generators
 - trigonometric generators
 - rational or simple analytic forms
 - externally supplied symbolic references
 
-Required semantics to freeze:
+Completed semantics:
 
-- JSON-serializable formula metadata
-- evaluation policy on canonical fields
-- finite-transform availability, or explicit `infinitesimal_only` status
-- validation diagnostics
-- compatibility with existing reporting helpers
+- JSON-compatible formula metadata and strict payload round trips
+- safe JSON AST expressions rather than executable strings
+- finite formula-evaluation diagnostics on canonical scalar 1D periodic fields
+- optional finite-transform validation through attached `InvariantMapSpec` payloads
+- symbolic references as metadata-only expressions
+- compatibility with existing symmetry-candidate validation reports
 
-Phase 2 may allow callable or external generators, but those should be treated as less stable unless paired with diagnostic reports.
+Callable or external executable generators remain deferred and should be treated as less stable unless paired with diagnostic reports.
 
-Phase 3 may allow learned-generator interop through accepted outputs only.
+Later learned-generator interop should still work through accepted outputs only.
 PDELie should validate such outputs; it should not train learned generators.
 
-Key design decision for `v0.17`:
+Selected design for `v0.17`:
 
-- decide whether formula-backed generators require a new canonical object such as `FormulaGeneratorFamily`
-- or whether a runtime metadata record is enough for the first stable slice
+- `FormulaGeneratorFamily` is a runtime-only structured record
+- it is not a canonical object
+- it does not change existing polynomial `GeneratorFamily` semantics
 
-The conservative default is a runtime formula-backed record first, with no change to existing polynomial `GeneratorFamily` semantics until the compatibility story is proven.
+The completed scope freeze belongs in `V0_17_SCOPE.md`.
 
 ---
 

--- a/docs/planning/V0_17_SCOPE.md
+++ b/docs/planning/V0_17_SCOPE.md
@@ -1,0 +1,140 @@
+# V0.17 Scope - Formula-backed Generator Families
+
+## Summary
+
+`v0.17` is a narrow formula-backed generator interoperability release.
+
+Stable path:
+
+`canonical scalar 1D periodic FieldBatch + formula-backed generator candidate -> safe formula metadata/evaluation diagnostics -> empirical configured validation report`
+
+This release adds formula-backed runtime records without changing existing polynomial `GeneratorFamily` semantics.
+
+## Stable Scope
+
+`v0.17` adds submodule-only runtime APIs:
+
+- `pdelie.symmetry.FormulaGeneratorFamily`
+- `pdelie.reporting.summarize_formula_generator_family(...)`
+- `pdelie.symmetry.validate_symmetry_candidate(...)` support for formula-backed candidates
+
+`FormulaGeneratorFamily` is runtime-only. It is not a new canonical object and does not change canonical `GeneratorFamily`.
+
+## Formula Record
+
+Frozen record properties:
+
+- `schema_version = "0.1"`
+- `parameterization = "formula_generator_family"`
+- supported variables are exactly `t`, `x`, and `u`
+- supported components are exactly `tau`, `xi`, and `phi`
+- each generator row has a nonempty `name`
+- each generator row must define all three components
+- optional `finite_transform_spec` is a canonical `InvariantMapSpec` payload
+- `diagnostics` are JSON-compatible provenance only
+
+Formula records support `.to_dict()` and `.from_dict()` round trips.
+
+## Safe Expression AST
+
+Formula expressions use a small JSON AST. They are not Python code and are not parsed from arbitrary executable strings.
+
+Supported nodes:
+
+- `const`
+- `var`
+- `add`
+- `mul`
+- integer `pow`
+- `sin`
+- `cos`
+- `reciprocal`
+- metadata-only `symbolic_reference`
+
+Rational expressions use `reciprocal` with a fixed denominator floor. Denominator-floor violations are empirical validation failures.
+
+Symbolic references are metadata only. They may be summarized, but they are not evaluated.
+
+## Candidate Validation
+
+`validate_symmetry_candidate(...)` accepts:
+
+- `FormulaGeneratorFamily` objects
+- strict current `FormulaGeneratorFamily` payload mappings
+
+Formula reports use:
+
+- `summary_schema_version = "0.1"`
+- `summary_type = "symmetry_candidate_validation"`
+- `candidate_kind = "formula_generator_family"`
+
+Validation behavior:
+
+- malformed formula records raise typed validation errors
+- well-formed formulas that evaluate to nonfinite values return `conclusion = "failed"`
+- formulas with finite evaluable components but no finite transform are generally `partially_validated`
+- symbolic-reference-only formulas are reporting/schema results and do not pretend to evaluate
+- formulas with supported passing finite-transform checks may be `validated`
+- `validated` remains empirical configured validation, not a mathematical proof of symmetry
+
+## Reporting
+
+`summarize_formula_generator_family(...)` returns a JSON-compatible runtime summary with:
+
+- formula parameterization and schema version
+- variables and component names
+- generator count and names
+- expression node kinds
+- component root-node summaries
+- finite-transform availability
+- symbolic-reference metadata
+- reciprocal denominator floor
+- diagnostics
+
+The helper does not mutate inputs and does not evaluate arbitrary code.
+
+## Non-goals
+
+`v0.17` does not add:
+
+- Python callable generator APIs
+- arbitrary executable formula-string parsing
+- neural generator training
+- learned-generator detector APIs
+- formula-derived finite-flow integration for arbitrary infinitesimal formulas
+- canonical `GeneratorFamily` schema changes
+- new PDEs
+- stable KS generator/residual/example APIs
+- weak KS
+- broad dataset adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid expansion
+- train/test policy
+- split management
+- operator-facing APIs
+- root `pdelie` exports
+
+## Milestone Status
+
+- Milestone 0: COMPLETE - scope freeze
+- Milestone 1: COMPLETE - formula schema and validation semantics freeze
+- Milestone 2: COMPLETE - formula record and reporting implementation
+- Milestone 3: COMPLETE - formula candidate validation
+- Milestone 4: COMPLETE - formula validation example
+- Milestone 5: COMPLETE - API/public-surface audit
+- Milestone 6: COMPLETE - release gate and readiness
+
+## Release Gate Expectations
+
+`v0.17` is complete only if:
+
+- formula records round-trip through strict JSON-compatible payloads
+- invalid formulas raise typed validation errors
+- formula summaries are JSON-compatible and submodule-only
+- formula candidates validate through `validate_symmetry_candidate(...)`
+- finite formula diagnostics and denominator-floor failures are covered
+- attached supported finite-transform specs reuse existing invariant-map validation
+- existing `GeneratorFamily` and `InvariantMapSpec` candidate validation behavior remains unchanged
+- formula validation example emits JSON only
+- no callable, executable-string, neural-detector, KS, weak KS, broad-adapter, operator, split-policy, or root-export surface lands
+- package/readiness docs preserve the `v1.0` package-index publishing deferral

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.16.0`, release completion means:
+For the current `v0.x` series, including `v0.17.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.16.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.16`.
+`v0.17.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.17`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_17_RELEASE_READINESS.md
+++ b/docs/releases/V0_17_RELEASE_READINESS.md
@@ -1,0 +1,124 @@
+# V0.17 Release Readiness
+
+- package version: `0.17.0`
+- git tag: `v0.17.0`
+- package-index publication: deferred until `v1.0` or later
+
+`v0.17.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.17`.
+
+## Summary
+
+`v0.17` closes as the formula-backed generator interoperability release.
+
+Stable claim:
+
+`canonical scalar 1D periodic FieldBatch + formula-backed generator candidate -> safe formula metadata/evaluation diagnostics -> empirical configured validation report`
+
+The public additions are:
+
+- `pdelie.symmetry.FormulaGeneratorFamily`
+- `pdelie.reporting.summarize_formula_generator_family(...)`
+- `pdelie.symmetry.validate_symmetry_candidate(...)` support for `candidate_kind = "formula_generator_family"`
+
+Formula expressions use a safe JSON AST.
+They are not executable Python strings or callables.
+
+`validated` still means configured empirical validation under supplied inputs and thresholds.
+It is not a mathematical proof of symmetry.
+
+## M0-M6 Outcome
+
+- M0: froze scope as formula-backed generator interoperability
+- M1: froze the formula record, safe AST, reporting, and validation semantics
+- M2: implemented `FormulaGeneratorFamily` and formula-family summaries
+- M3: extended candidate validation for formula-backed families
+- M4: added JSON-only formula-generator validation example
+- M5: audited public surface and non-goals
+- M6: aligned metadata, docs, CI, release gate, and readiness notes
+
+## Public API Notes
+
+New or extended submodule-only APIs:
+
+- `pdelie.symmetry.FormulaGeneratorFamily`
+- `pdelie.reporting.summarize_formula_generator_family`
+- `pdelie.symmetry.validate_symmetry_candidate`
+
+No root exports are added.
+
+`FormulaGeneratorFamily` is runtime-only.
+It is not a canonical object and does not change polynomial `GeneratorFamily` semantics.
+
+## Explicit Deferrals
+
+`v0.17` does not add:
+
+- callable generator APIs
+- arbitrary executable formula-string parsing
+- neural symmetry-detector training
+- learned-generator classes
+- formula-derived finite-flow integration for arbitrary infinitesimal formulas
+- canonical `GeneratorFamily` schema changes
+- train/test policy
+- split management
+- heldout-leakage detection
+- sparse-discovery branch policy
+- time-translation APIs
+- new PDE support
+- stable KS runtime support
+- weak KS
+- broad adapters
+- PDEBench or The Well support
+- multidimensional, multivariable, or nonuniform-grid expansion
+- operator-facing APIs
+- root runtime exports
+
+## CI Expectations
+
+Required CI checks before tagging:
+
+- `v0_17-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+Historical release-gate test files remain in the repository and are covered by the full editable test suite.
+
+## Local Validation Checklist
+
+Before tagging `v0.17.0`, run:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
+python -m pdelie.examples.symmetry_candidate_validation
+python -m pdelie.examples.formula_generator_validation
+git diff --check
+```
+
+Clean wheel smoke should verify:
+
+- stable root imports
+- `pdelie.symmetry.FormulaGeneratorFamily` imports from the submodule
+- `pdelie.reporting.summarize_formula_generator_family` imports from the submodule
+- root `pdelie.FormulaGeneratorFamily` remains absent
+- one formula-backed candidate validates or partially validates
+- one formula-backed finite-transform candidate validates
+- one denominator-floor formula candidate returns `conclusion = "failed"`
+- weak Heat report smoke remains green
+- KdV strong-path residual smoke remains green
+- order-4 derivative smoke remains green
+
+## Direct Tag Checklist
+
+- create and merge the release PR
+- wait for required CI checks to pass
+- tag the merged `main` commit as `v0.17.0`
+- do not publish to TestPyPI
+- do not publish to PyPI
+- record package-index publishing as deferred until `v1.0` or later

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -190,6 +190,18 @@ Runtime public API for the frozen `v0.16` Milestone 2/M3 slice:
 - this API returns a JSON-compatible runtime report, not a canonical object, detector, fitting algorithm, manuscript artifact, or training framework
 - this API has no root `pdelie` export
 
+Runtime public API for the frozen `v0.17` Milestone 2/M3 slice:
+
+- `pdelie.symmetry.FormulaGeneratorFamily` as a runtime-only structured record for formula-backed scalar 1D Lie-point generator families
+- `pdelie.reporting.summarize_formula_generator_family` for JSON-compatible runtime summaries of formula-backed generator records
+- `pdelie.symmetry.validate_symmetry_candidate` now also accepts `FormulaGeneratorFamily` objects and strict current `FormulaGeneratorFamily` payload mappings
+- formula candidate validation reports distinguish `candidate_kind = "formula_generator_family"`
+- formula expressions use a safe JSON AST with supported nodes `const`, `var`, `add`, `mul`, integer `pow`, `sin`, `cos`, `reciprocal`, and metadata-only `symbolic_reference`
+- formula-backed validation performs schema checks, finite formula-evaluation diagnostics when expressions are evaluable, and optional finite-transform validation when a supported `InvariantMapSpec` payload is attached
+- `FormulaGeneratorFamily` is runtime-only and does not change canonical polynomial `GeneratorFamily` semantics
+- arbitrary executable formula strings, Python callables, learned-generator training, neural detector APIs, public KS runtime APIs, weak KS, broad adapters, split policy, and operator-facing APIs remain deferred
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.16.0"
-description = "V0.16 external symmetry-candidate validation reports over the Heat/Burgers/weak-report/KdV engine"
+version = "0.17.0"
+description = "V0.17 formula-backed generator records and validation over the Heat/Burgers/weak-report/KdV engine"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -1,11 +1,18 @@
 __all__ = [
     "run_heat_vertical_slice_example",
+    "run_formula_generator_validation_example",
     "run_invariant_workflow_summary_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
     "run_symmetry_candidate_validation_example",
     "run_translation_orbit_batch_example",
 ]
+
+
+def run_formula_generator_validation_example() -> dict[str, object]:
+    from pdelie.examples.formula_generator_validation import run_formula_generator_validation_example as _impl
+
+    return _impl()
 
 
 def run_heat_vertical_slice_example() -> dict[str, object]:

--- a/src/pdelie/examples/formula_generator_validation.py
+++ b/src/pdelie/examples/formula_generator_validation.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie import GeneratorFamily, InvariantMapSpec
+from pdelie.contracts import _translation_generator_basis_spec
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.residuals import HeatResidualEvaluator
+from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_DOMAIN_LENGTH = 2.0 * np.pi
+
+
+def _const(value: float) -> dict[str, object]:
+    return {"node": "const", "value": float(value)}
+
+
+def _var(name: str) -> dict[str, object]:
+    return {"node": "var", "name": name}
+
+
+def _translation_generator() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="polynomial_translation_affine",
+        coefficients=np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+        basis_spec=_translation_generator_basis_spec(),
+        normalization="l2_unit",
+        diagnostics={},
+    )
+
+
+def _translation_spec_payload() -> dict[str, object]:
+    return InvariantMapSpec(
+        generator_metadata=_translation_generator().to_dict(),
+        construction_method="uniform_translation",
+        parameters={"axis": "x", "shift": _DOMAIN_LENGTH / 8.0},
+        domain_validity="global",
+        inverse_available=True,
+        diagnostics={},
+    ).to_dict()
+
+
+def _formula(name: str, *, tau: dict[str, object], xi: dict[str, object], phi: dict[str, object], **kwargs: object) -> FormulaGeneratorFamily:
+    return FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": name,
+                "components": {"tau": tau, "xi": xi, "phi": phi},
+            }
+        ],
+        **kwargs,
+    )
+
+
+def run_formula_generator_validation_example() -> dict[str, object]:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=17001)
+    evaluator = HeatResidualEvaluator()
+
+    cases = [
+        {
+            "case_name": "affine_formula",
+            "report": validate_symmetry_candidate(
+                field,
+                _formula("affine_formula", tau=_const(0.0), xi=_var("x"), phi=_var("u")),
+                residual_evaluator=evaluator,
+                source_candidate_id="affine_formula",
+            ),
+        },
+        {
+            "case_name": "trigonometric_formula",
+            "report": validate_symmetry_candidate(
+                field,
+                _formula(
+                    "trigonometric_formula",
+                    tau=_const(0.0),
+                    xi={"node": "sin", "arg": _var("x")},
+                    phi={"node": "cos", "arg": _var("u")},
+                ),
+                residual_evaluator=evaluator,
+                source_candidate_id="trigonometric_formula",
+            ),
+        },
+        {
+            "case_name": "rational_formula",
+            "report": validate_symmetry_candidate(
+                field,
+                _formula(
+                    "rational_formula",
+                    tau=_const(0.0),
+                    xi={
+                        "node": "reciprocal",
+                        "arg": {
+                            "node": "add",
+                            "terms": [
+                                _const(1.0),
+                                {"node": "pow", "base": _var("u"), "exponent": 2},
+                            ],
+                        },
+                    },
+                    phi=_const(0.0),
+                ),
+                residual_evaluator=evaluator,
+                source_candidate_id="rational_formula",
+            ),
+        },
+        {
+            "case_name": "formula_with_uniform_translation_transform",
+            "report": validate_symmetry_candidate(
+                field,
+                _formula(
+                    "formula_translation",
+                    tau=_const(0.0),
+                    xi=_const(1.0),
+                    phi=_const(0.0),
+                    finite_transform_spec=_translation_spec_payload(),
+                ),
+                residual_evaluator=evaluator,
+                source_candidate_id="formula_translation_with_finite_transform",
+            ),
+        },
+        {
+            "case_name": "failed_nonfinite_formula",
+            "report": validate_symmetry_candidate(
+                field,
+                _formula(
+                    "failed_nonfinite_formula",
+                    tau=_const(0.0),
+                    xi={"node": "reciprocal", "arg": _const(0.0)},
+                    phi=_const(0.0),
+                ),
+                residual_evaluator=evaluator,
+                source_candidate_id="failed_nonfinite_formula",
+            ),
+        },
+    ]
+
+    return {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": "formula_generator_validation_example",
+        "cases": cases,
+        "extra_metrics": {
+            "example_name": "formula_generator_validation",
+            "candidate_kinds": sorted({case["report"]["candidate_kind"] for case in cases}),
+            "conclusions": [case["report"]["conclusion"] for case in cases],
+            "expression_policy": "safe_json_ast_no_callables_no_executable_strings",
+            "interpretation": "configured_empirical_validation_not_mathematical_proof",
+        },
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_formula_generator_validation_example(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/reporting/__init__.py
+++ b/src/pdelie/reporting/__init__.py
@@ -1,4 +1,5 @@
 from pdelie.reporting.summaries import (
+    summarize_formula_generator_family,
     summarize_generator_fit_diagnostics,
     summarize_generator_family,
     summarize_invariant_workflow,
@@ -9,6 +10,7 @@ from pdelie.reporting.summaries import (
 )
 
 __all__ = [
+    "summarize_formula_generator_family",
     "summarize_generator_fit_diagnostics",
     "summarize_generator_family",
     "summarize_invariant_workflow",

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from pdelie.contracts import DerivativeBatch, GeneratorFamily, ResidualBatch, VerificationReport
 from pdelie.errors import PDELieValidationError, SchemaValidationError, ScopeValidationError
+from pdelie.symmetry.formula import FormulaGeneratorFamily
 from pdelie.symmetry.parameterization import translation_span_distance
 from pdelie.symmetry.parameterization.polynomial_translation import DEFAULT_TRANSLATION_SPAN_TOLERANCE
 
@@ -326,6 +327,82 @@ def summarize_generator_family(generator: GeneratorFamily) -> dict[str, Any]:
         reference_fallback_used=diagnostics.get("reference_fallback_used"),
         fallback_reason=diagnostics.get("fallback_reason"),
         diagnostics=diagnostics,
+    )
+
+
+def _formula_expression_nodes(expression: Mapping[str, Any]) -> list[str]:
+    node = str(expression["node"])
+    if node == "add":
+        return [node, *[item for term in expression["terms"] for item in _formula_expression_nodes(term)]]
+    if node == "mul":
+        return [node, *[item for factor in expression["factors"] for item in _formula_expression_nodes(factor)]]
+    if node == "pow":
+        return [node, *_formula_expression_nodes(expression["base"])]
+    if node in {"sin", "cos", "reciprocal"}:
+        return [node, *_formula_expression_nodes(expression["arg"])]
+    return [node]
+
+
+def _formula_symbolic_references(expression: Mapping[str, Any]) -> list[dict[str, Any]]:
+    node = str(expression["node"])
+    if node == "symbolic_reference":
+        return [{"label": expression["label"], "metadata": expression["metadata"]}]
+    if node == "add":
+        return [item for term in expression["terms"] for item in _formula_symbolic_references(term)]
+    if node == "mul":
+        return [item for factor in expression["factors"] for item in _formula_symbolic_references(factor)]
+    if node == "pow":
+        return _formula_symbolic_references(expression["base"])
+    if node in {"sin", "cos", "reciprocal"}:
+        return _formula_symbolic_references(expression["arg"])
+    return []
+
+
+def summarize_formula_generator_family(formula: FormulaGeneratorFamily) -> dict[str, Any]:
+    if not isinstance(formula, FormulaGeneratorFamily):
+        raise SchemaValidationError("summarize_formula_generator_family requires a FormulaGeneratorFamily.")
+
+    formula.validate()
+    generator_names = [generator["name"] for generator in formula.formula_generators]
+    formula_kinds: dict[str, int] = {}
+    symbolic_references: list[dict[str, Any]] = []
+    component_nodes: dict[str, list[str]] = {component: [] for component in formula.component_names}
+    for generator in formula.formula_generators:
+        for component in formula.component_names:
+            expression = generator["components"][component]
+            nodes = _formula_expression_nodes(expression)
+            for node in nodes:
+                formula_kinds[node] = formula_kinds.get(node, 0) + 1
+            component_nodes[component].append(str(expression["node"]))
+            for reference in _formula_symbolic_references(expression):
+                symbolic_references.append(
+                    {
+                        "generator_name": generator["name"],
+                        "component": component,
+                        "label": reference["label"],
+                        "metadata": reference["metadata"],
+                    }
+                )
+
+    return _summary_payload(
+        "formula_generator_family",
+        parameterization=formula.parameterization,
+        schema_version=formula.schema_version,
+        variables=list(formula.variables),
+        component_names=list(formula.component_names),
+        generator_count=len(formula.formula_generators),
+        generator_names=generator_names,
+        formula_kinds=formula_kinds,
+        component_nodes=component_nodes,
+        finite_transform_available=formula.finite_transform_spec is not None,
+        finite_transform_construction_method=(
+            None
+            if formula.finite_transform_spec is None
+            else formula.finite_transform_spec.get("construction_method")
+        ),
+        symbolic_references=symbolic_references,
+        reciprocal_denominator_floor=FormulaGeneratorFamily.RECIPROCAL_DENOMINATOR_FLOOR,
+        diagnostics=formula.diagnostics,
     )
 
 

--- a/src/pdelie/symmetry/__init__.py
+++ b/src/pdelie/symmetry/__init__.py
@@ -1,10 +1,12 @@
 from pdelie.symmetry.fitting.translation_baseline import fit_translation_generator
 from pdelie.symmetry.candidate_validation import validate_symmetry_candidate
 from pdelie.symmetry.closure import diagnose_generator_family_closure
+from pdelie.symmetry.formula import FormulaGeneratorFamily
 from pdelie.symmetry.span import compare_generator_spans
 from pdelie.symmetry.symbolic import render_generator_family, to_sympy_component_expressions
 
 __all__ = [
+    "FormulaGeneratorFamily",
     "fit_translation_generator",
     "validate_symmetry_candidate",
     "diagnose_generator_family_closure",

--- a/src/pdelie/symmetry/candidate_validation.py
+++ b/src/pdelie/symmetry/candidate_validation.py
@@ -11,6 +11,10 @@ from pdelie.errors import PDELieValidationError, SchemaValidationError, ScopeVal
 from pdelie.invariants import InvariantApplier
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.closure import diagnose_generator_family_closure
+from pdelie.symmetry.formula import (
+    FormulaGeneratorFamily,
+    _diagnose_formula_generator_family_on_field,
+)
 from pdelie.symmetry.parameterization.polynomial_translation import (
     _coerce_translation_coefficients,
 )
@@ -25,6 +29,7 @@ _INVERSE_RELATIVE_L2_TOLERANCE = 1e-8
 _SPAN_TOLERANCE = 1e-8
 _CLOSURE_TOLERANCE = 1e-8
 _RELATIVE_L2_EPS = 1e-12
+_FORMULA_RECIPROCAL_DENOMINATOR_FLOOR = FormulaGeneratorFamily.RECIPROCAL_DENOMINATOR_FLOOR
 
 
 def _json_safe(value: Any) -> Any:
@@ -42,7 +47,7 @@ def _json_safe(value: Any) -> Any:
 def _validate_json_compatible(value: Any, *, name: str) -> Any:
     normalized = _json_safe(value)
     try:
-        json.dumps(normalized)
+        json.dumps(normalized, allow_nan=False)
     except (TypeError, ValueError) as exc:
         raise SchemaValidationError(f"{name} must be JSON-compatible.") from exc
     return normalized
@@ -76,6 +81,10 @@ def _validate_epsilon_values(values: Any | None) -> np.ndarray:
 
 
 def _is_generator_payload(payload: Mapping[str, Any]) -> bool:
+    if any(key in payload for key in ("coefficients", "basis_spec", "normalization")):
+        return True
+    if payload.get("parameterization") == FormulaGeneratorFamily.PARAMETERIZATION:
+        return False
     return any(key in payload for key in ("parameterization", "coefficients", "basis_spec", "normalization"))
 
 
@@ -90,6 +99,17 @@ def _is_invariant_map_payload(payload: Mapping[str, Any]) -> bool:
             "inverse_available",
         )
     )
+
+
+def _is_formula_payload(payload: Mapping[str, Any]) -> bool:
+    return any(
+        key in payload
+        for key in (
+            "formula_generators",
+            "component_names",
+            "finite_transform_spec",
+        )
+    ) or payload.get("parameterization") == FormulaGeneratorFamily.PARAMETERIZATION
 
 
 def _coerce_generator_payload(payload: Mapping[str, Any], *, name: str) -> GeneratorFamily:
@@ -108,20 +128,34 @@ def _coerce_generator_payload(payload: Mapping[str, Any], *, name: str) -> Gener
         raise SchemaValidationError(f"{name} is malformed.") from exc
 
 
-def _coerce_candidate(candidate: Any) -> tuple[str, GeneratorFamily | InvariantMapSpec]:
+def _coerce_formula_payload(payload: Mapping[str, Any], *, name: str) -> FormulaGeneratorFamily:
+    try:
+        return FormulaGeneratorFamily.from_dict(payload)
+    except KeyError as exc:
+        raise SchemaValidationError(f"{name} is malformed.") from exc
+
+
+def _coerce_candidate(candidate: Any) -> tuple[str, GeneratorFamily | InvariantMapSpec | FormulaGeneratorFamily]:
     if isinstance(candidate, GeneratorFamily):
         candidate.validate()
         return "generator_family", candidate
     if isinstance(candidate, InvariantMapSpec):
         candidate.validate()
         return "invariant_map_spec", candidate
+    if isinstance(candidate, FormulaGeneratorFamily):
+        candidate.validate()
+        return "formula_generator_family", candidate
     if callable(candidate):
-        raise SchemaValidationError("Callable symmetry candidate descriptors are not supported in v0.16.")
+        raise SchemaValidationError("Callable symmetry candidate descriptors are not supported.")
     if isinstance(candidate, Mapping):
         generator_payload = _is_generator_payload(candidate)
         invariant_payload = _is_invariant_map_payload(candidate)
-        if generator_payload and invariant_payload:
-            raise SchemaValidationError("Symmetry candidate payload is ambiguous between GeneratorFamily and InvariantMapSpec.")
+        formula_payload = _is_formula_payload(candidate)
+        if sum(bool(flag) for flag in (generator_payload, invariant_payload, formula_payload)) > 1:
+            raise SchemaValidationError(
+                "Symmetry candidate payload is ambiguous between GeneratorFamily, "
+                "InvariantMapSpec, and FormulaGeneratorFamily."
+            )
         if generator_payload:
             return "generator_family", _coerce_generator_payload(candidate, name="GeneratorFamily candidate payload")
         if invariant_payload:
@@ -129,8 +163,18 @@ def _coerce_candidate(candidate: Any) -> tuple[str, GeneratorFamily | InvariantM
                 return "invariant_map_spec", InvariantMapSpec.from_dict(candidate)
             except KeyError as exc:
                 raise SchemaValidationError("InvariantMapSpec candidate payload is malformed.") from exc
-        raise SchemaValidationError("Symmetry candidate payload is not a recognized GeneratorFamily or InvariantMapSpec mapping.")
-    raise SchemaValidationError("candidate must be a GeneratorFamily, InvariantMapSpec, or strict payload mapping.")
+        if formula_payload:
+            return "formula_generator_family", _coerce_formula_payload(
+                candidate,
+                name="FormulaGeneratorFamily candidate payload",
+            )
+        raise SchemaValidationError(
+            "Symmetry candidate payload is not a recognized GeneratorFamily, "
+            "InvariantMapSpec, or FormulaGeneratorFamily mapping."
+        )
+    raise SchemaValidationError(
+        "candidate must be a GeneratorFamily, InvariantMapSpec, FormulaGeneratorFamily, or strict payload mapping."
+    )
 
 
 def _coerce_reference_generator(reference_generator: Any | None) -> GeneratorFamily | None:
@@ -361,6 +405,57 @@ def _validate_invariant_map_candidate(
     return spec.to_dict(), checks
 
 
+def _validate_formula_candidate(
+    field: FieldBatch,
+    formula: FormulaGeneratorFamily,
+    *,
+    residual_evaluator: ResidualEvaluator,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    from pdelie.reporting import summarize_formula_generator_family
+
+    checks: dict[str, dict[str, Any]] = {
+        "schema": {"required": True, "status": "passed", "report": {"object": "FormulaGeneratorFamily"}}
+    }
+
+    evaluation_report = _diagnose_formula_generator_family_on_field(formula, field)
+    if evaluation_report["failed_component_count"] > 0:
+        evaluation_status = "failed"
+        evaluation_required = True
+    elif evaluation_report["evaluated_component_count"] > 0:
+        evaluation_status = "passed"
+        evaluation_required = True
+    else:
+        evaluation_status = "unavailable"
+        evaluation_required = False
+    checks["formula_evaluation_diagnostics"] = {
+        "required": evaluation_required,
+        "status": evaluation_status,
+        "threshold": {
+            "finite_values": True,
+            "reciprocal_denominator_floor": _FORMULA_RECIPROCAL_DENOMINATOR_FLOOR,
+        },
+        "report": evaluation_report,
+    }
+
+    if formula.finite_transform_spec is None:
+        checks["finite_transform_spec_validation"] = {
+            "required": False,
+            "status": "unavailable",
+            "reason": "finite_transform_spec_not_provided",
+        }
+    else:
+        spec = InvariantMapSpec.from_dict(formula.finite_transform_spec)
+        _, finite_transform_checks = _validate_invariant_map_candidate(
+            field,
+            spec,
+            residual_evaluator=residual_evaluator,
+        )
+        for name, check in finite_transform_checks.items():
+            checks[f"finite_transform_{name}"] = check
+
+    return summarize_formula_generator_family(formula), checks
+
+
 def validate_symmetry_candidate(
     field: FieldBatch,
     candidate: Any,
@@ -389,11 +484,20 @@ def validate_symmetry_candidate(
             reference_generator=normalized_reference,
             finite_transform_epsilons=epsilons,
         )
-    else:
+    elif candidate_kind == "invariant_map_spec":
         assert isinstance(normalized_candidate, InvariantMapSpec)
         if normalized_reference is not None:
             raise SchemaValidationError("reference_generator is only supported for GeneratorFamily candidates.")
         candidate_summary, checks = _validate_invariant_map_candidate(
+            field,
+            normalized_candidate,
+            residual_evaluator=residual_evaluator,
+        )
+    else:
+        assert isinstance(normalized_candidate, FormulaGeneratorFamily)
+        if normalized_reference is not None:
+            raise SchemaValidationError("reference_generator is only supported for GeneratorFamily candidates.")
+        candidate_summary, checks = _validate_formula_candidate(
             field,
             normalized_candidate,
             residual_evaluator=residual_evaluator,
@@ -417,6 +521,7 @@ def validate_symmetry_candidate(
                 "span_principal_angle": _SPAN_TOLERANCE,
                 "span_projection_residual": _SPAN_TOLERANCE,
                 "closure": _CLOSURE_TOLERANCE,
+                "formula_reciprocal_denominator_floor": _FORMULA_RECIPROCAL_DENOMINATOR_FLOOR,
             },
             "candidate_summary": candidate_summary,
             "configured_validation_checks": list(checks.keys()),

--- a/src/pdelie/symmetry/formula.py
+++ b/src/pdelie/symmetry/formula.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch, InvariantMapSpec
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+_VARIABLES = ("t", "x", "u")
+_COMPONENT_NAMES = ("tau", "xi", "phi")
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_RECIPROCAL_DENOMINATOR_FLOOR = 1e-12
+_MAX_INTEGER_POWER = 8
+_EVALUABLE_NODES = frozenset({"const", "var", "add", "mul", "pow", "sin", "cos", "reciprocal"})
+_SYMBOLIC_NODE = "symbolic_reference"
+_SUPPORTED_NODES = _EVALUABLE_NODES.union({_SYMBOLIC_NODE})
+
+
+class _FormulaEvaluationFailure(Exception):
+    pass
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _validate_json_compatible(value: Any, *, name: str) -> Any:
+    normalized = _json_safe(value)
+    try:
+        json.dumps(normalized, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be JSON-compatible.") from exc
+    return normalized
+
+
+def _mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _reject_extra_keys(value: Mapping[str, Any], allowed: set[str], *, name: str) -> None:
+    extra = sorted(set(value).difference(allowed))
+    if extra:
+        raise SchemaValidationError(f"{name} has unsupported fields {extra}.")
+
+
+def _nonempty_string(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise SchemaValidationError(f"{name} must be a non-empty string.")
+    return value
+
+
+def _sequence(value: Any, *, name: str) -> Sequence[Any]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise SchemaValidationError(f"{name} must be a sequence.")
+    return value
+
+
+def _finite_float(value: Any, *, name: str) -> float:
+    if isinstance(value, bool):
+        raise SchemaValidationError(f"{name} must be a finite float.")
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite float.") from exc
+    if not np.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be a finite float.")
+    return normalized
+
+
+def _integer_power(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise SchemaValidationError(f"{name} must be an integer.")
+    normalized = int(value)
+    if normalized < 0 or normalized > _MAX_INTEGER_POWER:
+        raise SchemaValidationError(f"{name} must be between 0 and {_MAX_INTEGER_POWER}.")
+    return normalized
+
+
+def _normalize_expression(value: Any, *, name: str) -> dict[str, Any]:
+    expression = dict(_mapping(value, name=name))
+    node = _nonempty_string(expression.get("node"), name=f"{name}.node")
+    if node not in _SUPPORTED_NODES:
+        raise SchemaValidationError(f"{name}.node is unsupported: {node!r}.")
+
+    if node == "const":
+        _reject_extra_keys(expression, {"node", "value"}, name=name)
+        return {"node": node, "value": _finite_float(expression.get("value"), name=f"{name}.value")}
+    if node == "var":
+        _reject_extra_keys(expression, {"node", "name"}, name=name)
+        variable = _nonempty_string(expression.get("name"), name=f"{name}.name")
+        if variable not in _VARIABLES:
+            raise SchemaValidationError(f"{name}.name must be one of {_VARIABLES}.")
+        return {"node": node, "name": variable}
+    if node == "add":
+        _reject_extra_keys(expression, {"node", "terms"}, name=name)
+        terms = _sequence(expression.get("terms"), name=f"{name}.terms")
+        if len(terms) == 0:
+            raise SchemaValidationError(f"{name}.terms must be non-empty.")
+        return {
+            "node": node,
+            "terms": [
+                _normalize_expression(term, name=f"{name}.terms[{index}]")
+                for index, term in enumerate(terms)
+            ],
+        }
+    if node == "mul":
+        _reject_extra_keys(expression, {"node", "factors"}, name=name)
+        factors = _sequence(expression.get("factors"), name=f"{name}.factors")
+        if len(factors) == 0:
+            raise SchemaValidationError(f"{name}.factors must be non-empty.")
+        return {
+            "node": node,
+            "factors": [
+                _normalize_expression(factor, name=f"{name}.factors[{index}]")
+                for index, factor in enumerate(factors)
+            ],
+        }
+    if node == "pow":
+        _reject_extra_keys(expression, {"node", "base", "exponent"}, name=name)
+        return {
+            "node": node,
+            "base": _normalize_expression(expression.get("base"), name=f"{name}.base"),
+            "exponent": _integer_power(expression.get("exponent"), name=f"{name}.exponent"),
+        }
+    if node in {"sin", "cos", "reciprocal"}:
+        _reject_extra_keys(expression, {"node", "arg"}, name=name)
+        return {"node": node, "arg": _normalize_expression(expression.get("arg"), name=f"{name}.arg")}
+
+    _reject_extra_keys(expression, {"node", "label", "metadata"}, name=name)
+    label = _nonempty_string(expression.get("label"), name=f"{name}.label")
+    metadata = expression.get("metadata", {})
+    metadata_mapping = dict(_mapping(metadata, name=f"{name}.metadata"))
+    return {
+        "node": _SYMBOLIC_NODE,
+        "label": label,
+        "metadata": _validate_json_compatible(metadata_mapping, name=f"{name}.metadata"),
+    }
+
+
+def _expression_contains_symbolic_reference(expression: Mapping[str, Any]) -> bool:
+    node = expression["node"]
+    if node == _SYMBOLIC_NODE:
+        return True
+    if node == "add":
+        return any(_expression_contains_symbolic_reference(term) for term in expression["terms"])
+    if node == "mul":
+        return any(_expression_contains_symbolic_reference(factor) for factor in expression["factors"])
+    if node == "pow":
+        return _expression_contains_symbolic_reference(expression["base"])
+    if node in {"sin", "cos", "reciprocal"}:
+        return _expression_contains_symbolic_reference(expression["arg"])
+    return False
+
+
+def _symbolic_references(expression: Mapping[str, Any]) -> list[dict[str, Any]]:
+    node = expression["node"]
+    if node == _SYMBOLIC_NODE:
+        return [{"label": expression["label"], "metadata": expression["metadata"]}]
+    if node == "add":
+        return [item for term in expression["terms"] for item in _symbolic_references(term)]
+    if node == "mul":
+        return [item for factor in expression["factors"] for item in _symbolic_references(factor)]
+    if node == "pow":
+        return _symbolic_references(expression["base"])
+    if node in {"sin", "cos", "reciprocal"}:
+        return _symbolic_references(expression["arg"])
+    return []
+
+
+def _eval_expression(expression: Mapping[str, Any], variables: Mapping[str, np.ndarray]) -> np.ndarray:
+    node = expression["node"]
+    if node == "const":
+        return np.asarray(expression["value"], dtype=float)
+    if node == "var":
+        return np.asarray(variables[expression["name"]], dtype=float)
+    if node == "add":
+        result = np.asarray(0.0, dtype=float)
+        for term in expression["terms"]:
+            result = result + _eval_expression(term, variables)
+        return result
+    if node == "mul":
+        result = np.asarray(1.0, dtype=float)
+        for factor in expression["factors"]:
+            result = result * _eval_expression(factor, variables)
+        return result
+    if node == "pow":
+        return np.power(_eval_expression(expression["base"], variables), int(expression["exponent"]))
+    if node == "sin":
+        return np.sin(_eval_expression(expression["arg"], variables))
+    if node == "cos":
+        return np.cos(_eval_expression(expression["arg"], variables))
+    if node == "reciprocal":
+        denominator = _eval_expression(expression["arg"], variables)
+        if np.any(np.abs(denominator) <= _RECIPROCAL_DENOMINATOR_FLOOR):
+            raise _FormulaEvaluationFailure("reciprocal_denominator_floor_violation")
+        return 1.0 / denominator
+    raise _FormulaEvaluationFailure("symbolic_reference_not_evaluable")
+
+
+def _field_variables(field: FieldBatch) -> dict[str, np.ndarray]:
+    if not isinstance(field, FieldBatch):
+        raise SchemaValidationError("field must be a FieldBatch.")
+    field.validate()
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError("FormulaGeneratorFamily diagnostics require dims ('batch', 'time', 'x', 'var').")
+    if len(field.var_names) != 1 or field.values.shape[-1] != 1:
+        raise ScopeValidationError("FormulaGeneratorFamily diagnostics require a scalar field.")
+    if field.metadata["boundary_conditions"].get("x") != "periodic":
+        raise ScopeValidationError("FormulaGeneratorFamily diagnostics require periodic x boundary conditions.")
+    if not np.all(np.isfinite(field.values)):
+        raise ScopeValidationError("FormulaGeneratorFamily diagnostics require finite field values.")
+
+    shape = field.values.shape
+    time = np.asarray(field.coords["time"], dtype=float).reshape(1, shape[1], 1, 1)
+    x = np.asarray(field.coords["x"], dtype=float).reshape(1, 1, shape[2], 1)
+    return {
+        "t": np.broadcast_to(time, shape),
+        "x": np.broadcast_to(x, shape),
+        "u": np.asarray(field.values, dtype=float),
+    }
+
+
+def _normalize_generator_record(value: Any, *, index: int) -> dict[str, Any]:
+    record = dict(_mapping(value, name=f"formula_generators[{index}]"))
+    _reject_extra_keys(record, {"name", "components", "metadata"}, name=f"formula_generators[{index}]")
+    name = _nonempty_string(record.get("name"), name=f"formula_generators[{index}].name")
+    components = dict(_mapping(record.get("components"), name=f"formula_generators[{index}].components"))
+    missing = [component for component in _COMPONENT_NAMES if component not in components]
+    extra = sorted(set(components).difference(_COMPONENT_NAMES))
+    if missing:
+        raise SchemaValidationError(f"formula_generators[{index}].components is missing {missing}.")
+    if extra:
+        raise SchemaValidationError(f"formula_generators[{index}].components has unsupported components {extra}.")
+    metadata = record.get("metadata", {})
+    metadata_mapping = dict(_mapping(metadata, name=f"formula_generators[{index}].metadata"))
+    return {
+        "name": name,
+        "components": {
+            component: _normalize_expression(
+                components[component],
+                name=f"formula_generators[{index}].components.{component}",
+            )
+            for component in _COMPONENT_NAMES
+        },
+        "metadata": _validate_json_compatible(metadata_mapping, name=f"formula_generators[{index}].metadata"),
+    }
+
+
+@dataclass(slots=True)
+class FormulaGeneratorFamily:
+    """Runtime-only formula-backed scalar 1D Lie-point generator record."""
+
+    schema_version: str = "0.1"
+    parameterization: str = "formula_generator_family"
+    formula_generators: list[dict[str, Any]] = None  # type: ignore[assignment]
+    variables: tuple[str, ...] = _VARIABLES
+    component_names: tuple[str, ...] = _COMPONENT_NAMES
+    finite_transform_spec: dict[str, Any] | None = None
+    diagnostics: dict[str, Any] = None  # type: ignore[assignment]
+
+    SCHEMA_VERSION: ClassVar[str] = "0.1"
+    PARAMETERIZATION: ClassVar[str] = "formula_generator_family"
+    RECIPROCAL_DENOMINATOR_FLOOR: ClassVar[float] = _RECIPROCAL_DENOMINATOR_FLOOR
+
+    def __post_init__(self) -> None:
+        self.schema_version = str(self.schema_version)
+        self.parameterization = str(self.parameterization)
+        self.variables = tuple(str(variable) for variable in self.variables)
+        self.component_names = tuple(str(component) for component in self.component_names)
+        if self.formula_generators is None:
+            raise SchemaValidationError("formula_generators must be provided.")
+        raw_generators = _sequence(self.formula_generators, name="formula_generators")
+        if len(raw_generators) == 0:
+            raise SchemaValidationError("formula_generators must be non-empty.")
+        self.formula_generators = [
+            _normalize_generator_record(record, index=index)
+            for index, record in enumerate(raw_generators)
+        ]
+        if self.finite_transform_spec is not None:
+            spec_mapping = dict(_mapping(self.finite_transform_spec, name="finite_transform_spec"))
+            try:
+                self.finite_transform_spec = InvariantMapSpec.from_dict(spec_mapping).to_dict()
+            except KeyError as exc:
+                raise SchemaValidationError("finite_transform_spec is malformed.") from exc
+        if self.diagnostics is None:
+            self.diagnostics = {}
+        else:
+            self.diagnostics = _validate_json_compatible(
+                dict(_mapping(self.diagnostics, name="diagnostics")),
+                name="diagnostics",
+            )
+        self.validate()
+
+    def validate(self) -> None:
+        if self.schema_version != self.SCHEMA_VERSION:
+            raise SchemaValidationError("Unsupported FormulaGeneratorFamily schema_version.")
+        if self.parameterization != self.PARAMETERIZATION:
+            raise SchemaValidationError("FormulaGeneratorFamily parameterization must be 'formula_generator_family'.")
+        if self.variables != _VARIABLES:
+            raise SchemaValidationError(f"FormulaGeneratorFamily variables must be exactly {_VARIABLES}.")
+        if self.component_names != _COMPONENT_NAMES:
+            raise SchemaValidationError(f"FormulaGeneratorFamily component_names must be exactly {_COMPONENT_NAMES}.")
+        _validate_json_compatible(self.to_dict(), name="FormulaGeneratorFamily payload")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "parameterization": self.parameterization,
+            "variables": list(self.variables),
+            "component_names": list(self.component_names),
+            "formula_generators": _json_safe(self.formula_generators),
+            "diagnostics": _json_safe(self.diagnostics),
+        }
+        if self.finite_transform_spec is not None:
+            payload["finite_transform_spec"] = _json_safe(self.finite_transform_spec)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "FormulaGeneratorFamily":
+        _reject_extra_keys(
+            payload,
+            {
+                "schema_version",
+                "parameterization",
+                "variables",
+                "component_names",
+                "formula_generators",
+                "finite_transform_spec",
+                "diagnostics",
+            },
+            name="FormulaGeneratorFamily payload",
+        )
+        try:
+            return cls(
+                schema_version=str(payload["schema_version"]),
+                parameterization=str(payload["parameterization"]),
+                variables=tuple(payload["variables"]),
+                component_names=tuple(payload["component_names"]),
+                formula_generators=list(payload["formula_generators"]),
+                finite_transform_spec=payload.get("finite_transform_spec"),
+                diagnostics=dict(payload.get("diagnostics", {})),
+            )
+        except KeyError as exc:
+            raise SchemaValidationError("FormulaGeneratorFamily payload is malformed.") from exc
+
+
+def _diagnose_formula_generator_family_on_field(
+    formula: FormulaGeneratorFamily,
+    field: FieldBatch,
+) -> dict[str, Any]:
+    if not isinstance(formula, FormulaGeneratorFamily):
+        raise SchemaValidationError("formula must be a FormulaGeneratorFamily.")
+    formula.validate()
+    variables = _field_variables(field)
+    component_reports: list[dict[str, Any]] = []
+
+    for generator_index, generator in enumerate(formula.formula_generators):
+        for component in formula.component_names:
+            expression = generator["components"][component]
+            report: dict[str, Any] = {
+                "generator_index": generator_index,
+                "generator_name": generator["name"],
+                "component": component,
+                "expression_node": expression["node"],
+            }
+            if _expression_contains_symbolic_reference(expression):
+                report.update(
+                    {
+                        "status": "unavailable",
+                        "reason": "symbolic_reference_metadata_only",
+                        "symbolic_references": _symbolic_references(expression),
+                    }
+                )
+            else:
+                try:
+                    values = np.asarray(_eval_expression(expression, variables), dtype=float)
+                    values = np.broadcast_to(values, field.values.shape)
+                    if not np.all(np.isfinite(values)):
+                        raise _FormulaEvaluationFailure("nonfinite_formula_values")
+                except _FormulaEvaluationFailure as exc:
+                    report.update({"status": "failed", "reason": str(exc)})
+                else:
+                    report.update(
+                        {
+                            "status": "passed",
+                            "value_shape": list(values.shape),
+                            "max_abs_value": float(np.max(np.abs(values))),
+                            "rms_value": float(np.sqrt(np.mean(np.square(values)))),
+                        }
+                    )
+            component_reports.append(report)
+
+    statuses = [report["status"] for report in component_reports]
+    return _validate_json_compatible(
+        {
+            "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+            "summary_type": "formula_evaluation_diagnostics",
+            "field_shape": list(field.values.shape),
+            "variables": list(formula.variables),
+            "component_names": list(formula.component_names),
+            "generator_count": len(formula.formula_generators),
+            "reciprocal_denominator_floor": _RECIPROCAL_DENOMINATOR_FLOOR,
+            "component_reports": component_reports,
+            "evaluated_component_count": statuses.count("passed"),
+            "failed_component_count": statuses.count("failed"),
+            "unavailable_component_count": statuses.count("unavailable"),
+        },
+        name="FormulaGeneratorFamily evaluation diagnostics",
+    )
+
+
+__all__ = ["FormulaGeneratorFamily"]

--- a/src/pdelie/symmetry/formula.py
+++ b/src/pdelie/symmetry/formula.py
@@ -332,8 +332,9 @@ class FormulaGeneratorFamily:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "FormulaGeneratorFamily":
+        payload_mapping = dict(_mapping(payload, name="FormulaGeneratorFamily payload"))
         _reject_extra_keys(
-            payload,
+            payload_mapping,
             {
                 "schema_version",
                 "parameterization",
@@ -346,14 +347,31 @@ class FormulaGeneratorFamily:
             name="FormulaGeneratorFamily payload",
         )
         try:
+            schema_version = payload_mapping["schema_version"]
+            parameterization = payload_mapping["parameterization"]
+            variables = _sequence(payload_mapping["variables"], name="FormulaGeneratorFamily payload.variables")
+            component_names = _sequence(
+                payload_mapping["component_names"],
+                name="FormulaGeneratorFamily payload.component_names",
+            )
+            formula_generators = _sequence(
+                payload_mapping["formula_generators"],
+                name="FormulaGeneratorFamily payload.formula_generators",
+            )
+            diagnostics = dict(
+                _mapping(
+                    payload_mapping.get("diagnostics", {}),
+                    name="FormulaGeneratorFamily payload.diagnostics",
+                )
+            )
             return cls(
-                schema_version=str(payload["schema_version"]),
-                parameterization=str(payload["parameterization"]),
-                variables=tuple(payload["variables"]),
-                component_names=tuple(payload["component_names"]),
-                formula_generators=list(payload["formula_generators"]),
-                finite_transform_spec=payload.get("finite_transform_spec"),
-                diagnostics=dict(payload.get("diagnostics", {})),
+                schema_version=str(schema_version),
+                parameterization=str(parameterization),
+                variables=tuple(variables),
+                component_names=tuple(component_names),
+                formula_generators=list(formula_generators),
+                finite_transform_spec=payload_mapping.get("finite_transform_spec"),
+                diagnostics=diagnostics,
             )
         except KeyError as exc:
             raise SchemaValidationError("FormulaGeneratorFamily payload is malformed.") from exc

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -24,6 +24,7 @@ _ROOT_RUNTIME_NAMES = {
     "export_generator_family_manifest",
     "fit_pysindy_discovery",
     "fit_translation_generator",
+    "FormulaGeneratorFamily",
     "from_numpy",
     "from_xarray",
     "generate_burgers_1d_field_batch",
@@ -37,6 +38,7 @@ _ROOT_RUNTIME_NAMES = {
     "plot_verification_curve",
     "render_generator_family",
     "run_heat_vertical_slice_example",
+    "run_formula_generator_validation_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
     "run_invariant_workflow_summary_example",
@@ -46,6 +48,7 @@ _ROOT_RUNTIME_NAMES = {
     "subsample_time",
     "subsample_x",
     "summarize_generator_fit_diagnostics",
+    "summarize_formula_generator_family",
     "summarize_generator_family",
     "summarize_invariant_workflow",
     "summarize_recovery_grid",
@@ -60,7 +63,6 @@ _ROOT_RUNTIME_NAMES = {
 }
 _DEFERRED_OR_PRIVATE_NAMES = {
     "CallableGeneratorFamily",
-    "FormulaGeneratorFamily",
     "OperatorSymmetry",
     "KSResidualEvaluator",
     "KuramotoSivashinskyResidualEvaluator",
@@ -106,7 +108,6 @@ _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.residuals.evaluate_weak_ks_residual",
     "pdelie.symmetry.OperatorSymmetry",
     "pdelie.symmetry.CallableGeneratorFamily",
-    "pdelie.symmetry.FormulaGeneratorFamily",
     "pdelie.symmetry.validate_generator_candidate",
 }
 _V0_10_REPORTING_APIS = {
@@ -146,6 +147,11 @@ _V0_15_ORBIT_BATCH_APIS = {
 _V0_16_SYMMETRY_VALIDATION_APIS = {
     "pdelie.symmetry.validate_symmetry_candidate",
 }
+_V0_17_FORMULA_GENERATOR_APIS = {
+    "pdelie.symmetry.FormulaGeneratorFamily",
+    "pdelie.reporting.summarize_formula_generator_family",
+    "candidate_kind = \"formula_generator_family\"",
+}
 
 
 def _api_stability_text() -> str:
@@ -169,6 +175,7 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_14_INVARIANT_WORKFLOW_APIS
         | _V0_15_ORBIT_BATCH_APIS
         | _V0_16_SYMMETRY_VALIDATION_APIS
+        | _V0_17_FORMULA_GENERATOR_APIS
     ):
         assert api_name in text
 
@@ -197,7 +204,6 @@ def test_api_stability_doc_does_not_promote_deferred_v0_13_surfaces() -> None:
     assert "diagnose_time_translation_consistency" not in text
     assert "validate_generator_candidate" not in text
     assert "CallableGeneratorFamily" not in text
-    assert "FormulaGeneratorFamily" not in text
 
 
 def test_root_package_still_exposes_only_stable_canonical_surface() -> None:
@@ -227,6 +233,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "to_pysindy_trajectories",
         },
         "pdelie.examples": {
+            "run_formula_generator_validation_example",
             "run_heat_vertical_slice_example",
             "run_invariant_workflow_summary_example",
             "run_kdv_vertical_slice_example",
@@ -248,6 +255,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "import_generator_family_manifest",
         },
         "pdelie.reporting": {
+            "summarize_formula_generator_family",
             "summarize_generator_fit_diagnostics",
             "summarize_generator_family",
             "summarize_invariant_workflow",
@@ -265,6 +273,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "evaluate_weak_heat_residual",
         },
         "pdelie.symmetry": {
+            "FormulaGeneratorFamily",
             "compare_generator_spans",
             "diagnose_generator_family_closure",
             "fit_translation_generator",
@@ -303,32 +312,35 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
             assert not hasattr(module, name), f"{module.__name__}.{name}"
 
 
-def test_v0_16_planning_docs_record_candidate_validation_and_non_goals() -> None:
+def test_v0_17_planning_docs_record_formula_generators_and_non_goals() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_16_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_17_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
 
     assert "**Status:** COMPLETE" in plan
-    assert "Milestone 2 - GeneratorFamily Candidate Validation" in plan
-    assert "Milestone 3 - InvariantMapSpec Candidate Validation" in plan
-    assert "pdelie.symmetry.validate_symmetry_candidate" in plan
+    assert "Milestone 2 - Formula Record and Reporting Implementation" in plan
+    assert "Milestone 3 - Formula Candidate Validation" in plan
+    assert "pdelie.symmetry.FormulaGeneratorFamily" in plan
+    assert "pdelie.reporting.summarize_formula_generator_family" in plan
+    assert "candidate_kind = \"formula_generator_family\"" in plan
     assert "not a mathematical proof" in plan
-    assert "callable descriptor API" in plan
+    assert "callable generator API" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
     assert "## Milestone 6 - Release Gate and Readiness" in plan
-    assert "updated CI so the current explicit release gate is `v0_16-release-gate`" in plan
+    assert "updated CI so the current explicit release gate is `v0_17-release-gate`" in plan
     assert "- Milestone 6: COMPLETE" in plan
 
-    assert "external symmetry-candidate validation" in scope
+    assert "formula-backed generator interoperability" in scope
+    assert "pdelie.symmetry.FormulaGeneratorFamily" in scope
+    assert "pdelie.reporting.summarize_formula_generator_family" in scope
     assert "pdelie.symmetry.validate_symmetry_candidate" in scope
-    assert "candidate_kind = \"generator_family\"" in scope
-    assert "candidate_kind = \"invariant_map_spec\"" in scope
-    assert "callable transform descriptors" in scope
-    assert "neural symmetry-detector training" in scope
+    assert "candidate_kind = \"formula_generator_family\"" in scope
+    assert "callable generator APIs" in scope
+    assert "neural generator training" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
     assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.16` is the completed external symmetry-candidate validation release" in roadmap
+    assert "`v0.17` is the completed formula-backed generator interoperability release" in roadmap
     assert "`validated` means configured empirical validation" in roadmap
     assert "- no new PDE" in roadmap

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import pdelie
 from pdelie.examples import (
+    run_formula_generator_validation_example,
     run_heat_vertical_slice_example,
     run_invariant_workflow_summary_example,
     run_kdv_vertical_slice_example,
@@ -263,4 +264,38 @@ def test_symmetry_candidate_validation_module_prints_json_only() -> None:
 
     assert parsed["summary_type"] == "symmetry_candidate_validation_example"
     assert len(parsed["cases"]) == 4
+    assert "failed" in parsed["extra_metrics"]["conclusions"]
+
+
+def test_formula_generator_validation_example_runs_end_to_end() -> None:
+    result = run_formula_generator_validation_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "formula_generator_validation_example"
+    assert result["extra_metrics"]["example_name"] == "formula_generator_validation"
+    assert result["extra_metrics"]["candidate_kinds"] == ["formula_generator_family"]
+    assert result["extra_metrics"]["expression_policy"] == "safe_json_ast_no_callables_no_executable_strings"
+    assert len(result["cases"]) == 5
+    cases = {case["case_name"]: case for case in result["cases"]}
+    assert set(cases) == {
+        "affine_formula",
+        "failed_nonfinite_formula",
+        "formula_with_uniform_translation_transform",
+        "rational_formula",
+        "trigonometric_formula",
+    }
+    assert cases["formula_with_uniform_translation_transform"]["report"]["conclusion"] == "validated"
+    assert cases["failed_nonfinite_formula"]["report"]["conclusion"] == "failed"
+    for name in ("affine_formula", "rational_formula", "trigonometric_formula"):
+        assert cases[name]["report"]["candidate_kind"] == "formula_generator_family"
+        assert cases[name]["report"]["conclusion"] == "partially_validated"
+    assert not hasattr(pdelie, "run_formula_generator_validation_example")
+
+
+def test_formula_generator_validation_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.formula_generator_validation")
+
+    assert parsed["summary_type"] == "formula_generator_validation_example"
+    assert len(parsed["cases"]) == 5
     assert "failed" in parsed["extra_metrics"]["conclusions"]

--- a/tests/test_formula_generator_family.py
+++ b/tests/test_formula_generator_family.py
@@ -75,6 +75,26 @@ def test_formula_generator_family_round_trips_json_payload() -> None:
     assert restored.component_names == ("tau", "xi", "phi")
 
 
+@pytest.mark.parametrize(
+    ("field_name", "match"),
+    [
+        ("variables", "payload.variables"),
+        ("component_names", "payload.component_names"),
+        ("formula_generators", "payload.formula_generators"),
+        ("diagnostics", "payload.diagnostics"),
+    ],
+)
+def test_formula_generator_family_from_dict_rejects_malformed_container_fields(
+    field_name: str,
+    match: str,
+) -> None:
+    payload = _formula_generator().to_dict()
+    payload[field_name] = None
+
+    with pytest.raises(SchemaValidationError, match=match):
+        FormulaGeneratorFamily.from_dict(payload)
+
+
 def test_summarize_formula_generator_family_returns_json_summary_without_mutation() -> None:
     formula = FormulaGeneratorFamily(
         formula_generators=[

--- a/tests/test_formula_generator_family.py
+++ b/tests/test_formula_generator_family.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import numpy as np
+import pytest
+
+import pdelie
+from pdelie.errors import SchemaValidationError
+from pdelie.reporting import summarize_formula_generator_family
+from pdelie.symmetry import FormulaGeneratorFamily
+
+
+def _zero() -> dict[str, object]:
+    return {"node": "const", "value": 0.0}
+
+
+def _one() -> dict[str, object]:
+    return {"node": "const", "value": 1.0}
+
+
+def _u() -> dict[str, object]:
+    return {"node": "var", "name": "u"}
+
+
+def _formula_generator(
+    *,
+    xi: dict[str, object] | object | None = None,
+    tau: dict[str, object] | object | None = None,
+    phi: dict[str, object] | object | None = None,
+    name: str = "g",
+) -> FormulaGeneratorFamily:
+    return FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": name,
+                "components": {
+                    "tau": _zero() if tau is None else tau,
+                    "xi": _one() if xi is None else xi,
+                    "phi": _zero() if phi is None else phi,
+                },
+            }
+        ]
+    )
+
+
+def test_formula_generator_family_round_trips_json_payload() -> None:
+    formula = FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "affine_translation",
+                "components": {"tau": _zero(), "xi": _one(), "phi": _u()},
+                "metadata": {"source": "unit-test"},
+            },
+            {
+                "name": "trigonometric_fixture",
+                "components": {
+                    "tau": _zero(),
+                    "xi": {"node": "sin", "arg": {"node": "var", "name": "x"}},
+                    "phi": {"node": "cos", "arg": {"node": "var", "name": "u"}},
+                },
+            },
+        ],
+        diagnostics={"note": "runtime-only"},
+    )
+
+    payload = formula.to_dict()
+    restored = FormulaGeneratorFamily.from_dict(json.loads(json.dumps(payload)))
+
+    assert restored.to_dict() == payload
+    assert restored.schema_version == "0.1"
+    assert restored.parameterization == "formula_generator_family"
+    assert restored.variables == ("t", "x", "u")
+    assert restored.component_names == ("tau", "xi", "phi")
+
+
+def test_summarize_formula_generator_family_returns_json_summary_without_mutation() -> None:
+    formula = FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "rational_fixture",
+                "components": {
+                    "tau": _zero(),
+                    "xi": {
+                        "node": "reciprocal",
+                        "arg": {
+                            "node": "add",
+                            "terms": [
+                                _one(),
+                                {"node": "pow", "base": {"node": "var", "name": "u"}, "exponent": 2},
+                            ],
+                        },
+                    },
+                    "phi": {
+                        "node": "symbolic_reference",
+                        "label": "external_phi",
+                        "metadata": {"origin": "symbolic-system"},
+                    },
+                },
+            }
+        ]
+    )
+    before = copy.deepcopy(formula.to_dict())
+
+    summary = summarize_formula_generator_family(formula)
+
+    assert json.loads(json.dumps(summary)) == summary
+    assert formula.to_dict() == before
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "formula_generator_family"
+    assert summary["parameterization"] == "formula_generator_family"
+    assert summary["generator_count"] == 1
+    assert summary["generator_names"] == ["rational_fixture"]
+    assert summary["finite_transform_available"] is False
+    assert summary["formula_kinds"]["reciprocal"] == 1
+    assert summary["formula_kinds"]["pow"] == 1
+    assert summary["formula_kinds"]["symbolic_reference"] == 1
+    assert summary["symbolic_references"] == [
+        {
+            "generator_name": "rational_fixture",
+            "component": "phi",
+            "label": "external_phi",
+            "metadata": {"origin": "symbolic-system"},
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("components", "match"),
+    [
+        ({"tau": _zero(), "xi": _one()}, "missing"),
+        ({"tau": _zero(), "xi": _one(), "phi": _zero(), "eta": _zero()}, "unsupported components"),
+        ({"tau": {"node": "var", "name": "y"}, "xi": _one(), "phi": _zero()}, "one of"),
+        ({"tau": {"node": "const", "value": np.inf}, "xi": _one(), "phi": _zero()}, "finite float"),
+        ({"tau": {"node": "raw_string", "value": "x"}, "xi": _one(), "phi": _zero()}, "unsupported"),
+        ({"tau": "x", "xi": _one(), "phi": _zero()}, "mapping"),
+        ({"tau": {"node": "const", "value": 0.0}, "xi": lambda value: value, "phi": _zero()}, "mapping"),
+        (
+            {"tau": {"node": "pow", "base": _u(), "exponent": -1}, "xi": _one(), "phi": _zero()},
+            "between",
+        ),
+    ],
+)
+def test_formula_generator_family_rejects_invalid_formula_records(
+    components: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(SchemaValidationError, match=match):
+        FormulaGeneratorFamily(formula_generators=[{"name": "bad", "components": components}])
+
+
+def test_formula_generator_family_is_submodule_only_runtime_api() -> None:
+    assert FormulaGeneratorFamily is not None
+    assert not hasattr(pdelie, "FormulaGeneratorFamily")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -60,6 +60,7 @@ def test_runtime_package_api_is_importable() -> None:
     )
     from pdelie.residuals import KdVResidualEvaluator, evaluate_weak_burgers_residual, evaluate_weak_heat_residual
     from pdelie.reporting import (
+        summarize_formula_generator_family,
         summarize_generator_fit_diagnostics,
         summarize_generator_family,
         summarize_invariant_workflow,
@@ -69,6 +70,7 @@ def test_runtime_package_api_is_importable() -> None:
         summarize_weak_residual_report,
     )
     from pdelie.symmetry import (
+        FormulaGeneratorFamily,
         compare_generator_spans,
         diagnose_generator_family_closure,
         render_generator_family,
@@ -100,6 +102,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert evaluate_weak_burgers_residual is not None
     assert evaluate_weak_heat_residual is not None
     assert summarize_generator_fit_diagnostics is not None
+    assert summarize_formula_generator_family is not None
     assert summarize_generator_family is not None
     assert summarize_invariant_workflow is not None
     assert summarize_residual_batch is not None
@@ -115,6 +118,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert export_generator_family_manifest is not None
     assert import_generator_family_manifest is not None
     assert compare_generator_spans is not None
+    assert FormulaGeneratorFamily is not None
     assert diagnose_generator_family_closure is not None
     assert render_generator_family is not None
     assert to_sympy_component_expressions is not None
@@ -150,11 +154,13 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "from_numpy")
     assert not hasattr(pdelie, "from_the_well")
     assert not hasattr(pdelie, "from_xarray")
+    assert not hasattr(pdelie, "FormulaGeneratorFamily")
     assert not hasattr(pdelie, "split_batch_train_heldout")
     assert not hasattr(pdelie, "subsample_time")
     assert not hasattr(pdelie, "subsample_x")
     assert not hasattr(pdelie, "summarize_recovery_grid")
     assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
+    assert not hasattr(pdelie, "summarize_formula_generator_family")
     assert not hasattr(pdelie, "summarize_generator_family")
     assert not hasattr(pdelie, "summarize_invariant_workflow")
     assert not hasattr(pdelie, "summarize_orbit_coverage")
@@ -179,6 +185,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "WeakKSResidualEvaluator")
     assert not hasattr(pdelie, "OperatorSymmetry")
     assert not hasattr(pdelie, "run_invariant_workflow_summary_example")
+    assert not hasattr(pdelie, "run_formula_generator_validation_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(pdelie, "run_symmetry_candidate_validation_example")
@@ -263,6 +270,7 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
 def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
     reporting_module = importlib.import_module("pdelie.reporting")
 
+    assert hasattr(reporting_module, "summarize_formula_generator_family")
     assert hasattr(reporting_module, "summarize_generator_fit_diagnostics")
     assert hasattr(reporting_module, "summarize_generator_family")
     assert hasattr(reporting_module, "summarize_invariant_workflow")
@@ -278,6 +286,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     examples_module = importlib.import_module("pdelie.examples")
 
     assert hasattr(examples_module, "run_heat_vertical_slice_example")
+    assert hasattr(examples_module, "run_formula_generator_validation_example")
     assert hasattr(examples_module, "run_invariant_workflow_summary_example")
     assert hasattr(examples_module, "run_kdv_vertical_slice_example")
     assert hasattr(examples_module, "run_orbit_coverage_diagnostics_example")
@@ -310,6 +319,7 @@ def test_portability_package_runtime_api_matches_frozen_m2_surface() -> None:
 def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     symmetry_module = importlib.import_module("pdelie.symmetry")
 
+    assert hasattr(symmetry_module, "FormulaGeneratorFamily")
     assert hasattr(symmetry_module, "fit_translation_generator")
     assert hasattr(symmetry_module, "validate_symmetry_candidate")
     assert hasattr(symmetry_module, "diagnose_generator_family_closure")
@@ -317,7 +327,6 @@ def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     assert hasattr(symmetry_module, "render_generator_family")
     assert hasattr(symmetry_module, "to_sympy_component_expressions")
     assert not hasattr(symmetry_module, "CallableGeneratorFamily")
-    assert not hasattr(symmetry_module, "FormulaGeneratorFamily")
     assert not hasattr(symmetry_module, "OperatorSymmetry")
     assert not hasattr(symmetry_module, "build_translation_orbit_views")
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -11,6 +11,7 @@ from pdelie.data import generate_burgers_1d_field_batch, generate_heat_1d_field_
 from pdelie.derivatives import compute_spectral_fd_derivatives
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 from pdelie.reporting import (
+    summarize_formula_generator_family,
     summarize_generator_fit_diagnostics,
     summarize_generator_family,
     summarize_invariant_workflow,
@@ -19,6 +20,7 @@ from pdelie.reporting import (
     summarize_vertical_slice,
     summarize_weak_residual_report,
 )
+from pdelie.symmetry import FormulaGeneratorFamily
 from pdelie.residuals import (
     BurgersResidualEvaluator,
     HeatResidualEvaluator,
@@ -54,6 +56,21 @@ _FIT_DIAGNOSTIC_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
     "reference_fallback_used",
     "fallback_reason",
     "evidence_label",
+}
+_FORMULA_GENERATOR_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
+    "parameterization",
+    "schema_version",
+    "variables",
+    "component_names",
+    "generator_count",
+    "generator_names",
+    "formula_kinds",
+    "component_nodes",
+    "finite_transform_available",
+    "finite_transform_construction_method",
+    "symbolic_references",
+    "reciprocal_denominator_floor",
+    "diagnostics",
 }
 
 
@@ -158,6 +175,44 @@ def test_summarize_generator_family_reports_translation_fit_fields(heat_artifact
     assert summary["fit_mode"] == generator.diagnostics["fit_mode"]
     assert summary["reference_fallback_used"] == generator.diagnostics["reference_fallback_used"]
     assert summary["fallback_reason"] == generator.diagnostics["fallback_reason"]
+    _assert_json_serializable(summary)
+
+
+def test_summarize_formula_generator_family_reports_safe_formula_metadata() -> None:
+    formula = FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "formula_fixture",
+                "components": {
+                    "tau": {"node": "const", "value": 0.0},
+                    "xi": {
+                        "node": "sin",
+                        "arg": {"node": "var", "name": "x"},
+                    },
+                    "phi": {
+                        "node": "symbolic_reference",
+                        "label": "external_phi",
+                        "metadata": {"source": "unit-test"},
+                    },
+                },
+            }
+        ],
+        diagnostics={"status": "fixture"},
+    )
+
+    summary = summarize_formula_generator_family(formula)
+
+    assert set(summary) == _FORMULA_GENERATOR_SUMMARY_KEYS
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "formula_generator_family"
+    assert summary["parameterization"] == "formula_generator_family"
+    assert summary["generator_count"] == 1
+    assert summary["generator_names"] == ["formula_fixture"]
+    assert summary["formula_kinds"]["sin"] == 1
+    assert summary["formula_kinds"]["symbolic_reference"] == 1
+    assert summary["finite_transform_available"] is False
+    assert summary["symbolic_references"][0]["label"] == "external_phi"
+    assert summary["diagnostics"] == {"status": "fixture"}
     _assert_json_serializable(summary)
 
 

--- a/tests/test_symmetry_candidate_validation.py
+++ b/tests/test_symmetry_candidate_validation.py
@@ -389,6 +389,18 @@ def test_validate_symmetry_candidate_rejects_malformed_payloads_with_typed_error
         )
 
 
+@pytest.mark.parametrize("field_name", ["variables", "component_names", "formula_generators", "diagnostics"])
+def test_validate_symmetry_candidate_rejects_malformed_formula_payload_container_fields(
+    field_name: str,
+) -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1612)
+    payload = _formula_translation().to_dict()
+    payload[field_name] = None
+
+    with pytest.raises(SchemaValidationError, match="FormulaGeneratorFamily payload"):
+        validate_symmetry_candidate(field, payload, residual_evaluator=HeatResidualEvaluator())
+
+
 def test_validate_symmetry_candidate_rejects_bad_evaluator_epsilons_reference_and_scope() -> None:
     field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1611)
 

--- a/tests/test_symmetry_candidate_validation.py
+++ b/tests/test_symmetry_candidate_validation.py
@@ -11,7 +11,7 @@ from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.data import generate_heat_1d_field_batch, generate_kdv_1d_field_batch
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 from pdelie.residuals import HeatResidualEvaluator, KdVResidualEvaluator
-from pdelie.symmetry import validate_symmetry_candidate
+from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
 
 
 DOMAIN_LENGTH = 2.0 * np.pi
@@ -46,6 +46,26 @@ def _translation_spec(shift: float = DOMAIN_LENGTH / 8.0) -> InvariantMapSpec:
         domain_validity="global",
         inverse_available=True,
         diagnostics={},
+    )
+
+
+def _zero() -> dict[str, object]:
+    return {"node": "const", "value": 0.0}
+
+
+def _one() -> dict[str, object]:
+    return {"node": "const", "value": 1.0}
+
+
+def _formula_translation(*, finite_transform: bool = False) -> FormulaGeneratorFamily:
+    return FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "formula_translation",
+                "components": {"tau": _zero(), "xi": _one(), "phi": _zero()},
+            }
+        ],
+        finite_transform_spec=_translation_spec().to_dict() if finite_transform else None,
     )
 
 
@@ -212,6 +232,88 @@ def test_validate_symmetry_candidate_accepts_kdv_invariant_map_spec() -> None:
     assert report["check_reports"]["residual_stability"]["status"] == "passed"
 
 
+def test_validate_symmetry_candidate_accepts_formula_generator_family_object_and_payload() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1613)
+    formula = _formula_translation()
+
+    object_report = validate_symmetry_candidate(field, formula, residual_evaluator=HeatResidualEvaluator())
+    payload_report = validate_symmetry_candidate(field, formula.to_dict(), residual_evaluator=HeatResidualEvaluator())
+
+    for report in (object_report, payload_report):
+        assert json.loads(json.dumps(report)) == report
+        assert report["candidate_kind"] == "formula_generator_family"
+        assert report["conclusion"] == "partially_validated"
+        assert report["candidate_summary"]["summary_type"] == "formula_generator_family"
+        assert report["check_reports"]["schema"]["status"] == "passed"
+        assert report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "passed"
+        assert report["check_reports"]["finite_transform_spec_validation"]["status"] == "unavailable"
+        assert report["check_reports"]["formula_evaluation_diagnostics"]["report"]["evaluated_component_count"] == 3
+
+
+def test_validate_symmetry_candidate_validates_formula_finite_transform_spec() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1614)
+    formula = _formula_translation(finite_transform=True)
+
+    report = validate_symmetry_candidate(
+        field,
+        formula,
+        residual_evaluator=HeatResidualEvaluator(),
+        source_candidate_id={"source": "formula-fixture"},
+    )
+
+    assert report["candidate_kind"] == "formula_generator_family"
+    assert report["source_candidate_id"] == {"source": "formula-fixture"}
+    assert report["conclusion"] == "validated"
+    assert report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "passed"
+    assert report["check_reports"]["finite_transform_residual_stability"]["status"] == "passed"
+    assert report["check_reports"]["finite_transform_inverse_consistency"]["status"] == "passed"
+
+
+def test_validate_symmetry_candidate_reports_failed_formula_evaluation_without_exception() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1615)
+    formula = FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "bad_rational",
+                "components": {
+                    "tau": _zero(),
+                    "xi": {"node": "reciprocal", "arg": _zero()},
+                    "phi": _zero(),
+                },
+            }
+        ]
+    )
+
+    report = validate_symmetry_candidate(field, formula, residual_evaluator=HeatResidualEvaluator())
+
+    assert report["candidate_kind"] == "formula_generator_family"
+    assert report["conclusion"] == "failed"
+    assert report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "failed"
+    component_reports = report["check_reports"]["formula_evaluation_diagnostics"]["report"]["component_reports"]
+    assert any(item.get("reason") == "reciprocal_denominator_floor_violation" for item in component_reports)
+
+
+def test_validate_symmetry_candidate_reports_symbolic_formula_as_partial_without_fake_evaluation() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1616)
+    symbolic = {"node": "symbolic_reference", "label": "external_symbol", "metadata": {"kind": "fixture"}}
+    formula = FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "symbolic_only",
+                "components": {"tau": symbolic, "xi": symbolic, "phi": symbolic},
+            }
+        ]
+    )
+
+    report = validate_symmetry_candidate(field, formula, residual_evaluator=HeatResidualEvaluator())
+
+    assert report["candidate_kind"] == "formula_generator_family"
+    assert report["conclusion"] == "partially_validated"
+    assert report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "unavailable"
+    assert report["check_reports"]["formula_evaluation_diagnostics"]["report"]["evaluated_component_count"] == 0
+    assert report["candidate_summary"]["symbolic_references"]
+
+
 @pytest.mark.parametrize(
     ("spec_kwargs", "error_type", "match"),
     [
@@ -248,6 +350,11 @@ def test_validate_symmetry_candidate_rejects_callable_and_ambiguous_payloads() -
     with pytest.raises(SchemaValidationError, match="ambiguous"):
         validate_symmetry_candidate(field, payload, residual_evaluator=HeatResidualEvaluator())
 
+    formula_payload = _formula_translation().to_dict()
+    formula_payload["coefficients"] = [[1.0, 0.0, 0.0, 0.0]]
+    with pytest.raises(SchemaValidationError, match="ambiguous"):
+        validate_symmetry_candidate(field, formula_payload, residual_evaluator=HeatResidualEvaluator())
+
 
 def test_validate_symmetry_candidate_rejects_malformed_payloads_with_typed_errors() -> None:
     field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1610)
@@ -263,6 +370,13 @@ def test_validate_symmetry_candidate_rejects_malformed_payloads_with_typed_error
         validate_symmetry_candidate(
             field,
             {"construction_method": "uniform_translation"},
+            residual_evaluator=HeatResidualEvaluator(),
+        )
+
+    with pytest.raises(SchemaValidationError, match="FormulaGeneratorFamily payload is malformed"):
+        validate_symmetry_candidate(
+            field,
+            {"parameterization": "formula_generator_family"},
             residual_evaluator=HeatResidualEvaluator(),
         )
 

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
-    for historical_job in range(4, 16):
+    for historical_job in range(4, 17):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.16.0`" in publishing
+    assert "including `v0.17.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -56,19 +56,19 @@ def test_v0_12_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.16.0"
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
 
     assert "## 0.12.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "summarize_generator_fit_diagnostics" in readme
     assert "package version: `0.12.0`" in readiness
     assert "git tag: `v0.12.0`" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.12`" in readiness
-    assert "including `v0.16.0`" in publishing
-    assert "V0.16 is complete" in plan
+    assert "including `v0.17.0`" in publishing
+    assert "V0.17 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.12` - Diagnostics and supportability hardening" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_16_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_17_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.16.0"
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.16.0`" in readiness
-    assert "git tag: `v0.16.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.16`" in readiness
-    assert "including `v0.16.0`" in publishing
-    assert "V0.16 is complete" in plan
+    assert "package version: `0.17.0`" in readiness
+    assert "git tag: `v0.17.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.17`" in readiness
+    assert "including `v0.17.0`" in publishing
+    assert "V0.17 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_16_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_17_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.16.0"
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.14.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "summarize_invariant_workflow" in readme
     assert "summarize_uniform_translation_orbit" in readme
-    assert "package version: `0.16.0`" in readiness
-    assert "git tag: `v0.16.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.16`" in readiness
-    assert "including `v0.16.0`" in publishing
+    assert "package version: `0.17.0`" in readiness
+    assert "git tag: `v0.17.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.17`" in readiness
+    assert "including `v0.17.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap

--- a/tests/test_v0_15_release_gate.py
+++ b/tests/test_v0_15_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_16_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_17_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.16.0"
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
     assert "v0_14-release-gate" not in workflow
 
     assert "## 0.15.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "build_uniform_translation_orbit_batch" in readme
     assert "OrbitBatchResult" in readme
-    assert "package version: `0.16.0`" in readiness
-    assert "git tag: `v0.16.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.16`" in readiness
-    assert "including `v0.16.0`" in publishing
+    assert "package version: `0.17.0`" in readiness
+    assert "git tag: `v0.17.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.17`" in readiness
+    assert "including `v0.17.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.15` - Materialized uniform translation orbit batches" in roadmap

--- a/tests/test_v0_16_release_gate.py
+++ b/tests/test_v0_16_release_gate.py
@@ -45,7 +45,7 @@ def _translation_spec(generator: GeneratorFamily) -> InvariantMapSpec:
 def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_16_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_17_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -54,18 +54,18 @@ def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.16.0"
-    assert release_gate_jobs == ["v0_16-release-gate"]
-    assert "python -m pytest tests/test_v0_16_release_gate.py" in workflow
-    assert "v0_15-release-gate" not in workflow
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
+    assert "v0_16-release-gate" not in workflow
 
     assert "## 0.16.0" in changelog
-    assert "V0.16" in readme
+    assert "V0.17" in readme
     assert "validate_symmetry_candidate" in readme
-    assert "package version: `0.16.0`" in readiness
-    assert "git tag: `v0.16.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.16`" in readiness
-    assert "including `v0.16.0`" in publishing
+    assert "package version: `0.17.0`" in readiness
+    assert "git tag: `v0.17.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.17`" in readiness
+    assert "including `v0.17.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.16` - External symmetry-candidate validation" in roadmap
@@ -142,7 +142,6 @@ def test_v0_16_release_gate_no_deferred_surface_leaked() -> None:
         "compute_weak_derivatives",
         "diagnose_time_translation_consistency",
         "evaluate_weak_ks_residual",
-        "FormulaGeneratorFamily",
         "from_pdebench",
         "from_the_well",
         "generate_ks_1d_field_batch",

--- a/tests/test_v0_17_release_gate.py
+++ b/tests/test_v0_17_release_gate.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.residuals import HeatResidualEvaluator
+from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def _formula_translation(*, finite_transform: bool = False) -> FormulaGeneratorFamily:
+    finite_transform_spec = None
+    if finite_transform:
+        from pdelie import GeneratorFamily, InvariantMapSpec
+        from pdelie.contracts import _translation_generator_basis_spec
+
+        generator = GeneratorFamily(
+            parameterization="polynomial_translation_affine",
+            coefficients=np.asarray([[1.0, 0.0, 0.0, 0.0]], dtype=float),
+            basis_spec=_translation_generator_basis_spec(),
+            normalization="l2_unit",
+            diagnostics={},
+        )
+        finite_transform_spec = InvariantMapSpec(
+            generator_metadata=generator.to_dict(),
+            construction_method="uniform_translation",
+            parameters={"axis": "x", "shift": 0.125},
+            domain_validity="global",
+            inverse_available=True,
+            diagnostics={},
+        ).to_dict()
+
+    return FormulaGeneratorFamily(
+        formula_generators=[
+            {
+                "name": "formula_translation",
+                "components": {
+                    "tau": {"node": "const", "value": 0.0},
+                    "xi": {"node": "const", "value": 1.0},
+                    "phi": {"node": "const", "value": 0.0},
+                },
+            }
+        ],
+        finite_transform_spec=finite_transform_spec,
+    )
+
+
+def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_17_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_17_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.17.0"
+    assert release_gate_jobs == ["v0_17-release-gate"]
+    assert "python -m pytest tests/test_v0_17_release_gate.py" in workflow
+    assert "v0_16-release-gate" not in workflow
+
+    assert "## 0.17.0" in changelog
+    assert "V0.17" in readme
+    assert "FormulaGeneratorFamily" in readme
+    assert "package version: `0.17.0`" in readiness
+    assert "git tag: `v0.17.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.17`" in readiness
+    assert "including `v0.17.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.17` - Formula-backed generator families" in roadmap
+    assert "**Status:** Completed" in roadmap
+
+
+def test_v0_17_release_gate_formula_api_is_documented_and_submodule_only() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    symmetry_module = importlib.import_module("pdelie.symmetry")
+    reporting_module = importlib.import_module("pdelie.reporting")
+
+    assert hasattr(symmetry_module, "FormulaGeneratorFamily")
+    assert hasattr(symmetry_module, "validate_symmetry_candidate")
+    assert hasattr(reporting_module, "summarize_formula_generator_family")
+    assert not hasattr(pdelie, "FormulaGeneratorFamily")
+    assert not hasattr(pdelie, "summarize_formula_generator_family")
+    assert "pdelie.symmetry.FormulaGeneratorFamily" in api_stability
+    assert "pdelie.reporting.summarize_formula_generator_family" in api_stability
+    assert "candidate_kind = \"formula_generator_family\"" in api_stability
+    assert "safe JSON AST" in api_stability
+    assert "these APIs have no root `pdelie` exports" in api_stability
+
+
+def test_v0_17_release_gate_formula_candidates_validate_and_fail_as_expected() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=7, num_points=16, seed=17017)
+
+    partial_report = validate_symmetry_candidate(
+        field,
+        _formula_translation().to_dict(),
+        residual_evaluator=HeatResidualEvaluator(),
+        source_candidate_id="v0_17_formula",
+    )
+    validated_report = validate_symmetry_candidate(
+        field,
+        _formula_translation(finite_transform=True),
+        residual_evaluator=HeatResidualEvaluator(),
+        source_candidate_id="v0_17_formula_transform",
+    )
+    failed_report = validate_symmetry_candidate(
+        field,
+        FormulaGeneratorFamily(
+            formula_generators=[
+                {
+                    "name": "failed_formula",
+                    "components": {
+                        "tau": {"node": "const", "value": 0.0},
+                        "xi": {"node": "reciprocal", "arg": {"node": "const", "value": 0.0}},
+                        "phi": {"node": "const", "value": 0.0},
+                    },
+                }
+            ]
+        ),
+        residual_evaluator=HeatResidualEvaluator(),
+    )
+
+    assert json.loads(json.dumps(partial_report)) == partial_report
+    assert json.loads(json.dumps(validated_report)) == validated_report
+    assert json.loads(json.dumps(failed_report)) == failed_report
+    assert partial_report["candidate_kind"] == "formula_generator_family"
+    assert partial_report["conclusion"] == "partially_validated"
+    assert partial_report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "passed"
+    assert validated_report["candidate_kind"] == "formula_generator_family"
+    assert validated_report["conclusion"] == "validated"
+    assert validated_report["check_reports"]["finite_transform_residual_stability"]["status"] == "passed"
+    assert failed_report["candidate_kind"] == "formula_generator_family"
+    assert failed_report["conclusion"] == "failed"
+    assert failed_report["check_reports"]["formula_evaluation_diagnostics"]["status"] == "failed"
+
+
+def test_v0_17_release_gate_no_deferred_surface_leaked() -> None:
+    modules = [
+        pdelie,
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.invariants"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.examples"),
+        importlib.import_module("pdelie.discovery"),
+        importlib.import_module("pdelie.symmetry"),
+    ]
+    forbidden_names = {
+        "augment_translation_orbit",
+        "build_translation_orbit_dataset",
+        "build_translation_orbit_views",
+        "CallableGeneratorFamily",
+        "compute_coverage_diagnostics",
+        "compute_weak_derivatives",
+        "diagnose_time_translation_consistency",
+        "evaluate_weak_ks_residual",
+        "from_pdebench",
+        "from_the_well",
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "load_pdebench",
+        "load_the_well",
+        "materialize_uniform_translation_orbit",
+        "run_ks_vertical_slice_example",
+        "split_orbit_train_heldout",
+        "train_test_translation_orbit_split",
+        "validate_generator_candidate",
+        "WeakKSResidualEvaluator",
+    }
+
+    for module in modules:
+        for name in sorted(forbidden_names):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"


### PR DESCRIPTION
## Summary

This PR completes `v0.17.0` as a narrow formula-backed generator interoperability release.

The main addition is a safe, runtime-only formula-backed generator path that extends symmetry-candidate validation without changing the existing canonical polynomial `GeneratorFamily` semantics.

New public submodule APIs:

- `pdelie.symmetry.FormulaGeneratorFamily`
- `pdelie.reporting.summarize_formula_generator_family(...)`

Updated public validation surface:

- `pdelie.symmetry.validate_symmetry_candidate(...)` now accepts `FormulaGeneratorFamily` objects and strict current formula payload mappings
- formula candidates are reported with `candidate_kind == "formula_generator_family"`

## Scope

`v0.17` supports JSON-compatible formula metadata for scalar 1D Lie-point generator components over `t`, `x`, and `u`.

Supported formula expression nodes include safe AST records such as:

- `const`
- `var`
- `add`
- `mul`
- integer `pow`
- `sin`
- `cos`
- `reciprocal`
- metadata-only symbolic references

Formula-backed candidates can be summarized, checked for safe evaluation diagnostics, and optionally validated through an attached supported finite-transform spec.

## Non-goals

This release does not add:

- arbitrary Python expression strings
- callables or executable external generators
- learned-generator training
- formula-derived finite-flow integration
- new PDEs
- KS runtime promotion
- weak KS
- broad dataset adapters
- operator APIs
- root `pdelie` exports

`FormulaGeneratorFamily` is runtime-only and does not become a new canonical object layer.

## Example

Adds a compact JSON-only example:

- `python -m pdelie.examples.formula_generator_validation`
- `pdelie.examples.run_formula_generator_validation_example(...)`

The example demonstrates formula-backed candidate reporting and empirical configured validation, including passing, partial, and failed formula cases.

## Release/Docs

- bumps package metadata to `0.17.0`
- updates README and changelog for the `v0.17` formula-backed slice
- adds `docs/releases/V0_17_RELEASE_READINESS.md`
- updates `docs/specs/API_STABILITY.md`
- updates CI to the current `v0_17-release-gate`
- keeps PyPI/TestPyPI publication deferred until `v1.0` or later

## Validation

- `python -m pytest`
- `python -m build --sdist --wheel`
- `python -m pdelie.examples.formula_generator_validation`
- existing examples still pass
- `git diff --check`
```