### PR TITLE
Feat/v0.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_18-release-gate:
+  v0_19-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.18 release gate
-        run: python -m pytest tests/test_v0_18_release_gate.py
+      - name: Run V0.19 release gate
+        run: python -m pytest tests/test_v0_19_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +68,7 @@ jobs:
           python -m pdelie.examples.heat_vertical_slice
           python -m pdelie.examples.kdv_vertical_slice
           python -m pdelie.examples.reaction_diffusion_vertical_slice
+          python -m pdelie.examples.advection_diffusion_vertical_slice
           python -m pdelie.examples.orbit_coverage_diagnostics
           python -m pdelie.examples.invariant_workflow_summary
           python -m pdelie.examples.translation_orbit_batch
@@ -127,8 +128,14 @@ jobs:
           import pdelie
 
           from pdelie import FieldBatch, DerivativeBatch, ResidualBatch, ResidualEvaluator, GeneratorFamily, VerificationReport
-          from pdelie.data import generate_reaction_diffusion_1d_field_batch
-          from pdelie.examples import run_reaction_diffusion_vertical_slice_example
+          from pdelie.data import (
+              generate_advection_diffusion_1d_field_batch,
+              generate_reaction_diffusion_1d_field_batch,
+          )
+          from pdelie.examples import (
+              run_advection_diffusion_vertical_slice_example,
+              run_reaction_diffusion_vertical_slice_example,
+          )
           from pdelie.invariants import (
               OrbitBatchResult,
               build_uniform_translation_orbit_batch,
@@ -147,7 +154,7 @@ jobs:
               summarize_weak_residual_report,
           )
           from pdelie.symmetry import FormulaGeneratorFamily, validate_symmetry_candidate
-          from pdelie.residuals import ReactionDiffusionResidualEvaluator
+          from pdelie.residuals import AdvectionDiffusionResidualEvaluator, ReactionDiffusionResidualEvaluator
 
           assert FieldBatch is not None
           assert DerivativeBatch is not None
@@ -170,6 +177,9 @@ jobs:
           assert summarize_weak_residual_report is not None
           assert validate_symmetry_candidate is not None
           assert FormulaGeneratorFamily is not None
+          assert generate_advection_diffusion_1d_field_batch is not None
+          assert AdvectionDiffusionResidualEvaluator is not None
+          assert run_advection_diffusion_vertical_slice_example is not None
           assert generate_reaction_diffusion_1d_field_batch is not None
           assert ReactionDiffusionResidualEvaluator is not None
           assert run_reaction_diffusion_vertical_slice_example is not None
@@ -184,6 +194,9 @@ jobs:
           assert not hasattr(pdelie, "validate_symmetry_candidate")
           assert not hasattr(pdelie, "FormulaGeneratorFamily")
           assert not hasattr(pdelie, "summarize_formula_generator_family")
+          assert not hasattr(pdelie, "generate_advection_diffusion_1d_field_batch")
+          assert not hasattr(pdelie, "AdvectionDiffusionResidualEvaluator")
+          assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")
           assert not hasattr(pdelie, "generate_reaction_diffusion_1d_field_batch")
           assert not hasattr(pdelie, "ReactionDiffusionResidualEvaluator")
           assert not hasattr(pdelie, "run_reaction_diffusion_vertical_slice_example")
@@ -492,6 +505,34 @@ jobs:
           assert summary["extra_metrics"]["equation"] == "reaction_diffusion_fisher_kpp"
           assert summary["generator"]["reference_fallback_used"] is False
           print("reaction-diffusion-smoke-ok")
+          PY
+      - name: Advection-diffusion strong path smoke
+        run: |
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import json
+          import numpy as np
+          import pdelie
+
+          from pdelie.data import generate_advection_diffusion_1d_field_batch
+          from pdelie.derivatives import compute_spectral_fd_derivatives
+          from pdelie.examples import run_advection_diffusion_vertical_slice_example
+          from pdelie.residuals import AdvectionDiffusionResidualEvaluator
+
+          assert not hasattr(pdelie, "generate_advection_diffusion_1d_field_batch")
+          assert not hasattr(pdelie, "AdvectionDiffusionResidualEvaluator")
+          field = generate_advection_diffusion_1d_field_batch(batch_size=2, num_times=17, num_points=32, num_modes=4, seed=19018)
+          assert field.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"
+          derivatives = compute_spectral_fd_derivatives(field)
+          residual = AdvectionDiffusionResidualEvaluator().evaluate(field, derivatives)
+          assert np.isfinite(float(residual.diagnostics["max_abs_residual"]))
+          assert np.isfinite(float(residual.diagnostics["rms_residual"]))
+          summary = run_advection_diffusion_vertical_slice_example()
+          json.dumps(summary)
+          assert summary["summary_type"] == "vertical_slice"
+          assert summary["extra_metrics"]["equation"] == "advection_diffusion_constant_coefficient"
+          assert summary["generator"]["reference_fallback_used"] is False
+          assert summary["generator"]["diagnostics"]["evidence_label"] == "direct_svd_in_tolerance"
+          print("advection-diffusion-smoke-ok")
           PY
       - name: Order-4 derivative smoke
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,23 @@ Read these before coding:
 
 ## Stable scope
 V0.x stable scope only:
+- uniform rectilinear grids
 - synthetic PDE data
 - Lie point symmetries
+- canonical polynomial `GeneratorFamily` objects
+- runtime-only formula-backed generator records
+- frozen invariant/reporting/orbit utilities
 
 ## Do not implement unless explicitly asked
 - neural generators
+- Python-callable or executable-string generator APIs
+- weak-form advanced methods beyond frozen weak-report slices
 - operator symmetry
+- multidimensional or nonuniform-grid expansion
 - paper-specific experiment logic
+- broad dataset adapters or file-based dataset loaders
+- public KS runtime APIs
+- train/test policy or heldout-leakage management
 
 ## Workflow
 For nontrivial tasks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,12 @@ Read these before coding:
 
 ## Stable scope
 V0.x stable scope only:
-- uniform rectilinear grids
 - synthetic PDE data
 - Lie point symmetries
-- polynomial generators
 
 ## Do not implement unless explicitly asked
 - neural generators
-- weak-form advanced methods
 - operator symmetry
-- broad dataset adapters
 - paper-specific experiment logic
 
 ## Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.19.0
+
+First final release for the frozen V0.19 constant-coefficient advection-diffusion strong path.
+
+- adds `pdelie.data.generate_advection_diffusion_1d_field_batch(...)` for deterministic synthetic scalar 1D periodic constant-coefficient advection-diffusion fields
+- adds `pdelie.residuals.AdvectionDiffusionResidualEvaluator` for the strong residual `u_t + c*u_x - nu*u_xx = 0`
+- adds `python -m pdelie.examples.advection_diffusion_vertical_slice` and `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)` as JSON-only runtime smoke examples
+- freezes the equation tag `advection_diffusion_constant_coefficient` with `c` and `nu` metadata
+- uses exact periodic Fourier evolution for the synthetic rollout
+- verifies the frozen vertical slice with direct SVD translation evidence, no reference fallback, residual max around `5.51e-5`, residual RMS around `8.44e-6`, and exact held-out verification
+- documents the new APIs in `API_STABILITY.md` as submodule-only runtime APIs with no root exports
+- preserves prior Heat/Burgers strong paths, weak residual reports, normalized periodic KdV, Fisher-KPP reaction-diffusion, reporting helpers, invariant/orbit diagnostics, orbit batches, candidate validation, and formula-backed generator support
+
+Explicitly deferred for this final release:
+
+- variable-coefficient advection-diffusion
+- reaction-advection-diffusion
+- weak advection-diffusion
+- public custom advection-diffusion initial-condition APIs
+- KS runtime promotion
+- broad dataset adapters such as PDEBench or The Well
+- multidimensional, multivariable, or nonuniform-grid support
+- time-translation APIs
+- neural or callable generator APIs
+- operator-facing APIs
+- train/test policy, split management, or heldout-leakage detection
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.18.0
 
 First final release for the frozen V0.18 Fisher-KPP reaction-diffusion strong path.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.18 Fisher-KPP reaction-diffusion strong-path slice for the existing Heat/Burgers/weak-report/KdV engine:
+The current repository implements the frozen V0.19 advection-diffusion strong-path slice for the existing Heat/Burgers/weak-report/KdV/Fisher-KPP engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
 - synthetic normalized periodic short-horizon KdV
 - synthetic scalar 1D periodic Fisher-KPP reaction-diffusion tagged as `reaction_diffusion_fisher_kpp`
+- synthetic scalar 1D periodic constant-coefficient advection-diffusion tagged as `advection_diffusion_constant_coefficient`
 - strict external structured ingestion into canonical `FieldBatch`
 - deterministic window-indexed weak residual reports under `pdelie.residuals`
 - JSON-compatible runtime supportability summaries under `pdelie.reporting`
@@ -16,6 +17,7 @@ The current repository implements the frozen V0.18 Fisher-KPP reaction-diffusion
 - `spectral_fd` derivatives through `u_xxxx`
 - normalized KdV strong residuals under `pdelie.residuals.KdVResidualEvaluator`
 - Fisher-KPP reaction-diffusion strong residuals under `pdelie.residuals.ReactionDiffusionResidualEvaluator`
+- advection-diffusion strong residuals under `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
 - internal Kuramoto-Sivashinsky diagnostic sweep evidence with stable runtime promotion deferred
 - public orbit/coverage diagnostics under `pdelie.invariants`
 - invariant workflow summaries under `pdelie.reporting.summarize_invariant_workflow`
@@ -26,6 +28,7 @@ The current repository implements the frozen V0.18 Fisher-KPP reaction-diffusion
 - formula generator summaries under `pdelie.reporting.summarize_formula_generator_family`
 - formula-backed candidate validation through `candidate_kind = "formula_generator_family"`
 - reaction-diffusion vertical-slice example under `pdelie.examples.run_reaction_diffusion_vertical_slice_example`
+- advection-diffusion vertical-slice example under `pdelie.examples.run_advection_diffusion_vertical_slice_example`
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -40,7 +43,7 @@ The current repository implements the frozen V0.18 Fisher-KPP reaction-diffusion
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_18-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_19-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -89,7 +92,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.18`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.19`:
 
 - `00_pde_timeseries_to_generators.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -121,6 +124,7 @@ Run the packaged example modules from the repo root:
 python -m pdelie.examples.heat_vertical_slice
 python -m pdelie.examples.kdv_vertical_slice
 python -m pdelie.examples.reaction_diffusion_vertical_slice
+python -m pdelie.examples.advection_diffusion_vertical_slice
 python -m pdelie.examples.orbit_coverage_diagnostics
 python -m pdelie.examples.invariant_workflow_summary
 python -m pdelie.examples.translation_orbit_batch
@@ -243,8 +247,9 @@ Included in the current stable core:
 - external symmetry-candidate validation in `v0.16` accepts `GeneratorFamily` and `InvariantMapSpec` objects or strict payload mappings and returns empirical configured validation reports; it does not train detectors or accept callables
 - formula-backed generator support in `v0.17` adds safe runtime formula records, reporting, and empirical validation; it does not parse executable strings, accept callables, train learned generators, or change canonical polynomial `GeneratorFamily`
 - Fisher-KPP reaction-diffusion support in `v0.18` adds one scoped scalar 1D periodic strong path with direct SVD translation-fit evidence; it does not add advection-diffusion, KS promotion, weak reaction-diffusion, custom initial-condition APIs, or broader grid support
+- advection-diffusion support in `v0.19` adds one scoped scalar 1D periodic constant-coefficient strong path with direct SVD translation-fit evidence; it does not add variable coefficients, weak advection-diffusion, reaction-advection-diffusion, custom initial-condition APIs, time translation, or broader grid support
 
-Runtime-level public APIs in the frozen V0.18 slice:
+Runtime-level public APIs in the frozen V0.19 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -255,6 +260,9 @@ Runtime-level public APIs in the frozen V0.18 slice:
 - `pdelie.data.generate_reaction_diffusion_1d_field_batch` for synthetic scalar 1D periodic Fisher-KPP reaction-diffusion under the frozen v0.18 generator regime
 - `pdelie.residuals.ReactionDiffusionResidualEvaluator` for the strong-form residual `u_t - nu*u_xx - rho*u*(1-u) = 0`
 - `pdelie.examples.run_reaction_diffusion_vertical_slice_example` for a runtime smoke example, not a canonical report schema
+- `pdelie.data.generate_advection_diffusion_1d_field_batch` for synthetic scalar 1D periodic constant-coefficient advection-diffusion under the frozen v0.19 generator regime
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator` for the strong-form residual `u_t + c*u_x - nu*u_xx = 0`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example` for a runtime smoke example, not a canonical report schema
 - `pdelie.residuals.evaluate_weak_heat_residual` for deterministic window-indexed weak residual report dicts over canonical scalar 1D uniform periodic Heat `FieldBatch` data
 - `pdelie.residuals.evaluate_weak_burgers_residual` for deterministic window-indexed weak residual report dicts over canonical scalar 1D uniform periodic Burgers `FieldBatch` data
 - `pdelie.reporting.summarize_residual_batch` for JSON-compatible runtime summaries of `ResidualBatch` outputs
@@ -294,7 +302,7 @@ Runtime-level public APIs in the frozen V0.18 slice:
 
 The degraded weak-path release wins in `v0.8` are frozen as representative contract-stability signals. They are fallback-backed release checks, not a general weak-superiority claim.
 
-The KdV support retained through `v0.18` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+The KdV support retained through `v0.19` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
 
 The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 
@@ -310,9 +318,13 @@ The `v0.15` data-utility work adds materialized uniform translation orbit batche
 
 The `v0.15` orbit-batch helper constructs orbit-expanded data. It does not decide train/heldout policy or leakage safety. Serious workflows should keep source and shift indices enabled so materialized samples remain auditable.
 
-The `v0.16` candidate-validation work adds detector interop through strict payload validation and empirical reports. `validated` means the configured checks passed under the supplied field, residual evaluator, epsilons, and optional reference; it is not a mathematical proof. Callable descriptors, learned detector training, formula-backed generators, KS promotion, and operator-facing APIs remain deferred.
+The `v0.16` candidate-validation work adds detector interop through strict payload validation and empirical reports. `validated` means the configured checks passed under the supplied field, residual evaluator, epsilons, and optional reference; it is not a mathematical proof. Callable descriptors, learned detector training, KS promotion, and operator-facing APIs remain deferred.
+
+The `v0.17` formula-generator work adds safe formula-backed runtime records and empirical validation. Formula records use JSON AST metadata, not executable code or arbitrary string parsing.
 
 The `v0.18` reaction-diffusion work adds one stable Fisher-KPP strong path. The stable claim covers the frozen scalar 1D periodic synthetic regime with direct SVD translation-fit evidence. Mean and L2 drift are diagnostic-only because Fisher-KPP reaction terms are not conservation laws.
+
+The `v0.19` advection-diffusion work adds one stable constant-coefficient strong path. The stable claim covers the frozen scalar 1D periodic synthetic regime with exact Fourier rollout and direct SVD translation-fit evidence. Variable coefficients, weak advection-diffusion, and custom initial-condition APIs remain deferred.
 
 Explicitly deferred:
 - stable multi-generator PDE fitting
@@ -327,7 +339,9 @@ Explicitly deferred:
 - weak KdV APIs
 - custom KdV initial conditions or configurable KdV coefficients
 - general KdV support outside the frozen normalized periodic short-horizon regime
-- advection-diffusion
+- variable-coefficient advection-diffusion
+- reaction-advection-diffusion
+- weak advection-diffusion
 - weak reaction-diffusion
 - custom reaction-diffusion initial-condition APIs
 - stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,18 +1,18 @@
-# PDELie - Execution Plan (V0.18)
+# PDELie - Execution Plan (V0.19)
 
 **Status:** COMPLETE
 
-**V0.18 is complete as the stable Fisher-KPP reaction-diffusion strong path**
+**V0.19 is complete as the stable advection-diffusion strong path**
 
-This file is the completed execution record for the `v0.18` release series.
+This file is the completed execution record for the `v0.19` release series.
 
 ## Release Theme
 
-`v0.18` adds one scoped PDE expansion:
+`v0.19` adds one scoped PDE expansion:
 
-> canonical scalar 1D periodic FieldBatch -> spectral_fd derivatives -> Fisher-KPP residual -> translation fit/verification -> vertical-slice summary/example
+> canonical scalar 1D periodic FieldBatch -> spectral_fd derivatives -> advection-diffusion residual -> translation fit/verification -> vertical-slice summary/example
 
-The public claim is intentionally narrow. The release adds a stable synthetic Fisher-KPP generator, a strong-form residual evaluator, and a JSON-only vertical-slice smoke example. It does not add advection-diffusion, KS promotion, weak reaction-diffusion, custom initial-condition APIs, broad adapters, multidimensional or nonuniform support, neural/callable generator APIs, operator APIs, split policy, or root exports.
+The public claim is intentionally narrow. The release adds a stable synthetic constant-coefficient advection-diffusion generator, a strong-form residual evaluator, and a JSON-only vertical-slice smoke example. It does not add variable-coefficient advection-diffusion, reaction-advection-diffusion, weak advection-diffusion, KS promotion, custom initial-condition APIs, broad adapters, multidimensional or nonuniform support, time translation, neural/callable generator APIs, operator APIs, split policy, or root exports.
 
 ## Milestone Status
 
@@ -26,19 +26,19 @@ The public claim is intentionally narrow. The release adds a stable synthetic Fi
 
 Authoritative scope:
 
-- `docs/planning/V0_18_SCOPE.md`
+- `docs/planning/V0_19_SCOPE.md`
 
-`API_STABILITY.md` was updated when the public `v0.18` reaction-diffusion APIs landed.
+`API_STABILITY.md` was updated when the public `v0.19` advection-diffusion APIs landed.
 
 ## Milestone 0 - Scope Freeze
 
-Freeze `v0.18` as a stable Fisher-KPP reaction-diffusion strong-path release.
+Freeze `v0.19` as a stable constant-coefficient advection-diffusion strong-path release.
 
 Closeout:
 
-- added `docs/planning/V0_18_SCOPE.md`
-- reset `PLAN.md` as the active `v0.18` execution record
-- updated `ROADMAP.md` to record `v0.18` as the current completed release
+- added `docs/planning/V0_19_SCOPE.md`
+- reset `PLAN.md` as the active `v0.19` execution record
+- updated `ROADMAP.md` to record `v0.19` as the current completed release
 - kept the stable scope to scalar 1D uniform periodic synthetic data
 
 ## Milestone 1 - Equation And Numerical Semantics Freeze
@@ -46,80 +46,84 @@ Closeout:
 Frozen equation:
 
 ```text
-u_t = nu*u_xx + rho*u*(1 - u)
-residual = u_t - nu*u_xx - rho*u*(1 - u)
+u_t + c*u_x = nu*u_xx
+residual = u_t + c*u_x - nu*u_xx
 ```
 
 Frozen metadata:
 
-- `field.metadata["parameter_tags"]["equation"] == "reaction_diffusion_fisher_kpp"`
+- `field.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"`
+- `field.metadata["parameter_tags"]["c"]`
 - `field.metadata["parameter_tags"]["nu"]`
-- `field.metadata["parameter_tags"]["rho"]`
 
 Frozen defaults:
 
+- `c = 0.75`
 - `nu = 0.05`
-- `rho = 1.0`
-- smooth bounded Fourier-mode initial conditions
-- deterministic pseudo-spectral periodic RK4 rollout
+- zero-mean smooth Fourier-mode initial perturbations
+- exact periodic Fourier evolution
 
-Mass and mean drift are diagnostic-only because Fisher-KPP reaction terms are not mass conserving.
+Mean drift is diagnostic-only. Periodic constant-coefficient advection-diffusion preserves the mean analytically, but the release gate treats the diagnostic as supportability evidence, not a separate public invariant contract.
 
 ## Milestone 2 - Synthetic Data Generator
 
 Implemented:
 
-- `pdelie.data.generate_reaction_diffusion_1d_field_batch(...)`
+- `pdelie.data.generate_advection_diffusion_1d_field_batch(...)`
 
-The generator returns canonical scalar 1D periodic `FieldBatch` objects with finite unmasked values and the frozen Fisher-KPP equation tag. It has no public custom initial-condition API.
+The generator returns canonical scalar 1D periodic `FieldBatch` objects with finite unmasked values and the frozen advection-diffusion equation tag. It has no public custom initial-condition API.
 
 Validation added:
 
 - deterministic same-seed output and seed sensitivity
 - canonical dims, coords, metadata, scalar var, finite values, no mask by default
+- exact Fourier phase/diffusion sanity against the frozen multiplier
 - `from_numpy` ingestion parity
-- invalid size, parameter, mode, amplitude, substep, and domain inputs raise typed validation errors
+- invalid size, parameter, mode, amplitude, and domain inputs raise typed validation errors
 
 ## Milestone 3 - Residual Evaluator
 
 Implemented:
 
-- `pdelie.residuals.ReactionDiffusionResidualEvaluator`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
 
 Residual contract:
 
-- evaluates `u_t - nu*u_xx - rho*u*(1-u)`
+- evaluates `u_t + c*u_x - nu*u_xx`
 - computes `compute_spectral_fd_derivatives(field)` when derivatives are omitted
-- supplied derivatives must include `u_t` and `u_xx`
+- supplied derivatives must include `u_t`, `u_x`, and `u_xx`
 - validates scalar 1D periodic finite unmasked fields and the frozen equation tag
+- reads `c` and `nu` from metadata when constructor parameters are omitted
+- allows finite signed `c`
+- requires finite positive `nu`
 
 Observed frozen-fixture residual evidence:
 
-- residual max: approximately `1.07e-5`
-- residual RMS: approximately `1.22e-6`
+- residual max: approximately `5.51e-5`
+- residual RMS: approximately `8.44e-6`
 
 ## Milestone 4 - Vertical Slice And Example
 
 Implemented:
 
-- `pdelie.examples.run_reaction_diffusion_vertical_slice_example(...)`
-- command module: `python -m pdelie.examples.reaction_diffusion_vertical_slice`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)`
+- command module: `python -m pdelie.examples.advection_diffusion_vertical_slice`
 
 The example emits the existing nested `summarize_vertical_slice(...)` runtime summary shape.
 
 Observed frozen vertical-slice evidence:
 
 - derivative keys: `u_t`, `u_x`, `u_xx`
-- residual max: approximately `1.07e-5`
-- residual RMS: approximately `1.22e-6`
+- residual max: approximately `5.51e-5`
+- residual RMS: approximately `8.44e-6`
 - fit mode: `svd`
 - evidence label: `direct_svd_in_tolerance`
 - reference fallback: `false`
-- selected/SVD span distance: approximately `4.12e-3`
+- selected/SVD span distance: approximately `7.87e-4`
 - verification classification: `exact`
-- first held-out verification error: approximately `1.73e-9`
+- first held-out verification error: approximately `7.87e-8`
 
-This satisfies the stable promotion condition. No fallback-backed reaction-diffusion claim landed.
+This satisfies the stable promotion condition. No fallback-backed advection-diffusion claim landed.
 
 ## Milestone 5 - API / Public-surface Audit
 
@@ -127,24 +131,24 @@ Audit result:
 
 - new APIs are importable only from owning submodules
 - root `pdelie` remains unchanged
-- `API_STABILITY.md` documents the new reaction-diffusion generator, residual evaluator, and example runner
-- no advection-diffusion, KS promotion, weak reaction-diffusion, custom IC API, broad adapter, multidimensional/nonuniform support, operator API, neural/callable generator API, or split policy landed
+- `API_STABILITY.md` documents the new advection-diffusion generator, residual evaluator, and example runner
+- no variable-coefficient advection-diffusion, reaction-advection-diffusion, weak advection-diffusion, KS promotion, custom IC API, broad adapter, multidimensional/nonuniform support, time-translation API, operator API, neural/callable generator API, or split policy landed
 
 ## Milestone 6 - Release Gate And Readiness
 
 Implemented:
 
-- added compact `tests/test_v0_18_release_gate.py`
-- updated CI so the current explicit release gate is `v0_18-release-gate`
+- added compact `tests/test_v0_19_release_gate.py`
+- updated CI so the current explicit release gate is `v0_19-release-gate`
 - kept full editable `python -m pytest`
-- kept package smoke and added reaction-diffusion smoke coverage
-- bumped package metadata to `0.18.0`
+- kept package smoke and added advection-diffusion smoke coverage
+- bumped package metadata to `0.19.0`
 - updated README, changelog, publishing notes, roadmap, and release readiness docs
-- documented direct `v0.18.0` Git-tag release path
+- documented direct `v0.19.0` Git-tag release path
 
 Required checks before tagging:
 
-- `v0_18-release-gate`
+- `v0_19-release-gate`
 - `editable-tests`
 - `package-smoke`
 
@@ -152,10 +156,11 @@ Local validation checklist:
 
 - `python -m pytest`
 - `python -m build --sdist --wheel`
-- clean wheel smoke from `dist/pdelie-0.18.0-py3-none-any.whl`
+- clean wheel smoke from `dist/pdelie-0.19.0-py3-none-any.whl`
 - `python -m pdelie.examples.heat_vertical_slice`
 - `python -m pdelie.examples.kdv_vertical_slice`
 - `python -m pdelie.examples.reaction_diffusion_vertical_slice`
+- `python -m pdelie.examples.advection_diffusion_vertical_slice`
 - `python -m pdelie.examples.orbit_coverage_diagnostics`
 - `python -m pdelie.examples.invariant_workflow_summary`
 - `python -m pdelie.examples.translation_orbit_batch`

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -453,6 +453,75 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.19` - Stable advection-diffusion strong path
+**Status:** Completed
+
+`v0.19` is the completed narrow PDE-expansion release after the `v0.18` Fisher-KPP reaction-diffusion strong-path release.
+
+Its purpose is:
+
+> add one stable scalar 1D periodic constant-coefficient advection-diffusion strong path without broadening grids, adapters, weak-form scope, or generator scope.
+
+Completed release definition:
+
+`canonical scalar 1D periodic FieldBatch -> spectral_fd derivatives -> advection-diffusion residual -> translation fit/verification -> vertical-slice summary/example`
+
+Completed scope:
+
+- `pdelie.data.generate_advection_diffusion_1d_field_batch(...)`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)`
+- frozen advection-diffusion equation tag: `advection_diffusion_constant_coefficient`
+- residual `u_t + c*u_x - nu*u_xx`
+- default parameters `c = 0.75`, `nu = 0.05`
+- exact periodic Fourier synthetic rollout
+- direct-SVD translation fit evidence in the frozen vertical slice
+- compact current `v0_19-release-gate` readiness
+
+Release interpretation:
+
+- this is a scoped synthetic strong-form constant-coefficient advection-diffusion path, not a broad transport-diffusion framework
+- the stable claim is backed by direct SVD translation evidence, not reference fallback
+- mean drift is diagnostic-only in the release report
+- `v0.19.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no variable-coefficient advection-diffusion
+- no reaction-advection-diffusion
+- no weak advection-diffusion
+- no public custom initial-condition API
+- no KS runtime promotion
+- no broad dataset adapters
+- no PDEBench or The Well support
+- no multidimensional, multivariable, or nonuniform-grid expansion
+- no time-translation APIs
+- no neural or callable generator API
+- no operator-facing symmetry work
+- no train/test policy or split management
+- no root export expansion
+
+The authoritative `v0.19` scope freeze belongs in:
+
+- `V0_19_SCOPE.md`
+
+### Release Gate for `v0.19`
+
+`v0.19` is complete only if:
+
+- advection-diffusion generator and residual APIs are documented and covered by tests
+- new APIs are importable from their submodules only
+- root `pdelie` remains unchanged
+- the advection-diffusion vertical slice has direct SVD evidence in tolerance
+- the advection-diffusion example emits JSON only using the nested vertical-slice summary shape
+- no public variable-coefficient advection-diffusion, weak advection-diffusion, KS, broad adapter, custom-IC, nonuniform/multidimensional, time-translation, neural/callable, split-policy, or operator API lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.18` - Stable Fisher-KPP reaction-diffusion strong path
 **Status:** Completed
 
@@ -1004,36 +1073,6 @@ Only `Committed` items define the next release target.
 
 The principle is still one stable axis at a time: do not combine PDE expansion, data-adapter expansion, weak-form expansion, multi-generator machinery, and downstream policy in one release.
 
-### `v0.19` - Stable advection-diffusion strong path
-**Status:** Planned
-
-Preferred next release target once scope is frozen.
-
-Candidate stable path:
-
-`canonical scalar 1D periodic FieldBatch -> spectral_fd u_t/u_x/u_xx -> constant-coefficient advection-diffusion residual -> translation fit/verification -> vertical-slice example`
-
-Candidate equation:
-
-```text
-u_t + c*u_x = nu*u_xx
-residual = u_t + c*u_x - nu*u_xx
-```
-
-Purpose:
-
-- add one transport-plus-diffusion PDE without leaving the scalar 1D periodic order-2 derivative regime
-- test phase-moving fields under the current direct-SVD fitting and verification stack
-
-Deferred from `v0.19`:
-
-- variable coefficients
-- reaction-advection-diffusion
-- weak advection-diffusion
-- nonperiodic boundaries
-- multidimensional or nonuniform grids
-- custom initial-condition public APIs
-
 ### `v0.20` - Unified generator confidence reports
 **Status:** Planned
 
@@ -1323,6 +1362,7 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_16_SCOPE.md` once frozen
 - `V0_17_SCOPE.md` once frozen
 - `V0_18_SCOPE.md` once frozen
+- `V0_19_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -1366,7 +1406,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.16` = external symmetry-candidate interop and validation, not detector training
 - `v0.17` = formula-backed generator records and validation, without callables or learned-generator training
 - `v0.18` = stable scalar 1D periodic Fisher-KPP reaction-diffusion strong path
-- `v0.19` = planned stable scalar 1D periodic advection-diffusion strong path
+- `v0.19` = stable scalar 1D periodic constant-coefficient advection-diffusion strong path
 - `v0.20` = planned unified generator confidence reports
 - `v0.21` = planned external data readiness reports
 - `v0.22` = planned downstream discovery contracts and provenance reports

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -997,32 +997,283 @@ The authoritative `v0.7` scope freeze belongs in:
 
 ---
 
-## Medium-Term Horizon
+## Medium-Term Planned Pre-`v1.0` Outline
 
-### `v0.18+` - Scoped PDE expansion
+The following sequence is planned, not committed execution.
+Only `Committed` items define the next release target.
+
+The principle is still one stable axis at a time: do not combine PDE expansion, data-adapter expansion, weak-form expansion, multi-generator machinery, and downstream policy in one release.
+
+### `v0.19` - Stable advection-diffusion strong path
 **Status:** Planned
 
-`v0.18+` is the earliest planned point for another stable PDE expansion.
+Preferred next release target once scope is frozen.
 
-Preferred stable direction:
+Candidate stable path:
 
-- advection-diffusion or reaction-diffusion, because these are more likely to fit the current scalar structured-data contracts cleanly
+`canonical scalar 1D periodic FieldBatch -> spectral_fd u_t/u_x/u_xx -> constant-coefficient advection-diffusion residual -> translation fit/verification -> vertical-slice example`
 
-Alternative scoped direction:
+Candidate equation:
 
-- KS residual-only, but only if the public claim explicitly excludes direct residual-based fitting recovery
+```text
+u_t + c*u_x = nu*u_xx
+residual = u_t + c*u_x - nu*u_xx
+```
 
-Deferred until separately frozen:
+Purpose:
 
-- broad PDE zoo expansion
-- PDEBench or The Well adapters
-- multidimensional grids
-- nonuniform grids
-- operator-facing APIs
-- weak KS
-- learned-generator training
+- add one transport-plus-diffusion PDE without leaving the scalar 1D periodic order-2 derivative regime
+- test phase-moving fields under the current direct-SVD fitting and verification stack
 
-Each of these requires its own scope freeze before implementation.
+Deferred from `v0.19`:
+
+- variable coefficients
+- reaction-advection-diffusion
+- weak advection-diffusion
+- nonperiodic boundaries
+- multidimensional or nonuniform grids
+- custom initial-condition public APIs
+
+### `v0.20` - Unified generator confidence reports
+**Status:** Planned
+
+Purpose:
+
+> promote the notebook confidence-card teaching pattern into a public runtime reporting helper.
+
+Candidate scope:
+
+- combine residual health, fit conditioning, span evidence, verification, candidate validation, orbit/coverage diagnostics, and configured thresholds
+- produce JSON-compatible runtime summaries
+- make evidence labels and missing-evidence states explicit
+
+Explicit boundary:
+
+- reporting helpers remain report-only
+- no transformed `FieldBatch` collections are returned from reporting helpers
+- no train/test policy or downstream success policy is encoded
+
+### `v0.21` - External data readiness reports
+**Status:** Planned
+
+Purpose:
+
+> make “bring your own scalar 1D periodic data” safer before adding broad adapters.
+
+Candidate scope:
+
+- `FieldBatch` audit reports
+- coordinate and grid diagnostics
+- metadata completeness and consistency diagnostics
+- finite-value, mask, and scalar-var diagnostics
+- residual-evaluator compatibility preflight reports
+- conservative metadata inference for safe, explicit cases only
+
+Deferred:
+
+- `xarray.Dataset` support
+- file-based dataset loaders
+- PDEBench / The Well adapters
+- multidimensional or nonuniform-grid ingestion
+
+### `v0.22` - Downstream discovery contracts
+**Status:** Planned
+
+Purpose:
+
+> turn the narrow downstream discovery path into clearer, backend-neutral runtime contracts and reports.
+
+Candidate scope:
+
+- broad downstream discovery contracts for runtime reports
+- standardized recovery and provenance summaries
+- bridge-output summaries for backend-native arrays and labels
+- orbit-materialization provenance checks for downstream inputs
+- paper-agnostic downstream evaluation templates
+
+Deferred:
+
+- general discovery-backend framework
+- manuscript thresholds
+- backend lock-in beyond thin adapters
+- automatic experiment policy
+
+### `v0.23` - Split/leakage provenance diagnostics
+**Status:** Planned
+
+Purpose:
+
+> reduce misuse risk now that materialized orbit batches are public data utilities.
+
+Candidate scope:
+
+- diagnostics over user-supplied train/heldout partitions
+- source/shift provenance overlap reports
+- heldout-leakage risk reports for orbit-materialized data
+
+Explicit boundary:
+
+- no train/test split management
+- no automatic split generation
+- no downstream augmentation policy
+- no benchmark success criteria
+
+### `v0.24` - Weak-form supportability reset
+**Status:** Planned
+
+Purpose:
+
+> decide whether weak derivatives and broader weak-form methods can be promoted beyond the frozen `v0.8` weak residual report slice.
+
+Candidate scope:
+
+- weak derivative backend feasibility
+- broader weak-form residual method contracts
+- weak reaction-diffusion feasibility
+- noisy/coarse-data supportability diagnostics
+
+Deferred unless separately proven:
+
+- weak KdV APIs
+- weak KS APIs
+- broad noisy-data superiority claims
+
+### `v0.25` - KdV scope decision
+**Status:** Planned
+
+Purpose:
+
+> decide whether KdV should expand beyond the frozen normalized periodic short-horizon regime.
+
+Candidate scope:
+
+- custom KdV initial-condition feasibility
+- configurable KdV coefficient feasibility
+- general KdV support decision
+- weak KdV decision
+
+Acceptable outcome:
+
+- keep KdV frozen and document why if the broader regime is not supportable.
+
+### `v0.26` - KS revisit
+**Status:** Planned
+
+Purpose:
+
+> revisit the `v0.11`/`v0.12` KS no-go with better confidence diagnostics.
+
+Candidate decisions:
+
+- stable KS residual-only public path
+- stable full KS strong path
+- continued no-go/defer
+
+Explicitly evaluated:
+
+- stable KS data generator
+- stable KS residual evaluator
+- KS vertical-slice example
+- KS imported parity
+- weak KS API
+- root KS export
+
+Default stance:
+
+- no root KS export
+- no weak KS
+- no public full KS path unless direct residual-based fitting evidence improves
+
+### `v0.27` - Multi-generator feasibility
+**Status:** Planned
+
+Purpose:
+
+> test whether the current single-generator-centered runtime can support stable multi-generator workflows.
+
+Candidate scope:
+
+- stable multi-generator PDE fitting feasibility
+- multi-generator invariant machinery feasibility
+- closure/span/verification interactions for fitted families
+
+High-risk boundary:
+
+- this may alter core assumptions and should not be mixed with a PDE or adapter release.
+
+### `v0.28` - Data ecosystem feasibility
+**Status:** Planned
+
+Purpose:
+
+> decide whether external data ecosystem support can be widened without weakening canonical contracts.
+
+Candidate scope:
+
+- `xarray.Dataset` support
+- file-based dataset loaders
+- narrow adapter feasibility
+- metadata inference expansion
+
+Deferred unless scope is frozen:
+
+- PDEBench / The Well as stable APIs
+- broad adapter framework
+- implicit alias-based loaders
+
+### `v0.29` - Grid-domain feasibility
+**Status:** Planned
+
+Purpose:
+
+> evaluate multidimensional and nonuniform-grid ingestion as a contract change, not a small adapter patch.
+
+Candidate scope:
+
+- multidimensional ingestion feasibility
+- nonuniform-grid ingestion feasibility
+- resampling/reporting decisions
+- derivative/residual compatibility diagnostics for unsupported grids
+
+Default stance:
+
+- unsupported until a dedicated scope freeze proves the contracts.
+
+### `v0.30` - Orbit/action scope decision
+**Status:** Planned
+
+Purpose:
+
+> decide whether invariant actions should expand beyond frozen uniform spatial translation materialization.
+
+Candidate scope:
+
+- public orbit-view builders beyond the materialized uniform translation orbit batch helper
+- transformed `FieldBatch` collection policy for data APIs
+- time-translation APIs
+- `axis="time"` support
+
+Boundary:
+
+- reporting helpers remain report-only
+- transformed collections belong in explicit data/invariant APIs, not reporting APIs
+
+### `v0.31` - `v1.0` readiness hardening
+**Status:** Planned
+
+Purpose:
+
+> freeze the public engine before `v1.0`.
+
+Candidate scope:
+
+- public/private API audit
+- root export policy audit
+- deprecation policy
+- package publishing plan
+- docs and notebook consistency audit
+- release-gate consolidation
+- support matrix for stable PDEs, grids, residuals, candidate types, and downstream paths
 
 ### `v1.0` - Stable public engine
 **Status:** Deferred
@@ -1070,6 +1321,8 @@ This is not part of the near-term non-operator Paper 1 path and should not be mi
 - `V0_14_SCOPE.md` once frozen
 - `V0_15_SCOPE.md` once frozen
 - `V0_16_SCOPE.md` once frozen
+- `V0_17_SCOPE.md` once frozen
+- `V0_18_SCOPE.md` once frozen
 - `PLAN.md` for current execution only
 
 ### Non-authoritative for scheduling
@@ -1113,6 +1366,18 @@ It should **not** be edited every time a new idea appears.
 - `v0.16` = external symmetry-candidate interop and validation, not detector training
 - `v0.17` = formula-backed generator records and validation, without callables or learned-generator training
 - `v0.18` = stable scalar 1D periodic Fisher-KPP reaction-diffusion strong path
-- `v0.19+` = future scoped PDE expansion only after an explicit scope freeze
+- `v0.19` = planned stable scalar 1D periodic advection-diffusion strong path
+- `v0.20` = planned unified generator confidence reports
+- `v0.21` = planned external data readiness reports
+- `v0.22` = planned downstream discovery contracts and provenance reports
+- `v0.23` = planned split/leakage provenance diagnostics, not split management
+- `v0.24` = planned weak-form supportability reset
+- `v0.25` = planned KdV scope decision
+- `v0.26` = planned KS revisit
+- `v0.27` = planned multi-generator feasibility
+- `v0.28` = planned data ecosystem feasibility
+- `v0.29` = planned grid-domain feasibility
+- `v0.30` = planned orbit/action scope decision
+- `v0.31` = planned `v1.0` readiness hardening
 - `v1.0` = stable public engine
 - later / experimental = operator-facing symmetry discovery

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -10,12 +10,27 @@ Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
 
 After `v0.14`, the highest-ROI path has been to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then formula-backed generator support, then carefully scoped PDE expansion.
 
+After `v0.18`, the next planned path is to add one safe transport PDE, consolidate confidence reporting, harden external-data readiness, and only then consider more difficult axes such as weak forms, broader KdV/KS, multi-generator fitting, broad adapters, multidimensional/nonuniform grids, and time-translation actions.
+
 Staged sequence:
 
 - `v0.15`: materialized uniform translation orbit batches
 - `v0.16`: external symmetry-candidate interop and validation
 - `v0.17`: formula-backed generator families
-- `v0.18+`: scoped PDE expansion
+- `v0.18`: stable Fisher-KPP reaction-diffusion strong path
+- `v0.19`: planned advection-diffusion strong path
+- `v0.20`: planned unified generator confidence reports
+- `v0.21`: planned external data readiness reports
+- `v0.22`: planned downstream discovery contracts
+- `v0.23`: planned split/leakage provenance diagnostics
+- `v0.24`: planned weak-form supportability reset
+- `v0.25`: planned KdV scope decision
+- `v0.26`: planned KS revisit
+- `v0.27`: planned multi-generator feasibility
+- `v0.28`: planned data ecosystem feasibility
+- `v0.29`: planned grid-domain feasibility
+- `v0.30`: planned orbit/action scope decision
+- `v0.31`: planned `v1.0` readiness hardening
 
 PDELie should remain a reusable library and validation/reporting substrate.
 It should not become a neural symmetry-detector training framework.
@@ -167,45 +182,311 @@ The completed scope freeze belongs in `V0_17_SCOPE.md`.
 
 ---
 
-## V0.18 Completed And V0.19+ Scoped PDE Expansion
+## V0.18 Completed And V0.19 Planned Advection-Diffusion
 
 `v0.18` completed the first scoped PDE expansion by adding the stable scalar 1D periodic Fisher-KPP reaction-diffusion strong path.
 
-Future planned theme:
+`v0.19` planned theme:
 
-> add another stable numerical axis only after the invariant/data-utility surface remains supportable.
+> add one safe transport-plus-diffusion PDE under the same scalar 1D periodic order-2 derivative regime.
 
-Preferred stable expansion:
+Candidate stable path:
 
-- advection-diffusion or another tightly scoped reaction-diffusion variant, because they are likely to fit the current scalar/structured-data contracts with less ambiguity than KS promotion
+```text
+canonical scalar 1D periodic FieldBatch
+-> spectral_fd u_t/u_x/u_xx
+-> constant-coefficient advection-diffusion residual
+-> translation fit/verification
+-> vertical-slice example
+```
 
-Alternative scoped expansion:
+Candidate equation:
 
-- KS residual-only, but only if the public claim explicitly excludes direct residual-based fitting recovery
+```text
+u_t + c*u_x = nu*u_xx
+residual = u_t + c*u_x - nu*u_xx
+```
 
-Deferred until separately frozen:
+Deferred from `v0.19`:
 
-- broad PDE zoo expansion
-- PDEBench or The Well adapters
+- variable coefficients
+- reaction-advection-diffusion
+- weak advection-diffusion
+- nonperiodic boundaries
+- custom initial-condition APIs
 - multidimensional grids
 - nonuniform grids
-- operator-facing APIs
-- weak KS
-- learned-generator training
 
-Each PDE expansion requires its own scope freeze and release-gate evidence.
+Like `v0.18`, `v0.19` should stop if direct residual-based fitting evidence is not in tolerance.
+
+---
+
+## V0.20 - Unified Generator Confidence Reports
+
+Planned theme:
+
+> promote the notebook confidence-card pattern into a public supportability/reporting helper.
+
+Candidate scope:
+
+- residual health summaries
+- fit conditioning and singular-value summaries
+- selected/SVD span evidence
+- finite-transform verification summaries
+- candidate-validation conclusions
+- orbit/coverage/consistency diagnostics
+- configured threshold interpretation
+
+Explicit boundaries:
+
+- no transformed `FieldBatch` collections from reporting helpers
+- no train/test policy
+- no downstream success policy
+- no mathematical-proof claim
+
+---
+
+## V0.21 - External Data Readiness Reports
+
+Planned theme:
+
+> make user-owned scalar 1D periodic data safer to bring into the stable runtime before broad adapters land.
+
+Candidate scope:
+
+- stronger `FieldBatch` audit reports
+- coordinate and grid diagnostics
+- metadata completeness diagnostics
+- finite-value, mask, scalar-var, and shape diagnostics
+- residual-evaluator compatibility preflight
+- conservative metadata inference for explicit, low-risk cases
+
+Deferred:
+
+- `xarray.Dataset` support
+- file-based dataset loaders
+- PDEBench and The Well adapters
+- multidimensional or nonuniform-grid ingestion
+
+---
+
+## V0.22 - Downstream Discovery Contracts
+
+Planned theme:
+
+> standardize downstream discovery reporting without becoming a full experiment-policy framework.
+
+Candidate scope:
+
+- broad downstream discovery contracts for runtime reports
+- recovery and provenance summary reports
+- backend-native bridge-output summaries
+- orbit-materialization provenance checks
+- paper-agnostic downstream templates
+
+Deferred:
+
+- general discovery-backend framework
+- manuscript thresholds
+- automatic experiment policy
+- backend lock-in beyond thin adapters
+
+---
+
+## V0.23 - Split/Leakage Provenance Diagnostics
+
+Planned theme:
+
+> reduce orbit-materialization misuse by reporting provenance risks across user-supplied partitions.
+
+Candidate scope:
+
+- train/heldout partition diagnostics
+- source/shift overlap reports
+- heldout-leakage risk reports
+
+Explicit boundaries:
+
+- no train/test split management
+- no automatic split generation
+- no downstream augmentation policy
+- no benchmark success criteria
+
+---
+
+## V0.24 - Weak-Form Supportability Reset
+
+Planned theme:
+
+> decide whether weak derivatives and broader weak-form methods can be promoted beyond the frozen `v0.8` weak residual report slice.
+
+Candidate scope:
+
+- weak derivative backend feasibility
+- broader weak-form residual contracts
+- weak reaction-diffusion feasibility
+- noisy/coarse-data supportability diagnostics
+
+Deferred unless separately proven:
+
+- weak KdV APIs
+- weak KS APIs
+- broad weak-form superiority claims
+
+---
+
+## V0.25 - KdV Scope Decision
+
+Planned theme:
+
+> decide whether KdV should remain frozen or expand beyond normalized periodic short-horizon support.
+
+Candidate decisions:
+
+- custom KdV initial conditions
+- configurable KdV coefficients
+- general KdV support outside the frozen normalized periodic short-horizon regime
+- weak KdV APIs
+
+Acceptable outcome:
+
+- keep KdV frozen and document why if the broader regime is not supportable.
+
+---
+
+## V0.26 - KS Revisit
+
+Planned theme:
+
+> revisit the `v0.11`/`v0.12` KS no-go with better confidence diagnostics.
+
+Candidate decisions:
+
+- stable KS data generator
+- stable KS residual evaluator
+- KS vertical-slice example
+- KS imported parity
+- weak KS API
+- root KS export
+- continued no-go/defer
+
+Default stance:
+
+- no root KS export
+- no weak KS
+- no stable full KS path unless direct residual-based fitting evidence improves
+
+---
+
+## V0.27 - Multi-Generator Feasibility
+
+Planned theme:
+
+> test whether the single-generator-centered runtime can support stable multi-generator workflows.
+
+Candidate scope:
+
+- stable multi-generator PDE fitting feasibility
+- multi-generator invariant machinery feasibility
+- closure/span/verification interactions for fitted families
+
+Boundary:
+
+- this is high-risk core machinery and should not be mixed with a PDE, adapter, or weak-form release.
+
+---
+
+## V0.28 - Data Ecosystem Feasibility
+
+Planned theme:
+
+> decide whether external data ecosystem support can widen without weakening canonical contracts.
+
+Candidate scope:
+
+- `xarray.Dataset` support
+- file-based dataset loaders
+- narrow adapter feasibility
+- metadata inference expansion
+
+Deferred unless scope is frozen:
+
+- PDEBench / The Well as stable APIs
+- broad adapter framework
+- implicit alias-based loaders
+
+---
+
+## V0.29 - Grid-Domain Feasibility
+
+Planned theme:
+
+> evaluate multidimensional and nonuniform-grid ingestion as a contract change.
+
+Candidate scope:
+
+- multidimensional ingestion feasibility
+- nonuniform-grid ingestion feasibility
+- resampling/reporting decisions
+- derivative/residual compatibility diagnostics for unsupported grids
+
+Default stance:
+
+- unsupported until a dedicated scope freeze proves the contracts.
+
+---
+
+## V0.30 - Orbit/Action Scope Decision
+
+Planned theme:
+
+> decide whether invariant actions should expand beyond frozen uniform spatial translation materialization.
+
+Candidate scope:
+
+- public orbit-view builders beyond the frozen materialized uniform translation orbit batch helper
+- transformed `FieldBatch` collection policy for explicit data/invariant APIs
+- time-translation APIs
+- `axis="time"` support
+
+Boundary:
+
+- reporting helpers remain report-only
+- transformed collections must not be returned from reporting helpers
+
+---
+
+## V0.31 - V1.0 Readiness Hardening
+
+Planned theme:
+
+> freeze the public engine before `v1.0`.
+
+Candidate scope:
+
+- public/private API audit
+- root export policy audit
+- deprecation policy
+- package publishing plan
+- docs and notebook consistency audit
+- release-gate consolidation
+- support matrix for stable PDEs, grids, residuals, candidate types, and downstream paths
 
 ---
 
 ## Relationship To V1.0
 
-These releases should move PDELie toward `v1.0` by improving supportability, provenance, and interoperability before increasing scientific scope too aggressively.
+These releases should move PDELie toward `v1.0` by improving supportability, provenance, interoperability, and scoped numerical coverage before freezing the public contract.
 
 The preferred sequence is:
 
 1. materialize finite translation orbits safely
 2. validate external symmetry candidates
 3. represent non-polynomial formulas
-4. only then widen stable PDE coverage
+4. widen stable PDE coverage one axis at a time
+5. consolidate confidence reporting
+6. harden external data and downstream reporting
+7. decide weak/KdV/KS/multi-generator/grid boundaries explicitly
+8. run a dedicated `v1.0` readiness hardening release
 
 Package-index publishing, broad adapters, and stable v1 API commitments remain deferred until a dedicated `v1.0` readiness milestone.

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -10,7 +10,7 @@ Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
 
 After `v0.14`, the highest-ROI path has been to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then formula-backed generator support, then carefully scoped PDE expansion.
 
-After `v0.18`, the next planned path is to add one safe transport PDE, consolidate confidence reporting, harden external-data readiness, and only then consider more difficult axes such as weak forms, broader KdV/KS, multi-generator fitting, broad adapters, multidimensional/nonuniform grids, and time-translation actions.
+After `v0.19`, the next planned path is to consolidate confidence reporting, harden external-data readiness, and only then consider more difficult axes such as weak forms, broader KdV/KS, multi-generator fitting, broad adapters, multidimensional/nonuniform grids, and time-translation actions.
 
 Staged sequence:
 
@@ -18,7 +18,7 @@ Staged sequence:
 - `v0.16`: external symmetry-candidate interop and validation
 - `v0.17`: formula-backed generator families
 - `v0.18`: stable Fisher-KPP reaction-diffusion strong path
-- `v0.19`: planned advection-diffusion strong path
+- `v0.19`: stable advection-diffusion strong path
 - `v0.20`: planned unified generator confidence reports
 - `v0.21`: planned external data readiness reports
 - `v0.22`: planned downstream discovery contracts
@@ -182,15 +182,15 @@ The completed scope freeze belongs in `V0_17_SCOPE.md`.
 
 ---
 
-## V0.18 Completed And V0.19 Planned Advection-Diffusion
+## V0.18 And V0.19 Completed PDE Expansion
 
 `v0.18` completed the first scoped PDE expansion by adding the stable scalar 1D periodic Fisher-KPP reaction-diffusion strong path.
 
-`v0.19` planned theme:
+`v0.19` completed the second scoped PDE expansion:
 
 > add one safe transport-plus-diffusion PDE under the same scalar 1D periodic order-2 derivative regime.
 
-Candidate stable path:
+Completed stable path:
 
 ```text
 canonical scalar 1D periodic FieldBatch
@@ -200,14 +200,14 @@ canonical scalar 1D periodic FieldBatch
 -> vertical-slice example
 ```
 
-Candidate equation:
+Frozen equation:
 
 ```text
 u_t + c*u_x = nu*u_xx
 residual = u_t + c*u_x - nu*u_xx
 ```
 
-Deferred from `v0.19`:
+Deferred after `v0.19`:
 
 - variable coefficients
 - reaction-advection-diffusion
@@ -217,7 +217,7 @@ Deferred from `v0.19`:
 - multidimensional grids
 - nonuniform grids
 
-Like `v0.18`, `v0.19` should stop if direct residual-based fitting evidence is not in tolerance.
+Like `v0.18`, `v0.19` shipped only because direct residual-based fitting evidence was in tolerance.
 
 ---
 

--- a/docs/planning/V0_19_SCOPE.md
+++ b/docs/planning/V0_19_SCOPE.md
@@ -1,0 +1,161 @@
+# V0.19 Scope - Stable Advection-Diffusion Strong Path
+
+**Status:** COMPLETE
+
+`v0.19` is a narrow PDE-expansion release for one stable scalar 1D periodic constant-coefficient advection-diffusion path.
+
+Stable path:
+
+```text
+canonical scalar 1D periodic FieldBatch
+-> spectral_fd derivatives
+-> advection-diffusion residual
+-> translation fit/verification
+-> vertical-slice summary/example
+```
+
+## Summary
+
+`v0.19` adds a deterministic synthetic advection-diffusion generator, a strong-form residual evaluator, and a compact JSON-only vertical-slice example.
+
+Chosen equation:
+
+```text
+u_t + c*u_x = nu*u_xx
+residual = u_t + c*u_x - nu*u_xx
+```
+
+This release stays inside the existing safe numerical regime:
+
+- scalar 1D uniform periodic fields
+- synthetic data only
+- default order-2 `spectral_fd` derivatives
+- polynomial translation generator fitting
+- finite uniform translation verification
+- no root export expansion
+
+## Public APIs
+
+Submodule-only APIs added:
+
+- `pdelie.data.generate_advection_diffusion_1d_field_batch(...)`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)`
+
+Command example:
+
+```bash
+python -m pdelie.examples.advection_diffusion_vertical_slice
+```
+
+No root `pdelie` exports were added.
+
+## Frozen Semantics
+
+Generated fields are canonical `FieldBatch` objects with:
+
+- dims `("batch", "time", "x", "var")`
+- scalar variable name `u`
+- endpoint-excluded uniform periodic `x`
+- uniformly increasing `time`
+- finite unmasked values
+- `field.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"`
+- `field.metadata["parameter_tags"]["c"]`
+- `field.metadata["parameter_tags"]["nu"]`
+
+Frozen defaults:
+
+- `batch_size = 5`
+- `num_times = 65`
+- `num_points = 64`
+- `max_time = 0.4`
+- `advection_speed = 0.75`
+- `diffusivity = 0.05`
+- `num_modes = 6`
+- `amplitude = 0.2`
+- `domain_length = 2*pi`
+- `seed = 0`
+
+Generator rollout is exact periodic Fourier evolution with multiplier:
+
+```text
+exp((-nu*k**2 - 1j*c*k) * t)
+```
+
+The residual evaluator:
+
+- evaluates `u_t + c*u_x - nu*u_xx`
+- computes `compute_spectral_fd_derivatives(field)` when derivatives are omitted
+- requires supplied derivatives to include `u_t`, `u_x`, and `u_xx`
+- accepts finite signed `c`
+- requires finite positive `nu`
+- validates scalar 1D periodic finite unmasked fields and the frozen equation tag
+
+Mean drift is diagnostic-only. Periodic constant-coefficient advection-diffusion preserves the mean analytically, while numerical summaries use it only as a smoke diagnostic.
+
+## Promotion Evidence
+
+Frozen vertical-slice configuration:
+
+- generator seed: `19018`
+- train/heldout split: `split_batch_train_heldout(field, train_size=2, seed=19019)`
+- fit epsilon: `1e-4`
+
+Observed evidence:
+
+- residual max: approximately `5.51e-5`
+- residual RMS: approximately `8.44e-6`
+- fit mode: `svd`
+- evidence label: `direct_svd_in_tolerance`
+- reference fallback: `false`
+- selected/SVD span distance: approximately `7.87e-4`
+- verification classification: `exact`
+- first held-out verification error: approximately `7.87e-8`
+
+This satisfies the promotion gate. No fallback-backed advection-diffusion claim landed.
+
+## Non-goals
+
+`v0.19` explicitly does not add:
+
+- variable-coefficient advection-diffusion
+- reaction-advection-diffusion
+- weak advection-diffusion
+- custom advection-diffusion initial-condition APIs
+- multidimensional or nonuniform-grid ingestion
+- broad PDEBench / The Well adapters
+- time-translation APIs or `axis="time"` support
+- stable KS data generator, residual evaluator, vertical-slice example, imported parity, weak KS API, or root KS export
+- neural or callable generator APIs
+- operator-facing symmetry APIs
+- train/test split management, heldout-leakage detection, or downstream augmentation policy
+- transformed `FieldBatch` collections from reporting helpers
+- root export expansion
+
+## Milestone Status
+
+- Milestone 0: COMPLETE
+- Milestone 1: COMPLETE
+- Milestone 2: COMPLETE
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
+- Milestone 6: COMPLETE
+
+## Release Gate Expectations
+
+The current explicit CI release gate is `v0_19-release-gate`.
+
+Required checks before tagging:
+
+- `v0_19-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+Local validation should include:
+
+- `python -m pytest`
+- `python -m build --sdist --wheel`
+- clean wheel smoke from `dist/pdelie-0.19.0-py3-none-any.whl`
+- packaged examples, including `python -m pdelie.examples.advection_diffusion_vertical_slice`
+- `git diff --check`

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.18.0`, release completion means:
+For the current `v0.x` series, including `v0.19.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.18.0` is intentionally a Git-tag-only release.
-Do not run TestPyPI or PyPI publishing for `v0.18`.
+`v0.19.0` is intentionally a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.19`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_19_RELEASE_READINESS.md
+++ b/docs/releases/V0_19_RELEASE_READINESS.md
@@ -1,0 +1,127 @@
+# V0.19 Release Readiness
+
+- package version: `0.19.0`
+- git tag: `v0.19.0`
+- publishing mode: Git tag only
+
+`v0.19.0` is a Git-tag-only release.
+Do not run TestPyPI or PyPI publishing for `v0.19`.
+
+## Release Summary
+
+`v0.19` closes as the stable constant-coefficient advection-diffusion strong-path release.
+
+Public submodule-only APIs:
+
+- `pdelie.data.generate_advection_diffusion_1d_field_batch(...)`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)`
+
+Frozen equation:
+
+```text
+u_t + c*u_x = nu*u_xx
+residual = u_t + c*u_x - nu*u_xx
+```
+
+Frozen metadata tag:
+
+- `field.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"`
+
+## Milestone Summary
+
+- M0: scope freeze for the constant-coefficient advection-diffusion path
+- M1: equation, exact Fourier rollout, defaults, metadata, diagnostics, and thresholds frozen
+- M2: deterministic synthetic generator implemented
+- M3: strong-form residual evaluator implemented
+- M4: direct-SVD vertical slice and JSON-only example implemented
+- M5: API/public-surface audit completed
+- M6: release gate, metadata, docs, and readiness aligned
+
+## Observed Vertical-slice Evidence
+
+Frozen fixture:
+
+- residual max: approximately `5.51e-5`
+- residual RMS: approximately `8.44e-6`
+- fit mode: `svd`
+- evidence label: `direct_svd_in_tolerance`
+- reference fallback: `false`
+- selected/SVD span distance: approximately `7.87e-4`
+- held-out verification classification: `exact`
+- first held-out verification error: approximately `7.87e-8`
+
+Mean drift is diagnostic-only. The equation preserves mean analytically under periodic constant coefficients, but release evidence does not promote a separate invariant API.
+
+## Explicit Non-goals
+
+`v0.19` does not add:
+
+- variable-coefficient advection-diffusion
+- reaction-advection-diffusion
+- weak advection-diffusion
+- public custom initial-condition APIs
+- KS runtime promotion
+- broad dataset adapters
+- PDEBench / The Well loaders
+- multidimensional or nonuniform support
+- time-translation APIs
+- neural or callable generator APIs
+- operator-facing APIs
+- train/test policy or split-management utilities
+- root exports
+
+## Required CI Checks
+
+Before tagging, require:
+
+- `v0_19-release-gate`
+- `editable-tests`
+- `package-smoke`
+
+## Local Validation Checklist
+
+Before tagging `v0.19.0`, run:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.reaction_diffusion_vertical_slice
+python -m pdelie.examples.advection_diffusion_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
+python -m pdelie.examples.symmetry_candidate_validation
+python -m pdelie.examples.formula_generator_validation
+git diff --check
+```
+
+Clean wheel smoke should install:
+
+- `dist/pdelie-0.19.0-py3-none-any.whl`
+
+and verify:
+
+- stable root imports
+- retained reporting, invariant, orbit-batch, candidate-validation, formula-backed, and Fisher-KPP APIs
+- `pdelie.data.generate_advection_diffusion_1d_field_batch`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example`
+- one tiny advection-diffusion residual smoke
+- no root advection-diffusion exports
+- no weak advection-diffusion, variable-coefficient advection-diffusion, KS, broad adapter, custom-IC, time-translation, or operator surface
+
+## Direct Tag Procedure
+
+After the PR merges and required checks are green:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag v0.19.0
+git push origin v0.19.0
+```
+
+Do not publish to TestPyPI or PyPI for `v0.19.0`.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -215,6 +215,20 @@ Runtime public API for the frozen `v0.18` Milestone 2/M3/M4 slice:
 - the stable public claim covers the frozen scalar 1D periodic synthetic Fisher-KPP path with direct SVD translation-fit evidence; it does not add advection-diffusion, KS promotion, weak reaction-diffusion, custom initial-condition APIs, broad adapters, multidimensional or nonuniform support, split policy, neural/callable generators, or operator-facing APIs
 - these APIs have no root `pdelie` exports
 
+Runtime public API for the frozen `v0.19` Milestone 2/M3/M4 slice:
+
+- `pdelie.data.generate_advection_diffusion_1d_field_batch` for deterministic synthetic scalar 1D periodic constant-coefficient advection-diffusion fields under the frozen `v0.19` generator regime
+- stable generated fields use `field.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"` and include the frozen `c` / `nu` parameter tags
+- this generator has no public custom initial-condition API in `v0.19`; it emits zero-mean smooth Fourier-mode initial perturbations inside the frozen synthetic regime
+- generated fields use exact periodic Fourier evolution for `u_t + c*u_x = nu*u_xx`
+- `pdelie.residuals.AdvectionDiffusionResidualEvaluator` for strong-form residuals `u_t + c*u_x - nu*u_xx = 0`
+- when derivatives are omitted, the evaluator computes the existing default `compute_spectral_fd_derivatives(field)` order-2 derivative path
+- when derivatives are supplied, they must validate against the field and include `u_t`, `u_x`, and `u_xx`
+- stable inputs must be canonical scalar 1D uniform periodic finite unmasked `FieldBatch` objects with the frozen advection-diffusion equation tag
+- `pdelie.examples.run_advection_diffusion_vertical_slice_example` for a compact JSON-only runtime smoke example that emits the existing nested `summarize_vertical_slice(...)` summary shape
+- the stable public claim covers the frozen scalar 1D periodic synthetic constant-coefficient advection-diffusion path with direct SVD translation-fit evidence; it does not add variable-coefficient advection-diffusion, reaction-advection-diffusion, weak advection-diffusion, custom initial-condition APIs, public KS runtime APIs, broad adapters, multidimensional or nonuniform support, time translation, split policy, neural/callable generators, or operator-facing APIs
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -17,7 +17,7 @@ It is a **library**, not a project repo.
 - uniform rectilinear grids
 - Lie point symmetries
 - polynomial generator parameterizations
-- synthetic + small benchmark PDEs, currently including Heat, Burgers, normalized short-horizon KdV, and frozen scalar 1D Fisher-KPP reaction-diffusion strong paths
+- synthetic + small benchmark PDEs, currently including Heat, Burgers, normalized short-horizon KdV, frozen scalar 1D Fisher-KPP reaction-diffusion, and frozen scalar 1D constant-coefficient advection-diffusion strong paths
 
 ## Experimental
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -16,13 +16,18 @@ It is a **library**, not a project repo.
 
 - uniform rectilinear grids
 - Lie point symmetries
-- polynomial generator parameterizations
+- canonical polynomial `GeneratorFamily` parameterizations
+- runtime-only formula-backed generator records and empirical candidate-validation reports
+- frozen invariant, reporting, uniform-translation orbit, and materialized-orbit utilities
 - synthetic + small benchmark PDEs, currently including Heat, Burgers, normalized short-horizon KdV, frozen scalar 1D Fisher-KPP reaction-diffusion, and frozen scalar 1D constant-coefficient advection-diffusion strong paths
 
 ## Experimental
 
 - neural generators
+- Python-callable generators and executable formula strings
 - weak-form derivatives and weak-form extensions beyond the frozen `v0.8` weak residual report slice
+- broad dataset adapters, file-based dataset loaders, and Dataset-level ingestion
+- multidimensional, multivariable, and nonuniform-grid stable expansion
 - operator-level symmetry discovery
 - multi-generator invariant charts
 

--- a/notebooks/00_pde_timeseries_to_generators.ipynb
+++ b/notebooks/00_pde_timeseries_to_generators.ipynb
@@ -7,18 +7,18 @@
    "source": [
     "# PDE time series to generators with confidence\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",
-    "Quickstart for the V0.18 surface: start from a canonical PDE time series, compute derivatives and residuals, fit a translation generator, verify it on held-out data, and read the confidence evidence.\n",
+    "Quickstart for the V0.19 surface: start from a canonical PDE time series, compute derivatives and residuals, fit a translation generator, verify it on held-out data, and read the confidence evidence.\n",
     "\n",
     "## What you will learn\n",
     "\n",
     "- How `FieldBatch`, `DerivativeBatch`, `ResidualBatch`, `GeneratorFamily`, and `VerificationReport` fit together.\n",
     "- How metadata tags keep residual evaluators honest.\n",
     "- How direct SVD evidence, fallback status, span distance, and verification errors should be read together.\n",
-    "- How the same pipeline covers Heat and the V0.18 Fisher-KPP reaction-diffusion strong path.\n",
+    "- How the same pipeline covers Heat, Fisher-KPP reaction-diffusion, and the V0.19 advection-diffusion strong path.\n",
     "\n",
     "## Required extras\n",
     "\n",
@@ -198,7 +198,7 @@
    "source": [
     "## 4. Same workflow, Fisher-KPP reaction-diffusion\n",
     "\n",
-    "V0.18 adds one safer PDE expansion: scalar 1D periodic Fisher-KPP reaction-diffusion. It uses the existing order-2 derivative backend and ships only because the frozen fixture has direct SVD translation evidence, not reference-fallback evidence."
+    "V0.18 added the scalar 1D periodic Fisher-KPP reaction-diffusion path, and V0.19 adds a similarly scoped constant-coefficient advection-diffusion path. Both use the existing order-2 derivative backend and ship only with direct SVD translation evidence, not reference-fallback evidence."
    ]
   },
   {
@@ -245,7 +245,7 @@
    "source": [
     "## Recap\n",
     "\n",
-    "You saw the core V0.18 flow: canonical field, derivatives, residual, fitted translation generator, held-out verification, and a compact confidence card.\n",
+    "You saw the core V0.19 flow: canonical field, derivatives, residual, fitted translation generator, held-out verification, and a compact confidence card.\n",
     "\n",
     "## Common pitfalls\n",
     "\n",

--- a/notebooks/01_raw_vs_translation_canonical_discovery.ipynb
+++ b/notebooks/01_raw_vs_translation_canonical_discovery.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Raw vs translation-canonical discovery inputs\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/02_robustness_sweeps.ipynb
+++ b/notebooks/02_robustness_sweeps.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Robustness sweeps as diagnostic evidence\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/03_portability_round_trips.ipynb
+++ b/notebooks/03_portability_round_trips.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Portability round-trips with empirical revalidation\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",
@@ -102,7 +102,7 @@
    "source": [
     "manifest = export_generator_family_manifest(\n",
     "    generator,\n",
-    "    pdelie_version=\"tutorial-v0.18\",\n",
+    "    pdelie_version=\"tutorial-v0.19\",\n",
     "    provenance={\"notebook\": \"03_portability_round_trips\"},\n",
     ")\n",
     "imported = import_generator_family_manifest(manifest)\n",

--- a/notebooks/04_discovered_vs_known_translation_generators.ipynb
+++ b/notebooks/04_discovered_vs_known_translation_generators.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Comparing fitted, finite-map, formula-backed, and failed candidates\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/05_closure_algebra_diagnostics.ipynb
+++ b/notebooks/05_closure_algebra_diagnostics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Closure algebra diagnostics and formula metadata\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/06_orbit_coverage_diagnostics.ipynb
+++ b/notebooks/06_orbit_coverage_diagnostics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Orbit, coverage, and materialized translation batches\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/07_external_symmetry_candidates.ipynb
+++ b/notebooks/07_external_symmetry_candidates.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# External and formula-backed symmetry candidates\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/08_downstream_task_template.ipynb
+++ b/notebooks/08_downstream_task_template.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Downstream task template: symmetry-aware inputs without paper policy\n",
     "\n",
-    "**Current surface:** V0.18.\n",
+    "**Current surface:** V0.19.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,6 @@
 # PDELie Tutorial Notebooks
 
-This directory is the recommended entry point for new PDELie users on the shipped `v0.18` surface.
+This directory is the recommended entry point for new PDELie users on the shipped `v0.19` surface.
 
 Tutorial promise:
 
@@ -27,7 +27,7 @@ These notebooks are tutorials, not API contracts. Example outputs are runtime su
 
 - Converting supported arrays into canonical `FieldBatch` objects.
 - Computing `spectral_fd` derivatives on uniform periodic 1D grids.
-- Evaluating strong residuals for the stable Heat, Burgers, KdV, and Fisher-KPP paths.
+- Evaluating strong residuals for the stable Heat, Burgers, KdV, Fisher-KPP, and advection-diffusion paths.
 - Fitting and validating polynomial translation generators in the stable slice.
 - Producing JSON-compatible residual, fit, verification, invariant, orbit, candidate, and formula summaries.
 - Auditing finite uniform x-translation workflows with coverage, consistency, and provenance reports.
@@ -42,9 +42,9 @@ These notebooks are tutorials, not API contracts. Example outputs are runtime su
 - Not a train/test split manager or leakage detector.
 - Not an operator-learning framework.
 - Not a paper-specific experiment pipeline.
-- Not a general nonuniform or multidimensional PDE framework in `v0.18`.
+- Not a general nonuniform or multidimensional PDE framework in `v0.19`.
 
-KS remains internal feasibility/no-go evidence. `v0.19` advection-diffusion is only a roadmap direction and is not implemented here.
+KS remains internal feasibility/no-go evidence. `v0.19` advection-diffusion is implemented only as a frozen scalar 1D periodic constant-coefficient strong path.
 
 ## Installation
 
@@ -83,7 +83,7 @@ Jupyter itself is not a core runtime dependency. Install notebook tooling in you
 
 | Notebook | Main concept | Required extras | Est. runtime | Stable APIs used | Out-of-scope warnings |
 | --- | --- | --- | --- | --- | --- |
-| `00_pde_timeseries_to_generators.ipynb` | Heat and Fisher-KPP quickstart: field, derivatives, residual, fit, verify, confidence card | `.[viz]` or `.[test]` for plots | 1-2 min | `FieldBatch`, `compute_spectral_fd_derivatives`, Heat/Fisher-KPP residuals, `summarize_vertical_slice` | no proof, no KS, no weak form |
+| `00_pde_timeseries_to_generators.ipynb` | Heat, Fisher-KPP, and advection-diffusion quickstart: field, derivatives, residual, fit, verify, confidence card | `.[viz]` or `.[test]` for plots | 1-2 min | `FieldBatch`, `compute_spectral_fd_derivatives`, Heat/Fisher-KPP/advection-diffusion residuals, `summarize_vertical_slice` | no proof, no KS, no weak form |
 | `01_raw_vs_translation_canonical_discovery.ipynb` | Raw vs translation-canonical discovery inputs plus orbit-batch contrast | `.[downstream]` or `.[test]` | ~1 min | discovery bridge, coverage diagnostics, orbit batch builder | not a benchmark, no split/leakage policy |
 | `02_robustness_sweeps.ipynb` | Noise/subsampling/fit-epsilon diagnostics | `.[viz]` or `.[test]` | 1-2 min | robustness helpers, fit diagnostics, verification summaries | no robustness guarantee |
 | `03_portability_round_trips.ipynb` | Generator manifest export/import and empirical revalidation | core | <1 min | portability helpers, `validate_symmetry_candidate` | serialization is not scientific validity |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.18.0"
-description = "V0.18 Fisher-KPP reaction-diffusion strong path plus retained Heat/Burgers/weak-report/KdV and symmetry diagnostics"
+version = "0.19.0"
+description = "V0.19 advection-diffusion strong path plus retained Heat/Burgers/weak-report/KdV/Fisher-KPP and symmetry diagnostics"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/scripts/check_notebooks.py
+++ b/scripts/check_notebooks.py
@@ -68,8 +68,8 @@ def main() -> None:
                 failures.append(f"{path}: missing '{phrase}'")
         if not any(phrase in text for phrase in REQUIRED_SCOPE_PHRASES):
             failures.append(f"{path}: missing 'Out of scope' or 'Limitations'")
-        if "V0.18" not in text and "v0.18" not in text:
-            failures.append(f"{path}: should mention current V0.18 surface")
+        if "V0.19" not in text and "v0.19" not in text:
+            failures.append(f"{path}: should mention current V0.19 surface")
         for marker in STALE_MARKERS:
             if marker in text:
                 failures.append(f"{path}: stale marker '{marker}'")

--- a/src/pdelie/data/__init__.py
+++ b/src/pdelie/data/__init__.py
@@ -1,3 +1,4 @@
+from pdelie.data.advection_diffusion_1d import generate_advection_diffusion_1d_field_batch
 from pdelie.data.burgers_1d import generate_burgers_1d_field_batch
 from pdelie.data.heat_1d import (
     evaluate_heat_fourier_series,
@@ -19,6 +20,7 @@ __all__ = [
     "add_gaussian_noise",
     "from_numpy",
     "from_xarray",
+    "generate_advection_diffusion_1d_field_batch",
     "generate_burgers_1d_field_batch",
     "generate_kdv_1d_field_batch",
     "generate_reaction_diffusion_1d_field_batch",

--- a/src/pdelie/data/advection_diffusion_1d.py
+++ b/src/pdelie/data/advection_diffusion_1d.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie.contracts import FieldBatch
+from pdelie.data.heat_1d import DEFAULT_DOMAIN_LENGTH as _DEFAULT_DOMAIN_LENGTH
+from pdelie.errors import SchemaValidationError, ScopeValidationError, ShapeValidationError
+
+
+__all__ = ["generate_advection_diffusion_1d_field_batch"]
+
+
+DEFAULT_ADVECTION_DIFFUSION_EQUATION = "advection_diffusion_constant_coefficient"
+DEFAULT_ADVECTION_DIFFUSION_SPEED = 0.75
+DEFAULT_ADVECTION_DIFFUSION_DIFFUSIVITY = 0.05
+
+
+def _validate_integer_like(value: object, *, name: str, minimum: int | None = None) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise SchemaValidationError(f"{name} must be an integer.")
+    normalized = int(value)
+    if minimum is not None and normalized < minimum:
+        raise SchemaValidationError(f"{name} must be at least {minimum}.")
+    return normalized
+
+
+def _validate_finite_float(value: object, *, name: str, positive: bool, nonnegative: bool = False) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise SchemaValidationError(f"{name} must be a finite scalar.")
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite scalar.") from exc
+    if not np.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be a finite scalar.")
+    if positive and normalized <= 0.0:
+        raise SchemaValidationError(f"{name} must be positive.")
+    if nonnegative and normalized < 0.0:
+        raise SchemaValidationError(f"{name} must be nonnegative.")
+    return normalized
+
+
+def _sample_mode_coefficients(
+    *,
+    batch_size: int,
+    num_modes: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    mode_scale = 1.0 / np.arange(1, num_modes + 1, dtype=float)
+    cosine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    sine = rng.normal(size=(batch_size, num_modes)) * mode_scale
+    return cosine, sine
+
+
+def _evaluate_zero_mean_fourier_initial_condition(
+    *,
+    x: np.ndarray,
+    domain_length: float,
+    cosine_coefficients: np.ndarray,
+    sine_coefficients: np.ndarray,
+    amplitude: float,
+) -> np.ndarray:
+    x = np.asarray(x, dtype=float)
+    cosine_coefficients = np.asarray(cosine_coefficients, dtype=float)
+    sine_coefficients = np.asarray(sine_coefficients, dtype=float)
+
+    if cosine_coefficients.shape != sine_coefficients.shape:
+        raise ShapeValidationError("cosine_coefficients and sine_coefficients must match.")
+    if cosine_coefficients.ndim != 2:
+        raise ShapeValidationError("Coefficient arrays must have shape (batch, num_modes).")
+
+    modes = np.arange(1, cosine_coefficients.shape[1] + 1, dtype=float)
+    phase = (2.0 * np.pi / float(domain_length)) * x
+    spatial_cos = np.cos(np.outer(modes, phase))
+    spatial_sin = np.sin(np.outer(modes, phase))
+    values = np.sum(
+        cosine_coefficients[:, :, None] * spatial_cos[None, :, :]
+        + sine_coefficients[:, :, None] * spatial_sin[None, :, :],
+        axis=1,
+    )
+    max_abs = np.maximum(np.max(np.abs(values), axis=1, keepdims=True), 1e-12)
+    return float(amplitude) * values / max_abs
+
+
+def _rollout_advection_diffusion_periodic(
+    initial_values: np.ndarray,
+    *,
+    output_times: np.ndarray,
+    domain_length: float,
+    advection_speed: float,
+    diffusivity: float,
+) -> np.ndarray:
+    initial_values = np.asarray(initial_values, dtype=float)
+    output_times = np.asarray(output_times, dtype=float)
+
+    if initial_values.ndim != 2:
+        raise ShapeValidationError("initial_values must have shape (batch, x).")
+    if output_times.ndim != 1 or output_times.size < 2:
+        raise ShapeValidationError("output_times must be one-dimensional with at least two entries.")
+    if not np.all(np.isfinite(initial_values)) or not np.all(np.isfinite(output_times)):
+        raise ShapeValidationError("initial_values and output_times must be finite.")
+
+    dx = float(domain_length / initial_values.shape[-1])
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(initial_values.shape[-1], d=dx)
+    spectrum0 = np.fft.fft(initial_values, axis=-1)
+    rate = -float(diffusivity) * wavenumbers**2 - 1j * float(advection_speed) * wavenumbers
+    multipliers = np.exp(output_times[:, None] * rate[None, :])
+    spectrum = spectrum0[:, None, :] * multipliers[None, :, :]
+    return np.real(np.fft.ifft(spectrum, axis=-1))
+
+
+def generate_advection_diffusion_1d_field_batch(
+    *,
+    batch_size: int = 5,
+    num_times: int = 65,
+    num_points: int = 64,
+    max_time: float = 0.4,
+    advection_speed: float = DEFAULT_ADVECTION_DIFFUSION_SPEED,
+    diffusivity: float = DEFAULT_ADVECTION_DIFFUSION_DIFFUSIVITY,
+    num_modes: int = 6,
+    amplitude: float = 0.2,
+    domain_length: float = _DEFAULT_DOMAIN_LENGTH,
+    seed: int = 0,
+) -> FieldBatch:
+    normalized_batch_size = _validate_integer_like(batch_size, name="batch_size", minimum=1)
+    normalized_num_times = _validate_integer_like(num_times, name="num_times", minimum=3)
+    normalized_num_points = _validate_integer_like(num_points, name="num_points", minimum=16)
+    normalized_num_modes = _validate_integer_like(num_modes, name="num_modes", minimum=1)
+    normalized_seed = _validate_integer_like(seed, name="seed", minimum=0)
+    normalized_max_time = _validate_finite_float(max_time, name="max_time", positive=True)
+    normalized_advection_speed = _validate_finite_float(advection_speed, name="advection_speed", positive=False)
+    normalized_diffusivity = _validate_finite_float(diffusivity, name="diffusivity", positive=True)
+    normalized_amplitude = _validate_finite_float(amplitude, name="amplitude", positive=False, nonnegative=True)
+    normalized_domain_length = _validate_finite_float(domain_length, name="domain_length", positive=True)
+
+    max_modes = normalized_num_points // 3
+    if normalized_num_modes > max_modes:
+        raise ScopeValidationError("num_modes must be no greater than floor(num_points / 3).")
+    if normalized_amplitude > 1.0:
+        raise ScopeValidationError("amplitude must be no greater than 1.0 for the frozen advection-diffusion fixture.")
+
+    x = np.linspace(0.0, normalized_domain_length, normalized_num_points, endpoint=False, dtype=float)
+    t = np.linspace(0.0, normalized_max_time, normalized_num_times, dtype=float)
+    cosine, sine = _sample_mode_coefficients(
+        batch_size=normalized_batch_size,
+        num_modes=normalized_num_modes,
+        seed=normalized_seed,
+    )
+    initial_values = _evaluate_zero_mean_fourier_initial_condition(
+        x=x,
+        domain_length=normalized_domain_length,
+        cosine_coefficients=cosine,
+        sine_coefficients=sine,
+        amplitude=normalized_amplitude,
+    )
+    values = _rollout_advection_diffusion_periodic(
+        initial_values,
+        output_times=t,
+        domain_length=normalized_domain_length,
+        advection_speed=normalized_advection_speed,
+        diffusivity=normalized_diffusivity,
+    )
+
+    return FieldBatch(
+        values=values[..., None],
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_names=["u"],
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {
+                "equation": DEFAULT_ADVECTION_DIFFUSION_EQUATION,
+                "c": normalized_advection_speed,
+                "nu": normalized_diffusivity,
+            },
+        },
+        preprocess_log=[],
+    )

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "run_advection_diffusion_vertical_slice_example",
     "run_heat_vertical_slice_example",
     "run_formula_generator_validation_example",
     "run_invariant_workflow_summary_example",
@@ -8,6 +9,14 @@ __all__ = [
     "run_symmetry_candidate_validation_example",
     "run_translation_orbit_batch_example",
 ]
+
+
+def run_advection_diffusion_vertical_slice_example() -> dict[str, object]:
+    from pdelie.examples.advection_diffusion_vertical_slice import (
+        run_advection_diffusion_vertical_slice_example as _impl,
+    )
+
+    return _impl()
 
 
 def run_formula_generator_validation_example() -> dict[str, object]:

--- a/src/pdelie/examples/advection_diffusion_vertical_slice.py
+++ b/src/pdelie/examples/advection_diffusion_vertical_slice.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie.data import generate_advection_diffusion_1d_field_batch, split_batch_train_heldout
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.reporting import summarize_vertical_slice
+from pdelie.residuals import AdvectionDiffusionResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+
+
+_GENERATOR_SEED = 19018
+_BATCH_SIZE = 5
+_TRAIN_SIZE = 2
+_SPLIT_SEED = 19019
+
+
+def _mean_and_l2_drift(values: np.ndarray, *, dx: float) -> tuple[float, float]:
+    values = np.asarray(values[..., 0], dtype=float)
+    mean = dx * np.sum(values, axis=-1)
+    l2 = np.sqrt(dx * np.sum(np.square(values), axis=-1))
+    mean_drift = np.max(np.abs(mean - mean[:, [0]]))
+    relative_l2_drift = np.max(np.abs(l2 - l2[:, [0]]) / np.maximum(np.abs(l2[:, [0]]), 1e-12))
+    return float(mean_drift), float(relative_l2_drift)
+
+
+def run_advection_diffusion_vertical_slice_example() -> dict[str, object]:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=_BATCH_SIZE, seed=_GENERATOR_SEED)
+    dx = float(field.coords["x"][1] - field.coords["x"][0])
+    mean_drift, relative_l2_drift = _mean_and_l2_drift(field.values, dx=dx)
+    training, heldout = split_batch_train_heldout(field, train_size=_TRAIN_SIZE, seed=_SPLIT_SEED)
+
+    derivatives = compute_spectral_fd_derivatives(training)
+    residual_evaluator = AdvectionDiffusionResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    report = verify_translation_generator(heldout, generator, residual_evaluator)
+
+    return summarize_vertical_slice(
+        derivatives=derivatives,
+        residual=residual,
+        generator=generator,
+        verification=report,
+        extra_metrics={
+            "example_name": "advection_diffusion_vertical_slice",
+            "equation": "advection_diffusion_constant_coefficient",
+            "generator_seed": _GENERATOR_SEED,
+            "batch_size": _BATCH_SIZE,
+            "split_seed": _SPLIT_SEED,
+            "train_size": _TRAIN_SIZE,
+            "mean_drift_diagnostic": mean_drift,
+            "relative_l2_drift_diagnostic": relative_l2_drift,
+        },
+    )
+
+
+def main() -> None:
+    print(json.dumps(run_advection_diffusion_vertical_slice_example(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/residuals/__init__.py
+++ b/src/pdelie/residuals/__init__.py
@@ -1,3 +1,4 @@
+from pdelie.residuals.advection_diffusion_1d import AdvectionDiffusionResidualEvaluator
 from pdelie.residuals.burgers_1d import BurgersResidualEvaluator
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.residuals.heat_1d import HeatResidualEvaluator
@@ -6,6 +7,7 @@ from pdelie.residuals.reaction_diffusion_1d import ReactionDiffusionResidualEval
 from pdelie.residuals.weak_1d import evaluate_weak_burgers_residual, evaluate_weak_heat_residual
 
 __all__ = [
+    "AdvectionDiffusionResidualEvaluator",
     "BurgersResidualEvaluator",
     "HeatResidualEvaluator",
     "KdVResidualEvaluator",

--- a/src/pdelie/residuals/advection_diffusion_1d.py
+++ b/src/pdelie/residuals/advection_diffusion_1d.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+
+from pdelie.contracts import DerivativeBatch, FieldBatch, ResidualBatch
+from pdelie.data.advection_diffusion_1d import DEFAULT_ADVECTION_DIFFUSION_EQUATION
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.residuals.base import ResidualEvaluator
+
+
+_ADVECTION_DIFFUSION_EQUATION = "u_t + c*u_x - nu*u_xx = 0"
+_REQUIRED_DERIVATIVES = ("u_t", "u_x", "u_xx")
+
+
+def _finite_parameter(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise SchemaValidationError(f"{name} must be a finite scalar.")
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite scalar.") from exc
+    if not np.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be a finite scalar.")
+    return normalized
+
+
+def _finite_positive_parameter(value: object, *, name: str) -> float:
+    normalized = _finite_parameter(value, name=name)
+    if normalized <= 0.0:
+        raise SchemaValidationError(f"{name} must be a finite positive scalar.")
+    return normalized
+
+
+def _validate_advection_diffusion_field(field: FieldBatch) -> Mapping[str, object]:
+    field.validate()
+
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError(
+            "AdvectionDiffusionResidualEvaluator only supports dims ('batch', 'time', 'x', 'var')."
+        )
+    if len(field.var_names) != 1 or field.values.shape[-1] != 1:
+        raise ScopeValidationError("AdvectionDiffusionResidualEvaluator only supports scalar FieldBatch inputs.")
+    if field.mask is not None:
+        raise ScopeValidationError("AdvectionDiffusionResidualEvaluator does not support masked fields.")
+    if not np.all(np.isfinite(field.values)):
+        raise ScopeValidationError("AdvectionDiffusionResidualEvaluator requires finite field values.")
+
+    boundary_conditions = field.metadata.get("boundary_conditions")
+    if not isinstance(boundary_conditions, Mapping) or boundary_conditions.get("x") != "periodic":
+        raise ScopeValidationError("AdvectionDiffusionResidualEvaluator requires periodic boundary conditions in x.")
+
+    parameter_tags = field.metadata.get("parameter_tags")
+    if not isinstance(parameter_tags, Mapping):
+        raise SchemaValidationError(
+            "AdvectionDiffusionResidualEvaluator requires field.metadata['parameter_tags'] to be a mapping."
+        )
+    if parameter_tags.get("equation") != DEFAULT_ADVECTION_DIFFUSION_EQUATION:
+        raise ScopeValidationError(
+            "AdvectionDiffusionResidualEvaluator requires "
+            "field.metadata['parameter_tags']['equation'] == 'advection_diffusion_constant_coefficient'."
+        )
+    return parameter_tags
+
+
+class AdvectionDiffusionResidualEvaluator(ResidualEvaluator):
+    def __init__(self, *, advection_speed: float | None = None, diffusivity: float | None = None) -> None:
+        self.advection_speed = (
+            None if advection_speed is None else _finite_parameter(advection_speed, name="advection_speed")
+        )
+        self.diffusivity = None if diffusivity is None else _finite_positive_parameter(diffusivity, name="diffusivity")
+
+    def evaluate(
+        self,
+        field: FieldBatch,
+        derivatives: DerivativeBatch | None = None,
+    ) -> ResidualBatch:
+        parameter_tags = _validate_advection_diffusion_field(field)
+        advection_speed = (
+            _finite_parameter(parameter_tags.get("c"), name="field.metadata['parameter_tags']['c']")
+            if self.advection_speed is None
+            else self.advection_speed
+        )
+        diffusivity = (
+            _finite_positive_parameter(parameter_tags.get("nu"), name="field.metadata['parameter_tags']['nu']")
+            if self.diffusivity is None
+            else self.diffusivity
+        )
+
+        if derivatives is None:
+            derivatives = compute_spectral_fd_derivatives(field)
+        derivatives.validate_against(field)
+
+        for name in _REQUIRED_DERIVATIVES:
+            if name not in derivatives.derivatives:
+                raise SchemaValidationError(f"AdvectionDiffusionResidualEvaluator requires derivative '{name}'.")
+
+        residual = (
+            derivatives.derivatives["u_t"]
+            + advection_speed * derivatives.derivatives["u_x"]
+            - diffusivity * derivatives.derivatives["u_xx"]
+        )
+        batch = ResidualBatch(
+            residual=residual,
+            definition_type="analytic",
+            normalization="none",
+            diagnostics={
+                "backend": derivatives.backend,
+                "equation": _ADVECTION_DIFFUSION_EQUATION,
+                "c": advection_speed,
+                "nu": diffusivity,
+                "max_abs_residual": float(np.max(np.abs(residual))),
+                "rms_residual": float(np.sqrt(np.mean(np.square(residual)))),
+            },
+        )
+        batch.validate_against(field)
+        return batch

--- a/tests/test_advection_diffusion_generator.py
+++ b/tests/test_advection_diffusion_generator.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from pdelie.contracts import FieldBatch
+from pdelie.data import from_numpy, generate_advection_diffusion_1d_field_batch
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+def test_advection_diffusion_generator_is_deterministic_and_seed_sensitive() -> None:
+    first = generate_advection_diffusion_1d_field_batch(seed=19018)
+    second = generate_advection_diffusion_1d_field_batch(seed=19018)
+    different = generate_advection_diffusion_1d_field_batch(seed=19019)
+
+    np.testing.assert_allclose(first.values, second.values)
+    assert not np.allclose(first.values, different.values)
+    np.testing.assert_allclose(first.coords["time"], second.coords["time"])
+    np.testing.assert_allclose(first.coords["x"], second.coords["x"])
+
+
+def test_advection_diffusion_generator_returns_canonical_field_batch() -> None:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=3, seed=19018)
+
+    field.validate()
+    assert field.dims == ("batch", "time", "x", "var")
+    assert field.values.shape == (3, 65, 64, 1)
+    assert field.var_names == ["u"]
+    assert field.mask is None
+    assert np.isfinite(field.values).all()
+
+    time = field.coords["time"]
+    x = field.coords["x"]
+    assert np.all(np.diff(time) > 0.0)
+    np.testing.assert_allclose(np.diff(time), time[1] - time[0])
+    np.testing.assert_allclose(x[0], 0.0)
+    assert x[-1] < 2.0 * np.pi
+    np.testing.assert_allclose(np.diff(x), x[1] - x[0])
+
+    tags = field.metadata["parameter_tags"]
+    assert tags["equation"] == "advection_diffusion_constant_coefficient"
+    assert tags["c"] == 0.75
+    assert tags["nu"] == 0.05
+    assert field.metadata["boundary_conditions"]["x"] == "periodic"
+
+
+def test_advection_diffusion_generator_matches_exact_fourier_evolution() -> None:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=2, seed=19018)
+    values = field.values[..., 0]
+    x = field.coords["x"]
+    time = field.coords["time"]
+    tags = field.metadata["parameter_tags"]
+    dx = float(x[1] - x[0])
+    wavenumbers = 2.0 * np.pi * np.fft.fftfreq(x.size, d=dx)
+    spectrum0 = np.fft.fft(values[:, 0, :], axis=-1)
+    multiplier = np.exp(time[:, None] * (-tags["nu"] * wavenumbers[None, :] ** 2 - 1j * tags["c"] * wavenumbers[None, :]))
+    expected = np.real(np.fft.ifft(spectrum0[:, None, :] * multiplier[None, :, :], axis=-1))
+
+    np.testing.assert_allclose(values, expected, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(np.mean(values[:, 0, :], axis=-1), 0.0, rtol=0.0, atol=1e-14)
+
+
+def test_advection_diffusion_generator_import_round_trip_with_from_numpy() -> None:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=2, seed=19018)
+    imported = from_numpy(
+        field.values,
+        dims=field.dims,
+        coords=field.coords,
+        var_name="u",
+        metadata=field.metadata,
+        preprocess_log=field.preprocess_log,
+    )
+
+    imported.validate()
+    np.testing.assert_allclose(imported.values, field.values)
+    np.testing.assert_allclose(imported.coords["time"], field.coords["time"])
+    np.testing.assert_allclose(imported.coords["x"], field.coords["x"])
+    assert imported.metadata == field.metadata
+    assert imported.preprocess_log[-1]["operation"] == "from_numpy"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type"),
+    [
+        ({"batch_size": 0}, SchemaValidationError),
+        ({"num_times": 2}, SchemaValidationError),
+        ({"num_points": 15}, SchemaValidationError),
+        ({"num_modes": 0}, SchemaValidationError),
+        ({"num_modes": 32}, ScopeValidationError),
+        ({"seed": -1}, SchemaValidationError),
+        ({"max_time": 0.0}, SchemaValidationError),
+        ({"advection_speed": float("nan")}, SchemaValidationError),
+        ({"diffusivity": 0.0}, SchemaValidationError),
+        ({"diffusivity": -0.1}, SchemaValidationError),
+        ({"diffusivity": float("nan")}, SchemaValidationError),
+        ({"amplitude": -0.1}, SchemaValidationError),
+        ({"amplitude": 1.5}, ScopeValidationError),
+        ({"domain_length": 0.0}, SchemaValidationError),
+    ],
+)
+def test_advection_diffusion_generator_rejects_invalid_parameters(
+    kwargs: dict[str, object],
+    error_type: type[Exception],
+) -> None:
+    with pytest.raises(error_type):
+        generate_advection_diffusion_1d_field_batch(**kwargs)
+
+
+def test_advection_diffusion_generator_allows_signed_advection_speed() -> None:
+    forward = generate_advection_diffusion_1d_field_batch(advection_speed=0.75, seed=19018)
+    backward = generate_advection_diffusion_1d_field_batch(advection_speed=-0.75, seed=19018)
+
+    assert forward.metadata["parameter_tags"]["c"] == 0.75
+    assert backward.metadata["parameter_tags"]["c"] == -0.75
+    assert not np.allclose(forward.values[:, -1], backward.values[:, -1])
+
+
+def test_advection_diffusion_generator_metadata_can_be_preserved_in_field_copy() -> None:
+    field = generate_advection_diffusion_1d_field_batch(seed=19018)
+    copied = FieldBatch(
+        values=field.values.copy(),
+        dims=field.dims,
+        coords={name: coord.copy() for name, coord in field.coords.items()},
+        var_names=list(field.var_names),
+        metadata=deepcopy(field.metadata),
+        preprocess_log=list(field.preprocess_log),
+        mask=None,
+    )
+
+    copied.validate()
+    assert copied.metadata["parameter_tags"]["equation"] == "advection_diffusion_constant_coefficient"

--- a/tests/test_advection_diffusion_residual.py
+++ b/tests/test_advection_diffusion_residual.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from pdelie.contracts import DerivativeBatch, FieldBatch
+from pdelie.data import (
+    generate_advection_diffusion_1d_field_batch,
+    generate_burgers_1d_field_batch,
+    generate_heat_1d_field_batch,
+    generate_kdv_1d_field_batch,
+    generate_reaction_diffusion_1d_field_batch,
+)
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+from pdelie.residuals import (
+    AdvectionDiffusionResidualEvaluator,
+    BurgersResidualEvaluator,
+    HeatResidualEvaluator,
+    KdVResidualEvaluator,
+    ReactionDiffusionResidualEvaluator,
+)
+
+
+def _copy_field(field: FieldBatch, **overrides: object) -> FieldBatch:
+    values = overrides.get("values", field.values.copy())
+    dims = overrides.get("dims", field.dims)
+    coords = overrides.get("coords", {name: coord.copy() for name, coord in field.coords.items()})
+    var_names = overrides.get("var_names", list(field.var_names))
+    metadata = overrides.get("metadata", deepcopy(field.metadata))
+    preprocess_log = overrides.get("preprocess_log", list(field.preprocess_log))
+    mask = overrides.get("mask", None if field.mask is None else field.mask.copy())
+    return FieldBatch(
+        values=values,  # type: ignore[arg-type]
+        dims=dims,  # type: ignore[arg-type]
+        coords=coords,  # type: ignore[arg-type]
+        var_names=var_names,  # type: ignore[arg-type]
+        metadata=metadata,  # type: ignore[arg-type]
+        preprocess_log=preprocess_log,  # type: ignore[arg-type]
+        mask=mask,  # type: ignore[arg-type]
+    )
+
+
+def _drop_derivative(derivatives: DerivativeBatch, name: str) -> DerivativeBatch:
+    return DerivativeBatch(
+        derivatives={
+            derivative_name: values
+            for derivative_name, values in derivatives.derivatives.items()
+            if derivative_name != name
+        },
+        backend=derivatives.backend,
+        config=dict(derivatives.config),
+        boundary_assumptions=derivatives.boundary_assumptions,
+        diagnostics=dict(derivatives.diagnostics),
+    )
+
+
+def test_advection_diffusion_residual_internal_and_explicit_derivatives_match() -> None:
+    field = generate_advection_diffusion_1d_field_batch(seed=19018)
+    evaluator = AdvectionDiffusionResidualEvaluator()
+    derivatives = compute_spectral_fd_derivatives(field)
+
+    internal = evaluator.evaluate(field)
+    explicit = evaluator.evaluate(field, derivatives)
+
+    internal.validate_against(field)
+    explicit.validate_against(field)
+    np.testing.assert_allclose(internal.residual, explicit.residual)
+    assert explicit.definition_type == "analytic"
+    assert explicit.normalization == "none"
+    assert explicit.diagnostics["equation"] == "u_t + c*u_x - nu*u_xx = 0"
+    assert explicit.diagnostics["c"] == 0.75
+    assert explicit.diagnostics["nu"] == 0.05
+    assert explicit.diagnostics["max_abs_residual"] < 5e-4
+    assert explicit.diagnostics["rms_residual"] < 5e-5
+
+
+@pytest.mark.parametrize("missing", ["u_t", "u_x", "u_xx"])
+def test_advection_diffusion_residual_requires_derivative_keys(missing: str) -> None:
+    field = generate_advection_diffusion_1d_field_batch(seed=19018)
+    derivatives = compute_spectral_fd_derivatives(field)
+
+    with pytest.raises(SchemaValidationError, match=missing):
+        AdvectionDiffusionResidualEvaluator().evaluate(field, _drop_derivative(derivatives, missing))
+
+
+def test_advection_diffusion_residual_uses_explicit_parameters_when_supplied() -> None:
+    field = generate_advection_diffusion_1d_field_batch(advection_speed=-0.4, diffusivity=0.02, seed=19018)
+    residual = AdvectionDiffusionResidualEvaluator(advection_speed=-0.4, diffusivity=0.02).evaluate(field)
+
+    assert residual.diagnostics["c"] == -0.4
+    assert residual.diagnostics["nu"] == 0.02
+    assert residual.diagnostics["max_abs_residual"] < 5e-4
+    assert residual.diagnostics["rms_residual"] < 5e-5
+
+
+@pytest.mark.parametrize(
+    "metadata_update",
+    [
+        {"parameter_tags": {"equation": "heat_1d", "c": 0.75, "nu": 0.05}},
+        {"parameter_tags": {"equation": "advection_diffusion_constant_coefficient", "nu": 0.05}},
+        {"parameter_tags": {"equation": "advection_diffusion_constant_coefficient", "c": 0.75}},
+        {"parameter_tags": {"equation": "advection_diffusion_constant_coefficient", "c": 0.75, "nu": 0.0}},
+        {"boundary_conditions": {"x": "dirichlet"}},
+    ],
+)
+def test_advection_diffusion_residual_rejects_wrong_metadata(metadata_update: dict[str, object]) -> None:
+    field = generate_advection_diffusion_1d_field_batch(seed=19018)
+    metadata = deepcopy(field.metadata)
+    metadata.update(metadata_update)
+    malformed = _copy_field(field, metadata=metadata)
+
+    with pytest.raises((SchemaValidationError, ScopeValidationError)):
+        AdvectionDiffusionResidualEvaluator().evaluate(malformed)
+
+
+def test_advection_diffusion_residual_rejects_valid_looking_other_pde_fields() -> None:
+    heat = generate_heat_1d_field_batch(batch_size=2, num_times=17, num_points=32, seed=19018)
+    burgers = generate_burgers_1d_field_batch(batch_size=2, num_times=17, num_points=32, seed=19018)
+    kdv = generate_kdv_1d_field_batch(batch_size=2, num_times=17, num_points=32, seed=19018)
+    reaction = generate_reaction_diffusion_1d_field_batch(batch_size=2, num_times=17, num_points=32, seed=19018)
+
+    evaluator = AdvectionDiffusionResidualEvaluator()
+    for field in (heat, burgers, kdv, reaction):
+        with pytest.raises(ScopeValidationError, match="advection_diffusion_constant_coefficient"):
+            evaluator.evaluate(field)
+
+    assert HeatResidualEvaluator().evaluate(heat).diagnostics["max_abs_residual"] >= 0.0
+    assert BurgersResidualEvaluator().evaluate(burgers).diagnostics["max_abs_residual"] >= 0.0
+    assert KdVResidualEvaluator().evaluate(kdv).diagnostics["max_abs_residual"] >= 0.0
+    assert ReactionDiffusionResidualEvaluator().evaluate(reaction).diagnostics["max_abs_residual"] >= 0.0
+
+
+def test_advection_diffusion_residual_rejects_multivariable_masked_and_nonfinite_fields() -> None:
+    field = generate_advection_diffusion_1d_field_batch(seed=19018)
+    multivariable = _copy_field(
+        field,
+        values=np.concatenate([field.values, field.values], axis=-1),
+        var_names=["u", "v"],
+    )
+    masked = _copy_field(field, mask=np.zeros_like(field.values, dtype=bool))
+    nonfinite_values = field.values.copy()
+    nonfinite_values[0, 0, 0, 0] = np.nan
+    nonfinite = _copy_field(field, values=nonfinite_values)
+
+    evaluator = AdvectionDiffusionResidualEvaluator()
+    with pytest.raises(ScopeValidationError, match="scalar"):
+        evaluator.evaluate(multivariable)
+    with pytest.raises(ScopeValidationError, match="masked"):
+        evaluator.evaluate(masked)
+    with pytest.raises(ScopeValidationError, match="finite"):
+        evaluator.evaluate(nonfinite)

--- a/tests/test_advection_diffusion_vertical_slice.py
+++ b/tests/test_advection_diffusion_vertical_slice.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+import pdelie
+from pdelie.data import generate_advection_diffusion_1d_field_batch, split_batch_train_heldout
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.examples import run_advection_diffusion_vertical_slice_example
+from pdelie.reporting import summarize_vertical_slice
+from pdelie.residuals import AdvectionDiffusionResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+
+
+def _run_vertical_slice() -> dict[str, object]:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=5, seed=19018)
+    training, heldout = split_batch_train_heldout(field, train_size=2, seed=19019)
+    derivatives = compute_spectral_fd_derivatives(training)
+    residual_evaluator = AdvectionDiffusionResidualEvaluator()
+    residual = residual_evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, residual_evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, residual_evaluator)
+    return summarize_vertical_slice(
+        derivatives=derivatives,
+        residual=residual,
+        generator=generator,
+        verification=verification,
+        extra_metrics={"equation": "advection_diffusion_constant_coefficient"},
+    )
+
+
+def test_advection_diffusion_vertical_slice_direct_svd_feasibility() -> None:
+    summary = _run_vertical_slice()
+
+    assert json.loads(json.dumps(summary)) == summary
+    assert summary["summary_type"] == "vertical_slice"
+    assert summary["derivative_keys"] == ["u_t", "u_x", "u_xx"]
+    assert summary["residual"]["max_abs_residual"] < 5e-4
+    assert summary["residual"]["rms_residual"] < 5e-5
+    assert summary["generator"]["parameterization"] == "polynomial_translation_affine"
+    assert summary["generator"]["fit_mode"] == "svd"
+    assert summary["generator"]["reference_fallback_used"] is False
+    assert summary["generator"]["fallback_reason"] is None
+    assert summary["generator"]["translation_span_distance"] <= 5e-2
+    assert summary["generator"]["diagnostics"]["evidence_label"] == "direct_svd_in_tolerance"
+    assert summary["generator"]["diagnostics"]["svd_span_distance"] <= 5e-2
+    assert summary["verification"]["classification"] != "failed"
+    assert summary["verification"]["first_error"] < 5e-4
+    assert summary["verification"]["diagnostics"]["transform_mode"] == "uniform_translation"
+
+
+def test_advection_diffusion_vertical_slice_example_runs_end_to_end() -> None:
+    result = run_advection_diffusion_vertical_slice_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "vertical_slice"
+    assert result["extra_metrics"]["example_name"] == "advection_diffusion_vertical_slice"
+    assert result["extra_metrics"]["equation"] == "advection_diffusion_constant_coefficient"
+    assert result["residual"]["max_abs_residual"] < 5e-4
+    assert result["residual"]["rms_residual"] < 5e-5
+    assert result["generator"]["fit_mode"] == "svd"
+    assert result["generator"]["reference_fallback_used"] is False
+    assert result["generator"]["translation_span_distance"] <= 5e-2
+    assert result["generator"]["diagnostics"]["evidence_label"] == "direct_svd_in_tolerance"
+    assert result["verification"]["classification"] != "failed"
+    assert result["verification"]["first_error"] < 5e-4
+    assert np.isfinite(float(result["extra_metrics"]["mean_drift_diagnostic"]))
+    assert np.isfinite(float(result["extra_metrics"]["relative_l2_drift_diagnostic"]))
+    assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -7,6 +7,7 @@ import pdelie
 
 
 _ROOT_RUNTIME_NAMES = {
+    "AdvectionDiffusionResidualEvaluator",
     "InvariantApplier",
     "add_gaussian_noise",
     "build_uniform_translation_orbit_batch",
@@ -20,6 +21,7 @@ _ROOT_RUNTIME_NAMES = {
     "diagnose_time_translation_consistency",
     "evaluate_discovery_recovery",
     "evaluate_weak_burgers_residual",
+    "evaluate_weak_advection_diffusion_residual",
     "evaluate_weak_heat_residual",
     "export_generator_family_manifest",
     "fit_pysindy_discovery",
@@ -27,6 +29,7 @@ _ROOT_RUNTIME_NAMES = {
     "FormulaGeneratorFamily",
     "from_numpy",
     "from_xarray",
+    "generate_advection_diffusion_1d_field_batch",
     "generate_burgers_1d_field_batch",
     "generate_heat_1d_field_batch",
     "generate_kdv_1d_field_batch",
@@ -39,6 +42,7 @@ _ROOT_RUNTIME_NAMES = {
     "plot_verification_curve",
     "render_generator_family",
     "run_heat_vertical_slice_example",
+    "run_advection_diffusion_vertical_slice_example",
     "run_formula_generator_validation_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
@@ -73,11 +77,13 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "WeakHeatResidualEvaluator",
     "WeakKdVResidualEvaluator",
     "WeakReactionDiffusionResidualEvaluator",
+    "WeakAdvectionDiffusionResidualEvaluator",
     "augment_translation_orbit",
     "build_translation_orbit_dataset",
     "build_translation_orbit_views",
     "compute_coverage_diagnostics",
     "compute_weak_derivatives",
+    "evaluate_weak_advection_diffusion_residual",
     "evaluate_weak_kdv_residual",
     "evaluate_weak_ks_residual",
     "evaluate_weak_reaction_diffusion_residual",
@@ -85,7 +91,8 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "from_the_well",
     "generate_ks_1d_field_batch",
     "generate_ks_feasibility_field_batch",
-    "generate_advection_diffusion_1d_field_batch",
+    "generate_reaction_advection_diffusion_1d_field_batch",
+    "generate_variable_coefficient_advection_diffusion_1d_field_batch",
     "load_pdebench",
     "load_the_well",
     "materialize_uniform_translation_orbit",
@@ -103,7 +110,8 @@ _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.data.from_pdebench",
     "pdelie.data.from_the_well",
     "pdelie.data.generate_ks_1d_field_batch",
-    "pdelie.data.generate_advection_diffusion_1d_field_batch",
+    "pdelie.data.generate_reaction_advection_diffusion_1d_field_batch",
+    "pdelie.data.generate_variable_coefficient_advection_diffusion_1d_field_batch",
     "pdelie.data.load_pdebench",
     "pdelie.data.load_the_well",
     "pdelie.reporting.summarize_orbit_coverage",
@@ -114,6 +122,8 @@ _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.residuals.WeakReactionDiffusionResidualEvaluator",
     "pdelie.residuals.evaluate_weak_ks_residual",
     "pdelie.residuals.evaluate_weak_reaction_diffusion_residual",
+    "pdelie.residuals.evaluate_weak_advection_diffusion_residual",
+    "pdelie.residuals.WeakAdvectionDiffusionResidualEvaluator",
     "pdelie.symmetry.OperatorSymmetry",
     "pdelie.symmetry.CallableGeneratorFamily",
     "pdelie.symmetry.validate_generator_candidate",
@@ -166,6 +176,12 @@ _V0_18_REACTION_DIFFUSION_APIS = {
     "pdelie.examples.run_reaction_diffusion_vertical_slice_example",
     "reaction_diffusion_fisher_kpp",
 }
+_V0_19_ADVECTION_DIFFUSION_APIS = {
+    "pdelie.data.generate_advection_diffusion_1d_field_batch",
+    "pdelie.residuals.AdvectionDiffusionResidualEvaluator",
+    "pdelie.examples.run_advection_diffusion_vertical_slice_example",
+    "advection_diffusion_constant_coefficient",
+}
 
 
 def _api_stability_text() -> str:
@@ -191,6 +207,7 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_16_SYMMETRY_VALIDATION_APIS
         | _V0_17_FORMULA_GENERATOR_APIS
         | _V0_18_REACTION_DIFFUSION_APIS
+        | _V0_19_ADVECTION_DIFFUSION_APIS
     ):
         assert api_name in text
 
@@ -234,6 +251,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "from_xarray",
             "generate_burgers_1d_field_batch",
             "generate_heat_1d_field_batch",
+            "generate_advection_diffusion_1d_field_batch",
             "generate_kdv_1d_field_batch",
             "generate_reaction_diffusion_1d_field_batch",
             "split_batch_train_heldout",
@@ -250,6 +268,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
         },
         "pdelie.examples": {
             "run_formula_generator_validation_example",
+            "run_advection_diffusion_vertical_slice_example",
             "run_heat_vertical_slice_example",
             "run_invariant_workflow_summary_example",
             "run_kdv_vertical_slice_example",
@@ -282,6 +301,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "summarize_weak_residual_report",
         },
         "pdelie.residuals": {
+            "AdvectionDiffusionResidualEvaluator",
             "BurgersResidualEvaluator",
             "HeatResidualEvaluator",
             "KdVResidualEvaluator",
@@ -330,35 +350,35 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
             assert not hasattr(module, name), f"{module.__name__}.{name}"
 
 
-def test_v0_18_planning_docs_record_reaction_diffusion_and_non_goals() -> None:
+def test_v0_19_planning_docs_record_advection_diffusion_and_non_goals() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_18_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_19_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
 
     assert "**Status:** COMPLETE" in plan
     assert "Milestone 2 - Synthetic Data Generator" in plan
     assert "Milestone 3 - Residual Evaluator" in plan
-    assert "pdelie.data.generate_reaction_diffusion_1d_field_batch" in plan
-    assert "pdelie.residuals.ReactionDiffusionResidualEvaluator" in plan
-    assert "reaction_diffusion_fisher_kpp" in plan
+    assert "pdelie.data.generate_advection_diffusion_1d_field_batch" in plan
+    assert "pdelie.residuals.AdvectionDiffusionResidualEvaluator" in plan
+    assert "advection_diffusion_constant_coefficient" in plan
     assert "direct_svd_in_tolerance" in plan
-    assert "No fallback-backed reaction-diffusion claim landed" in plan
+    assert "No fallback-backed advection-diffusion claim landed" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
     assert "## Milestone 6 - Release Gate And Readiness" in plan
-    assert "updated CI so the current explicit release gate is `v0_18-release-gate`" in plan
+    assert "updated CI so the current explicit release gate is `v0_19-release-gate`" in plan
     assert "- Milestone 6: COMPLETE" in plan
 
-    assert "Stable Fisher-KPP Reaction-Diffusion Strong Path" in scope
-    assert "pdelie.data.generate_reaction_diffusion_1d_field_batch" in scope
-    assert "pdelie.residuals.ReactionDiffusionResidualEvaluator" in scope
-    assert "pdelie.examples.run_reaction_diffusion_vertical_slice_example" in scope
+    assert "Stable Advection-Diffusion Strong Path" in scope
+    assert "pdelie.data.generate_advection_diffusion_1d_field_batch" in scope
+    assert "pdelie.residuals.AdvectionDiffusionResidualEvaluator" in scope
+    assert "pdelie.examples.run_advection_diffusion_vertical_slice_example" in scope
     assert "direct_svd_in_tolerance" in scope
-    assert "weak reaction-diffusion" in scope
+    assert "weak advection-diffusion" in scope
     assert "neural or callable generator APIs" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
     assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.18` is the completed narrow PDE-expansion release" in roadmap
-    assert "stable scalar 1D periodic Fisher-KPP reaction-diffusion strong path" in roadmap
-    assert "- no advection-diffusion" in roadmap
+    assert "`v0.19` is the completed narrow PDE-expansion release" in roadmap
+    assert "stable scalar 1D periodic constant-coefficient advection-diffusion strong path" in roadmap
+    assert "- no variable-coefficient advection-diffusion" in roadmap

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import pdelie
 from pdelie.examples import (
+    run_advection_diffusion_vertical_slice_example,
     run_formula_generator_validation_example,
     run_heat_vertical_slice_example,
     run_invariant_workflow_summary_example,
@@ -176,6 +177,36 @@ def test_reaction_diffusion_vertical_slice_example_is_deterministic() -> None:
     _assert_repeated_summary_matches(first, second)
 
 
+def test_advection_diffusion_vertical_slice_example_runs_end_to_end_and_is_json_serializable() -> None:
+    result = run_advection_diffusion_vertical_slice_example()
+    _assert_vertical_slice_summary(result)
+
+    assert result["extra_metrics"]["example_name"] == "advection_diffusion_vertical_slice"
+    assert result["extra_metrics"]["equation"] == "advection_diffusion_constant_coefficient"
+    assert result["extra_metrics"]["generator_seed"] == 19018
+    assert result["extra_metrics"]["split_seed"] == 19019
+    assert result["extra_metrics"]["train_size"] == 2
+    assert result["residual"]["max_abs_residual"] < 5e-4
+    assert result["residual"]["rms_residual"] < 5e-5
+    assert np.isfinite(float(result["extra_metrics"]["mean_drift_diagnostic"]))
+    assert np.isfinite(float(result["extra_metrics"]["relative_l2_drift_diagnostic"]))
+    assert result["generator"]["parameterization"] == "polynomial_translation_affine"
+    assert result["generator"]["fit_mode"] == "svd"
+    assert result["generator"]["reference_fallback_used"] is False
+    assert result["generator"]["diagnostics"]["evidence_label"] == "direct_svd_in_tolerance"
+    assert result["generator"]["translation_span_distance"] <= 5e-2
+    assert result["verification"]["classification"] != "failed"
+    assert result["verification"]["first_error"] < 5e-4
+    assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")
+
+
+def test_advection_diffusion_vertical_slice_example_is_deterministic() -> None:
+    first = run_advection_diffusion_vertical_slice_example()
+    second = run_advection_diffusion_vertical_slice_example()
+
+    _assert_repeated_summary_matches(first, second)
+
+
 def test_heat_vertical_slice_module_prints_json_only() -> None:
     parsed = _run_module_json("pdelie.examples.heat_vertical_slice")
 
@@ -192,6 +223,13 @@ def test_kdv_vertical_slice_module_prints_json_only() -> None:
 
 def test_reaction_diffusion_vertical_slice_module_prints_json_only() -> None:
     parsed = _run_module_json("pdelie.examples.reaction_diffusion_vertical_slice")
+
+    _assert_vertical_slice_summary(parsed)
+    assert parsed["verification"]["classification"] != "failed"
+
+
+def test_advection_diffusion_vertical_slice_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.advection_diffusion_vertical_slice")
 
     _assert_vertical_slice_summary(parsed)
     assert parsed["verification"]["classification"] != "failed"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -33,6 +33,7 @@ def test_runtime_package_api_is_importable() -> None:
         add_gaussian_noise,
         from_numpy,
         from_xarray,
+        generate_advection_diffusion_1d_field_batch,
         generate_kdv_1d_field_batch,
         generate_reaction_diffusion_1d_field_batch,
         split_batch_train_heldout,
@@ -60,6 +61,7 @@ def test_runtime_package_api_is_importable() -> None:
         import_generator_family_manifest,
     )
     from pdelie.residuals import (
+        AdvectionDiffusionResidualEvaluator,
         KdVResidualEvaluator,
         ReactionDiffusionResidualEvaluator,
         evaluate_weak_burgers_residual,
@@ -94,6 +96,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert add_gaussian_noise is not None
     assert from_numpy is not None
     assert from_xarray is not None
+    assert generate_advection_diffusion_1d_field_batch is not None
     assert generate_kdv_1d_field_batch is not None
     assert generate_reaction_diffusion_1d_field_batch is not None
     assert split_batch_train_heldout is not None
@@ -105,6 +108,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert compute_periodic_window_coverage is not None
     assert diagnose_uniform_translation_consistency is not None
     assert summarize_uniform_translation_orbit is not None
+    assert AdvectionDiffusionResidualEvaluator is not None
     assert KdVResidualEvaluator is not None
     assert ReactionDiffusionResidualEvaluator is not None
     assert evaluate_weak_burgers_residual is not None
@@ -157,6 +161,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "evaluate_weak_heat_residual")
     assert not hasattr(pdelie, "evaluate_weak_ks_residual")
     assert not hasattr(pdelie, "evaluate_weak_reaction_diffusion_residual")
+    assert not hasattr(pdelie, "evaluate_weak_advection_diffusion_residual")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "fit_pysindy_discovery")
     assert not hasattr(pdelie, "from_pdebench")
@@ -191,17 +196,20 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "KSResidualEvaluator")
     assert not hasattr(pdelie, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(pdelie, "ReactionDiffusionResidualEvaluator")
+    assert not hasattr(pdelie, "AdvectionDiffusionResidualEvaluator")
     assert not hasattr(pdelie, "materialize_uniform_translation_orbit")
     assert not hasattr(pdelie, "split_orbit_train_heldout")
     assert not hasattr(pdelie, "train_test_translation_orbit_split")
     assert not hasattr(pdelie, "WeakKSResidualEvaluator")
     assert not hasattr(pdelie, "WeakReactionDiffusionResidualEvaluator")
+    assert not hasattr(pdelie, "WeakAdvectionDiffusionResidualEvaluator")
     assert not hasattr(pdelie, "OperatorSymmetry")
     assert not hasattr(pdelie, "run_invariant_workflow_summary_example")
     assert not hasattr(pdelie, "run_formula_generator_validation_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(pdelie, "run_reaction_diffusion_vertical_slice_example")
+    assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")
     assert not hasattr(pdelie, "run_symmetry_candidate_validation_example")
     assert not hasattr(pdelie, "run_translation_orbit_batch_example")
     assert not hasattr(pdelie, "sample_kdv_mode_coefficients")
@@ -242,6 +250,7 @@ def test_data_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(data_module, "add_gaussian_noise")
     assert hasattr(data_module, "from_numpy")
     assert hasattr(data_module, "from_xarray")
+    assert hasattr(data_module, "generate_advection_diffusion_1d_field_batch")
     assert hasattr(data_module, "generate_kdv_1d_field_batch")
     assert hasattr(data_module, "generate_reaction_diffusion_1d_field_batch")
     assert hasattr(data_module, "subsample_time")
@@ -254,7 +263,6 @@ def test_data_package_runtime_api_matches_current_frozen_surface() -> None:
     assert not hasattr(data_module, "from_the_well")
     assert not hasattr(data_module, "generate_ks_1d_field_batch")
     assert not hasattr(data_module, "generate_ks_feasibility_field_batch")
-    assert not hasattr(data_module, "generate_advection_diffusion_1d_field_batch")
     assert not hasattr(data_module, "load_pdebench")
     assert not hasattr(data_module, "load_the_well")
     assert not hasattr(data_module, "sample_kdv_mode_coefficients")
@@ -264,6 +272,7 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
     residuals_module = importlib.import_module("pdelie.residuals")
 
     assert hasattr(residuals_module, "HeatResidualEvaluator")
+    assert hasattr(residuals_module, "AdvectionDiffusionResidualEvaluator")
     assert hasattr(residuals_module, "BurgersResidualEvaluator")
     assert hasattr(residuals_module, "KdVResidualEvaluator")
     assert hasattr(residuals_module, "ReactionDiffusionResidualEvaluator")
@@ -280,6 +289,7 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
     assert not hasattr(residuals_module, "WeakKuramotoSivashinskyResidualEvaluator")
     assert not hasattr(residuals_module, "WeakReactionDiffusionResidualEvaluator")
     assert not hasattr(residuals_module, "evaluate_weak_reaction_diffusion_residual")
+    assert not hasattr(residuals_module, "evaluate_weak_advection_diffusion_residual")
     assert not hasattr(residuals_module, "KSResidualEvaluator")
     assert not hasattr(residuals_module, "KuramotoSivashinskyResidualEvaluator")
     assert not hasattr(residuals_module, "KDVResidualEvaluator")
@@ -304,6 +314,7 @@ def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
 def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     examples_module = importlib.import_module("pdelie.examples")
 
+    assert hasattr(examples_module, "run_advection_diffusion_vertical_slice_example")
     assert hasattr(examples_module, "run_heat_vertical_slice_example")
     assert hasattr(examples_module, "run_formula_generator_validation_example")
     assert hasattr(examples_module, "run_invariant_workflow_summary_example")

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
     for historical_job in range(4, 17):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.18.0`" in publishing
+    assert "including `v0.19.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -67,14 +67,14 @@ def test_v0_12_release_gate_current_ci_visibility_is_v0_18_only() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "summarize_generator_fit_diagnostics" in readme
-    assert "including `v0.18.0`" in publishing
-    assert "V0.18 is complete" in plan
+    assert "including `v0.19.0`" in publishing
+    assert "V0.19 is complete" in plan
 
 
 def test_v0_12_release_gate_fit_diagnostic_helper_is_documented_and_submodule_only() -> None:

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_18_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.18.0`" in readiness
-    assert "git tag: `v0.18.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.18`" in readiness
-    assert "including `v0.18.0`" in publishing
-    assert "V0.18 is complete" in plan
+    assert "package version: `0.19.0`" in readiness
+    assert "git tag: `v0.19.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
+    assert "including `v0.19.0`" in publishing
+    assert "V0.19 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_18_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.14.0" in changelog
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "summarize_invariant_workflow" in readme
     assert "summarize_uniform_translation_orbit" in readme
-    assert "package version: `0.18.0`" in readiness
-    assert "git tag: `v0.18.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.18`" in readiness
-    assert "including `v0.18.0`" in publishing
+    assert "package version: `0.19.0`" in readiness
+    assert "git tag: `v0.19.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
+    assert "including `v0.19.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap

--- a/tests/test_v0_15_release_gate.py
+++ b/tests/test_v0_15_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_18_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_14-release-gate" not in workflow
 
     assert "## 0.15.0" in changelog
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "build_uniform_translation_orbit_batch" in readme
     assert "OrbitBatchResult" in readme
-    assert "package version: `0.18.0`" in readiness
-    assert "git tag: `v0.18.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.18`" in readiness
-    assert "including `v0.18.0`" in publishing
+    assert "package version: `0.19.0`" in readiness
+    assert "git tag: `v0.19.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
+    assert "including `v0.19.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.15` - Materialized uniform translation orbit batches" in roadmap

--- a/tests/test_v0_16_release_gate.py
+++ b/tests/test_v0_16_release_gate.py
@@ -45,7 +45,7 @@ def _translation_spec(generator: GeneratorFamily) -> InvariantMapSpec:
 def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_18_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -54,18 +54,18 @@ def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
     assert "## 0.16.0" in changelog
-    assert "V0.18" in readme
+    assert "V0.19" in readme
     assert "validate_symmetry_candidate" in readme
-    assert "package version: `0.18.0`" in readiness
-    assert "git tag: `v0.18.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.18`" in readiness
-    assert "including `v0.18.0`" in publishing
+    assert "package version: `0.19.0`" in readiness
+    assert "git tag: `v0.19.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
+    assert "including `v0.19.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.16` - External symmetry-candidate validation" in roadmap

--- a/tests/test_v0_17_release_gate.py
+++ b/tests/test_v0_17_release_gate.py
@@ -63,7 +63,7 @@ def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_18_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_17_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 

--- a/tests/test_v0_17_release_gate.py
+++ b/tests/test_v0_17_release_gate.py
@@ -58,7 +58,7 @@ def _formula_translation(*, finite_transform: bool = False) -> FormulaGeneratorF
 def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_18_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -67,18 +67,18 @@ def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.18.0"
-    assert release_gate_jobs == ["v0_18-release-gate"]
-    assert "python -m pytest tests/test_v0_18_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.19.0"
+    assert release_gate_jobs == ["v0_19-release-gate"]
+    assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
-    assert "## 0.18.0" in changelog
-    assert "V0.18" in readme
+    assert "## 0.19.0" in changelog
+    assert "V0.19" in readme
     assert "FormulaGeneratorFamily" in readme
-    assert "package version: `0.18.0`" in readiness
-    assert "git tag: `v0.18.0`" in readiness
-    assert "Do not run TestPyPI or PyPI publishing for `v0.18`" in readiness
-    assert "including `v0.18.0`" in publishing
+    assert "package version: `0.19.0`" in readiness
+    assert "git tag: `v0.19.0`" in readiness
+    assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
+    assert "including `v0.19.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap

--- a/tests/test_v0_19_release_gate.py
+++ b/tests/test_v0_19_release_gate.py
@@ -7,10 +7,10 @@ import tomllib
 from pathlib import Path
 
 import pdelie
-from pdelie.data import generate_reaction_diffusion_1d_field_batch, split_batch_train_heldout
+from pdelie.data import generate_advection_diffusion_1d_field_batch, split_batch_train_heldout
 from pdelie.derivatives import compute_spectral_fd_derivatives
-from pdelie.examples import run_reaction_diffusion_vertical_slice_example
-from pdelie.residuals import ReactionDiffusionResidualEvaluator
+from pdelie.examples import run_advection_diffusion_vertical_slice_example
+from pdelie.residuals import AdvectionDiffusionResidualEvaluator
 from pdelie.symmetry.fitting import fit_translation_generator
 from pdelie.verification import verify_translation_generator
 
@@ -19,7 +19,7 @@ def _repo_text(path: str) -> str:
     return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
 
 
-def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+def test_v0_19_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
     readiness = _repo_text("docs/releases/V0_19_RELEASE_READINESS.md")
@@ -27,52 +27,52 @@ def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_18_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_19_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
     assert pyproject["project"]["version"] == "0.19.0"
     assert release_gate_jobs == ["v0_19-release-gate"]
     assert "python -m pytest tests/test_v0_19_release_gate.py" in workflow
-    assert "v0_17-release-gate" not in workflow
+    assert "v0_18-release-gate" not in workflow
 
     assert "## 0.19.0" in changelog
     assert "V0.19" in readme
-    assert "reaction_diffusion_fisher_kpp" in readme
+    assert "advection_diffusion_constant_coefficient" in readme
     assert "package version: `0.19.0`" in readiness
     assert "git tag: `v0.19.0`" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.19`" in readiness
     assert "including `v0.19.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
-    assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap
+    assert "`v0.19` - Stable advection-diffusion strong path" in roadmap
     assert "**Status:** Completed" in roadmap
 
 
-def test_v0_18_release_gate_reaction_diffusion_api_is_documented_and_submodule_only() -> None:
+def test_v0_19_release_gate_advection_diffusion_api_is_documented_and_submodule_only() -> None:
     api_stability = _repo_text("docs/specs/API_STABILITY.md")
     data_module = importlib.import_module("pdelie.data")
     residuals_module = importlib.import_module("pdelie.residuals")
     examples_module = importlib.import_module("pdelie.examples")
 
-    assert hasattr(data_module, "generate_reaction_diffusion_1d_field_batch")
-    assert hasattr(residuals_module, "ReactionDiffusionResidualEvaluator")
-    assert hasattr(examples_module, "run_reaction_diffusion_vertical_slice_example")
-    assert not hasattr(pdelie, "generate_reaction_diffusion_1d_field_batch")
-    assert not hasattr(pdelie, "ReactionDiffusionResidualEvaluator")
-    assert not hasattr(pdelie, "run_reaction_diffusion_vertical_slice_example")
-    assert "pdelie.data.generate_reaction_diffusion_1d_field_batch" in api_stability
-    assert "pdelie.residuals.ReactionDiffusionResidualEvaluator" in api_stability
-    assert "pdelie.examples.run_reaction_diffusion_vertical_slice_example" in api_stability
-    assert "reaction_diffusion_fisher_kpp" in api_stability
+    assert hasattr(data_module, "generate_advection_diffusion_1d_field_batch")
+    assert hasattr(residuals_module, "AdvectionDiffusionResidualEvaluator")
+    assert hasattr(examples_module, "run_advection_diffusion_vertical_slice_example")
+    assert not hasattr(pdelie, "generate_advection_diffusion_1d_field_batch")
+    assert not hasattr(pdelie, "AdvectionDiffusionResidualEvaluator")
+    assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")
+    assert "pdelie.data.generate_advection_diffusion_1d_field_batch" in api_stability
+    assert "pdelie.residuals.AdvectionDiffusionResidualEvaluator" in api_stability
+    assert "pdelie.examples.run_advection_diffusion_vertical_slice_example" in api_stability
+    assert "advection_diffusion_constant_coefficient" in api_stability
     assert "these APIs have no root `pdelie` exports" in api_stability
 
 
-def test_v0_18_release_gate_reaction_diffusion_vertical_slice_is_direct_svd() -> None:
-    field = generate_reaction_diffusion_1d_field_batch(batch_size=5, seed=18018)
-    training, heldout = split_batch_train_heldout(field, train_size=2, seed=18019)
+def test_v0_19_release_gate_advection_diffusion_vertical_slice_is_direct_svd() -> None:
+    field = generate_advection_diffusion_1d_field_batch(batch_size=5, seed=19018)
+    training, heldout = split_batch_train_heldout(field, train_size=2, seed=19019)
     derivatives = compute_spectral_fd_derivatives(training)
-    evaluator = ReactionDiffusionResidualEvaluator()
+    evaluator = AdvectionDiffusionResidualEvaluator()
     residual = evaluator.evaluate(training, derivatives)
     generator = fit_translation_generator(training, evaluator, epsilon=1e-4)
     verification = verify_translation_generator(heldout, generator, evaluator)
@@ -86,23 +86,53 @@ def test_v0_18_release_gate_reaction_diffusion_vertical_slice_is_direct_svd() ->
     assert float(verification.error_curve[0]) < 5e-4
 
 
-def test_v0_18_release_gate_example_outputs_nested_summary() -> None:
-    result = run_reaction_diffusion_vertical_slice_example()
+def test_v0_19_release_gate_example_outputs_nested_summary() -> None:
+    result = run_advection_diffusion_vertical_slice_example()
 
     assert json.loads(json.dumps(result)) == result
     assert result["summary_type"] == "vertical_slice"
-    assert result["extra_metrics"]["equation"] == "reaction_diffusion_fisher_kpp"
+    assert result["extra_metrics"]["equation"] == "advection_diffusion_constant_coefficient"
     assert result["derivative_keys"] == ["u_t", "u_x", "u_xx"]
     assert result["residual"]["summary_type"] == "residual_batch"
     assert result["generator"]["summary_type"] == "generator_family"
     assert result["verification"]["summary_type"] == "verification_report"
     assert result["generator"]["reference_fallback_used"] is False
+    assert result["generator"]["diagnostics"]["evidence_label"] == "direct_svd_in_tolerance"
     assert result["verification"]["classification"] != "failed"
 
 
-def test_v0_18_release_gate_no_deferred_surface_leaked() -> None:
+def test_v0_19_release_gate_no_deferred_surface_leaked() -> None:
+    root_forbidden = {
+        "AdvectionDiffusionResidualEvaluator",
+        "generate_advection_diffusion_1d_field_batch",
+        "run_advection_diffusion_vertical_slice_example",
+    }
+    deferred_forbidden = {
+        "CallableGeneratorFamily",
+        "compute_weak_derivatives",
+        "evaluate_weak_advection_diffusion_residual",
+        "evaluate_weak_ks_residual",
+        "evaluate_weak_reaction_diffusion_residual",
+        "from_pdebench",
+        "from_the_well",
+        "generate_ks_1d_field_batch",
+        "generate_ks_feasibility_field_batch",
+        "generate_reaction_advection_diffusion_1d_field_batch",
+        "generate_variable_coefficient_advection_diffusion_1d_field_batch",
+        "KSResidualEvaluator",
+        "KuramotoSivashinskyResidualEvaluator",
+        "load_pdebench",
+        "load_the_well",
+        "sample_advection_diffusion_initial_conditions",
+        "WeakAdvectionDiffusionResidualEvaluator",
+        "WeakKSResidualEvaluator",
+        "WeakReactionDiffusionResidualEvaluator",
+    }
+
+    for name in sorted(root_forbidden | deferred_forbidden):
+        assert not hasattr(pdelie, name), f"pdelie.{name}"
+
     modules = [
-        pdelie,
         importlib.import_module("pdelie.data"),
         importlib.import_module("pdelie.invariants"),
         importlib.import_module("pdelie.residuals"),
@@ -111,24 +141,6 @@ def test_v0_18_release_gate_no_deferred_surface_leaked() -> None:
         importlib.import_module("pdelie.discovery"),
         importlib.import_module("pdelie.symmetry"),
     ]
-    forbidden_names = {
-        "CallableGeneratorFamily",
-        "compute_weak_derivatives",
-        "evaluate_weak_ks_residual",
-        "evaluate_weak_reaction_diffusion_residual",
-        "from_pdebench",
-        "from_the_well",
-        "generate_ks_1d_field_batch",
-        "generate_ks_feasibility_field_batch",
-        "KSResidualEvaluator",
-        "KuramotoSivashinskyResidualEvaluator",
-        "load_pdebench",
-        "load_the_well",
-        "sample_reaction_diffusion_initial_conditions",
-        "WeakKSResidualEvaluator",
-        "WeakReactionDiffusionResidualEvaluator",
-    }
-
     for module in modules:
-        for name in sorted(forbidden_names):
+        for name in sorted(deferred_forbidden):
             assert not hasattr(module, name), f"{module.__name__}.{name}"

--- a/tests/test_weak_contract_integration.py
+++ b/tests/test_weak_contract_integration.py
@@ -26,6 +26,7 @@ _TRAINING_KWARGS = {"batch_size": 4, "num_times": 33, "num_points": 64}
 _HELDOUT_KWARGS = {"batch_size": 3, "num_times": 33, "num_points": 64}
 _EXPECTED_METHOD_FAMILY = "local_separable_quartic_bump_trapezoid_v1"
 _EXPECTED_RESIDUALS_EXPORTS = {
+    "AdvectionDiffusionResidualEvaluator",
     "BurgersResidualEvaluator",
     "HeatResidualEvaluator",
     "KdVResidualEvaluator",


### PR DESCRIPTION
**Summary**

This PR completes `v0.19.0` as a narrow stable PDE-expansion release by adding a constant-coefficient scalar 1D periodic advection-diffusion strong path.

Stable path:

```text
canonical scalar 1D periodic FieldBatch
-> spectral_fd derivatives
-> advection-diffusion residual
-> translation fit/verification
-> vertical-slice summary/example
```

New submodule-only public APIs:

- `pdelie.data.generate_advection_diffusion_1d_field_batch(...)`
- `pdelie.residuals.AdvectionDiffusionResidualEvaluator`
- `pdelie.examples.run_advection_diffusion_vertical_slice_example(...)`

No root `pdelie` exports are added.

**What Changed**

- Added deterministic exact Fourier rollout for:

```text
u_t + c*u_x = nu*u_xx
residual = u_t + c*u_x - nu*u_xx
```

- Added a residual evaluator with internal and explicit derivative paths.
- Added a JSON-only vertical-slice example:

```bash
python -m pdelie.examples.advection_diffusion_vertical_slice
```

- Added generator, residual, vertical-slice, public-surface, API-stability, release-gate, and example coverage.
- Updated release docs, roadmap, API stability docs, package metadata, README, changelog, CI gate, and notebook framing for `v0.19`.

**Promotion Evidence**

The frozen vertical slice passes direct SVD translation recovery without fallback:

- residual max: `5.506260218636483e-05`
- residual RMS: `8.439318241686304e-06`
- fit mode: `svd`
- evidence label: `direct_svd_in_tolerance`
- reference fallback used: `False`
- selected/SVD span distance: `0.0007867834950908272`
- held-out verification classification: `exact`
- first held-out verification error: `7.87178251723934e-08`

**Scope Boundaries**

This PR does not add:

- root exports
- weak advection-diffusion
- variable-coefficient advection-diffusion
- reaction-advection-diffusion
- custom initial-condition APIs
- KS runtime promotion
- time-translation APIs
- multidimensional or nonuniform grids
- PDEBench/The Well adapters
- operator APIs
- neural/callable generator APIs
- train/test split or leakage policy

**Validation**

- `python -m pytest`: `779 passed, 2 skipped`
- targeted advection-diffusion suites: passed
- public/API/release-gate/example suites: passed
- historical release gates through `v0.19`: passed
- `python -m build --sdist --wheel`: built `pdelie-0.19.0`
- clean wheel smoke: passed
- packaged examples, including advection-diffusion: passed
- `python scripts/check_notebooks.py`: `validated 9 notebooks`
- `git diff --check`: clean