### PR TITLE
Release v0.22 downstream discovery contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_21-release-gate:
+  v0_22-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.21 release gate
-        run: python -m pytest tests/test_v0_21_release_gate.py
+      - name: Run V0.22 release gate
+        run: python -m pytest tests/test_v0_22_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -76,6 +76,7 @@ jobs:
           python -m pdelie.examples.formula_generator_validation
           python -m pdelie.examples.generator_confidence_report
           python -m pdelie.examples.external_data_readiness
+          python -m pdelie.examples.downstream_discovery_contracts
   package-smoke:
     runs-on: ubuntu-latest
     steps:
@@ -136,9 +137,11 @@ jobs:
           )
           from pdelie.examples import (
               run_advection_diffusion_vertical_slice_example,
+              run_downstream_discovery_contracts_example,
               run_external_data_readiness_example,
               run_reaction_diffusion_vertical_slice_example,
           )
+          from pdelie.discovery import summarize_discovery_bridge_output, summarize_discovery_result
           from pdelie.invariants import (
               OrbitBatchResult,
               build_uniform_translation_orbit_batch,
@@ -147,6 +150,7 @@ jobs:
               summarize_uniform_translation_orbit,
           )
           from pdelie.reporting import (
+              summarize_downstream_discovery_workflow,
               summarize_field_batch_readiness,
               summarize_formula_generator_family,
               summarize_generator_confidence,
@@ -172,6 +176,9 @@ jobs:
           assert compute_periodic_window_coverage is not None
           assert diagnose_uniform_translation_consistency is not None
           assert summarize_uniform_translation_orbit is not None
+          assert summarize_discovery_bridge_output is not None
+          assert summarize_discovery_result is not None
+          assert summarize_downstream_discovery_workflow is not None
           assert summarize_field_batch_readiness is not None
           assert summarize_generator_fit_diagnostics is not None
           assert summarize_generator_confidence is not None
@@ -187,11 +194,15 @@ jobs:
           assert generate_advection_diffusion_1d_field_batch is not None
           assert AdvectionDiffusionResidualEvaluator is not None
           assert run_advection_diffusion_vertical_slice_example is not None
+          assert run_downstream_discovery_contracts_example is not None
           assert run_external_data_readiness_example is not None
           assert generate_reaction_diffusion_1d_field_batch is not None
           assert ReactionDiffusionResidualEvaluator is not None
           assert run_reaction_diffusion_vertical_slice_example is not None
           assert not hasattr(pdelie, "summarize_field_batch_readiness")
+          assert not hasattr(pdelie, "summarize_discovery_bridge_output")
+          assert not hasattr(pdelie, "summarize_discovery_result")
+          assert not hasattr(pdelie, "summarize_downstream_discovery_workflow")
           assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
           assert not hasattr(pdelie, "summarize_vertical_slice")
           assert not hasattr(pdelie, "compute_periodic_window_coverage")
@@ -206,6 +217,7 @@ jobs:
           assert not hasattr(pdelie, "generate_advection_diffusion_1d_field_batch")
           assert not hasattr(pdelie, "AdvectionDiffusionResidualEvaluator")
           assert not hasattr(pdelie, "run_advection_diffusion_vertical_slice_example")
+          assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
           assert not hasattr(pdelie, "run_external_data_readiness_example")
           assert not hasattr(pdelie, "generate_reaction_diffusion_1d_field_batch")
           assert not hasattr(pdelie, "ReactionDiffusionResidualEvaluator")
@@ -424,6 +436,53 @@ jobs:
           assert not hasattr(pdelie, "from_xarray_dataset")
           assert not hasattr(pdelie, "load_field_batch")
           print("field-readiness-smoke-ok")
+          PY
+      - name: Downstream discovery contracts smoke
+        run: |
+          /tmp/pdelie-rc-venv/bin/python - <<'PY'
+          import json
+          import pdelie
+
+          from pdelie.data import generate_heat_1d_field_batch
+          from pdelie.discovery import (
+              summarize_discovery_bridge_output,
+              summarize_discovery_result,
+              to_pysindy_trajectories,
+          )
+          from pdelie.examples import run_downstream_discovery_contracts_example
+          from pdelie.reporting import summarize_downstream_discovery_workflow
+
+          field = generate_heat_1d_field_batch(batch_size=1, num_times=7, num_points=8, seed=22022)
+          trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+          bridge = summarize_discovery_bridge_output(trajectories, time_values, feature_names)
+          result = summarize_discovery_result({
+              "status": "success",
+              "backend": "manual",
+              "feature_names": ["u"],
+              "library_feature_names": ["u_xx"],
+              "coefficients": [[0.1]],
+              "equation_terms": {"u": {"u_xx": 0.1}},
+              "equation_strings": {"u": "0.1*u_xx"},
+              "fit_diagnostics": {},
+          }, target_terms={"u": {"u_xx": 0.1}})
+          workflow = summarize_downstream_discovery_workflow(
+              discovery_inputs=bridge,
+              discovery_result=result,
+          )
+          example = run_downstream_discovery_contracts_example()
+          json.dumps(bridge)
+          json.dumps(result)
+          json.dumps(workflow)
+          json.dumps(example)
+          assert bridge["summary_type"] == "discovery_bridge_output"
+          assert result["summary_type"] == "discovery_result"
+          assert workflow["summary_type"] == "downstream_discovery_workflow"
+          assert example["summary_type"] == "downstream_discovery_contracts_example"
+          assert not hasattr(pdelie, "summarize_discovery_bridge_output")
+          assert not hasattr(pdelie, "summarize_discovery_result")
+          assert not hasattr(pdelie, "summarize_downstream_discovery_workflow")
+          assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
+          print("downstream-discovery-contracts-smoke-ok")
           PY
       - name: Generator fit diagnostics smoke
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ V0.x stable scope only:
 - canonical polynomial `GeneratorFamily` objects
 - runtime-only formula-backed generator records
 - frozen invariant/reporting/orbit utilities
+- downstream discovery contract reports
 
 ## Do not implement unless explicitly asked
 - neural generators
@@ -27,6 +28,7 @@ V0.x stable scope only:
 - multidimensional or nonuniform-grid expansion
 - paper-specific experiment logic
 - broad dataset adapters or file-based dataset loaders
+- broad discovery-backend frameworks
 - public KS runtime APIs
 - train/test policy or heldout-leakage management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.22.0
+
+First final release for the frozen V0.22 downstream discovery contracts slice.
+
+- adds `pdelie.discovery.summarize_discovery_bridge_output(...)` for JSON-compatible summaries over downstream bridge arrays
+- adds `pdelie.discovery.summarize_discovery_result(...)` for compact backend-neutral discovery-result and recovery summaries
+- adds `pdelie.reporting.summarize_downstream_discovery_workflow(...)` for composing readiness, confidence, orbit-batch, bridge, and discovery-result reports
+- adds `python -m pdelie.examples.downstream_discovery_contracts` and `pdelie.examples.run_downstream_discovery_contracts_example(...)` as JSON-only runtime smoke examples
+- freezes `summary_type == "discovery_bridge_output"`, `summary_type == "discovery_result"`, and `summary_type == "downstream_discovery_workflow"`
+- validates finite 2D trajectory arrays, shared trajectory shapes, strictly increasing time values, unique feature names, and JSON-compatible provenance
+- summarizes coefficient arrays by shape, finite status, norms, and nonzero counts without copying full coefficient matrices into reports
+- supports optional feature-keyed recovery summaries through `evaluate_discovery_recovery(...)`
+- reports orbit-batch source/shift provenance traceability without detecting leakage or managing splits
+- documents the new helpers in `API_STABILITY.md` as submodule-only runtime APIs with no root exports
+- preserves existing Heat/Burgers strong paths, weak residual reports, normalized periodic KdV, Fisher-KPP reaction-diffusion, advection-diffusion, confidence reports, external data readiness, invariant/orbit diagnostics, orbit batches, candidate validation, and formula-backed generator support
+
+Explicitly deferred for this final release:
+
+- split management or heldout-leakage detection
+- downstream augmentation policy
+- a general discovery-backend framework
+- manuscript benchmark thresholds
+- file loaders
+- `xarray.Dataset` support
+- PDEBench or The Well adapters
+- broad dataset adapter framework
+- multidimensional, multivariable, or nonuniform-grid support
+- new PDE support
+- KS runtime promotion
+- weak-form expansion
+- time-translation APIs
+- neural or callable generator APIs
+- operator-facing APIs
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.21.0
 
 First final release for the frozen V0.21 external data readiness report slice.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Numerical discovery and verification of Lie symmetries for PDE data.
 
-The current repository implements the frozen V0.21 external data readiness reporting slice for the existing Heat/Burgers/weak-report/KdV/Fisher-KPP/advection-diffusion engine:
+The current repository implements the frozen V0.22 downstream discovery contracts slice for the existing Heat/Burgers/weak-report/KdV/Fisher-KPP/advection-diffusion engine:
 
 - synthetic 1D heat equation
 - synthetic 1D Burgers equation
@@ -29,10 +29,12 @@ The current repository implements the frozen V0.21 external data readiness repor
 - formula-backed candidate validation through `candidate_kind = "formula_generator_family"`
 - unified generator confidence reports under `pdelie.reporting.summarize_generator_confidence`
 - external data readiness reports under `pdelie.reporting.summarize_field_batch_readiness`
+- downstream discovery bridge/result/workflow contract reports under `pdelie.discovery` and `pdelie.reporting`
 - reaction-diffusion vertical-slice example under `pdelie.examples.run_reaction_diffusion_vertical_slice_example`
 - advection-diffusion vertical-slice example under `pdelie.examples.run_advection_diffusion_vertical_slice_example`
 - generator-confidence example under `pdelie.examples.run_generator_confidence_report_example`
 - external-data-readiness example under `pdelie.examples.run_external_data_readiness_example`
+- downstream-discovery-contracts example under `pdelie.examples.run_downstream_discovery_contracts_example`
 - `FieldBatch -> DerivativeBatch -> ResidualBatch -> GeneratorFamily -> InvariantMapSpec -> VerificationReport`
 - one stable derivative backend: `spectral_fd`
 - family-shaped `GeneratorFamily` with explicit `basis_spec`
@@ -47,7 +49,7 @@ The current repository implements the frozen V0.21 external data readiness repor
 - one runtime-only thin PySINDy discovery adapter under `pdelie.discovery`
 - one runtime-only translation-canonical discovery-input helper under `pdelie.discovery`
 - one runtime-only robustness helper layer under `pdelie.data`
-- one compact current `v0_21-release-gate` CI job plus full editable tests and package smoke
+- one compact current `v0_22-release-gate` CI job plus full editable tests and package smoke
 
 ## Setup
 
@@ -96,7 +98,7 @@ python -m pytest
 
 ## Tutorial Notebooks
 
-The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.21`:
+The repository includes exploratory notebooks under `notebooks/` for the shipped symmetry/discovery runtime surface retained through `v0.22`:
 
 - `00_pde_timeseries_to_generators.ipynb`
 - `01_raw_vs_translation_canonical_discovery.ipynb`
@@ -266,8 +268,9 @@ Included in the current stable core:
 - advection-diffusion support in `v0.19` adds one scoped scalar 1D periodic constant-coefficient strong path with direct SVD translation-fit evidence; it does not add variable coefficients, weak advection-diffusion, reaction-advection-diffusion, custom initial-condition APIs, time translation, or broader grid support
 - confidence reporting in `v0.20` adds categorical generator-confidence reports; it does not add scalar scores, proof claims, benchmark success policy, train/test policy, or downstream leakage policy
 - external data readiness reporting in `v0.21` adds `FieldBatch` compatibility reports and residual preflight; it does not add file loaders, Dataset support, broad adapters, resampling, metadata mutation, train/test policy, or leakage policy
+- downstream discovery contracts in `v0.22` add bridge/result/workflow reports; they do not add a backend framework, split management, leakage detection, or manuscript benchmark policy
 
-Runtime-level public APIs in the frozen V0.21 slice:
+Runtime-level public APIs in the frozen V0.22 slice:
 
 - `pdelie.data.from_numpy` for strict runtime conversion of explicit NumPy/array-like 1D uniform rectilinear trajectory data into canonical `FieldBatch`
 - `pdelie.data.from_xarray` for strict runtime conversion of explicit `xarray.DataArray` 1D uniform rectilinear trajectory data into canonical `FieldBatch` when the optional `xarray` dependency is installed
@@ -313,6 +316,10 @@ Runtime-level public APIs in the frozen V0.21 slice:
 - `pdelie.discovery.fit_pysindy_discovery` for a runtime-only backend-native PySINDy fit adapter
 - `pdelie.discovery.build_translation_canonical_discovery_inputs` for runtime-only heuristic translation-canonical discovery inputs
 - `pdelie.discovery.summarize_recovery_grid` for runtime-only grouped recovery summaries
+- `pdelie.discovery.summarize_discovery_bridge_output` for JSON-compatible downstream bridge output summaries
+- `pdelie.discovery.summarize_discovery_result` for compact backend-neutral discovery result and recovery summaries
+- `pdelie.reporting.summarize_downstream_discovery_workflow` for combining readiness, confidence, orbit-batch, bridge, and discovery-result reports
+- `pdelie.examples.run_downstream_discovery_contracts_example` for a runtime smoke example of downstream discovery contracts, not a backend framework
 - `pdelie.data.add_gaussian_noise`, `subsample_time`, `subsample_x`, and `split_batch_train_heldout` for deterministic `FieldBatch` robustness workflows
 - `pdelie.portability.export_generator_family_manifest` and `pdelie.portability.import_generator_family_manifest` for manifest-level generator-family portability
 - `pdelie.portability.coerce_generator_family` for strict normalization of canonical, manifest, and narrow legacy translation inputs
@@ -324,7 +331,7 @@ Runtime-level public APIs in the frozen V0.21 slice:
 
 The degraded weak-path release wins in `v0.8` are frozen as representative contract-stability signals. They are fallback-backed release checks, not a general weak-superiority claim.
 
-The KdV support retained through `v0.21` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
+The KdV support retained through `v0.22` is normalized, periodic, scalar, 1D, and short-horizon. Accepted generator parameters outside the release-guaranteed regime are user-risk and are not general KdV stability guarantees.
 
 The `v0.10` reporting helpers are supportability APIs. They produce JSON-compatible runtime summaries, not canonical objects, manuscript tables, or artifact schemas.
 
@@ -352,10 +359,12 @@ The `v0.20` confidence-reporting work adds one categorical supportability helper
 
 The `v0.21` external-data readiness work adds one supportability helper for inspecting canonical `FieldBatch` inputs before residual, confidence, and downstream workflows. It does not load files, accept `xarray.Dataset`, infer PDE identity, resample grids, mutate metadata, or broaden stable numerical scope.
 
+The `v0.22` downstream discovery contracts work adds report-only contracts for bridge outputs, backend-neutral discovery results, optional recovery summaries, and workflow composition. It does not manage splits, detect heldout leakage, define benchmark success criteria, load files, or become a discovery-backend framework.
+
 Explicitly deferred:
 - stable multi-generator PDE fitting
 - multi-generator invariant machinery
-- broad downstream discovery contracts
+- broad downstream discovery backends or benchmark policy
 - `xarray.Dataset` support
 - file-based dataset loaders
 - multidimensional or nonuniform-grid ingestion

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,18 +1,18 @@
-# PDELie - Execution Plan (V0.21)
+# PDELie - Execution Plan (V0.22)
 
 **Status:** COMPLETE
 
-**V0.21 is complete as the external data readiness report release**
+**V0.22 is complete as the downstream discovery contracts release**
 
-This file is the completed execution record for the `v0.21` release series.
+This file is the completed execution record for the `v0.22` release series.
 
 ## Release Theme
 
-`v0.21` adds one scoped supportability/reporting API:
+`v0.22` adds downstream sparse-discovery supportability reports:
 
-> user-owned data -> canonical FieldBatch -> readiness report -> optional residual-evaluator preflight -> confidence/downstream workflows
+> FieldBatch / orbit batch / bridge outputs / backend-native discovery result -> JSON-compatible discovery summaries -> optional recovery summary -> downstream workflow report
 
-The public claim is intentionally narrow. The release adds a JSON-compatible reporting helper and a JSON-only example. It does not add file loaders, Dataset support, broad adapters, resampling, metadata mutation, train/test policy, downstream contracts, new PDEs, KS promotion, weak-form expansion, time translation, neural/callable generator APIs, operator APIs, or root exports.
+The public claim is intentionally narrow. The release standardizes runtime contracts around downstream discovery inputs, backend-neutral result mappings, recovery summaries, and workflow composition. It does not add split management, leakage detection, broad backend frameworks, file loaders, Dataset support, new PDEs, KS promotion, weak-form expansion, time translation, neural/callable generator APIs, operator APIs, or root exports.
 
 ## Milestone Status
 
@@ -26,122 +26,118 @@ The public claim is intentionally narrow. The release adds a JSON-compatible rep
 
 Authoritative scope:
 
-- `docs/planning/V0_21_SCOPE.md`
+- `docs/planning/V0_22_SCOPE.md`
 
-`API_STABILITY.md` was updated when the public `v0.21` readiness reporting API landed.
+`API_STABILITY.md` was updated when the public `v0.22` discovery/reporting APIs landed.
 
 ## Milestone 0 - Scope Freeze
 
-Freeze `v0.21` as an external-data readiness reporting release.
+Freeze `v0.22` as a downstream discovery contracts release.
 
 Closeout:
 
-- added `docs/planning/V0_21_SCOPE.md`
-- reset `PLAN.md` as the active `v0.21` execution record
-- updated `ROADMAP.md` to record `v0.21` as the current completed release
-- kept ingestion and numerical scope unchanged
+- added `docs/planning/V0_22_SCOPE.md`
+- reset `PLAN.md` as the active `v0.22` execution record
+- updated `ROADMAP.md` to record `v0.22` as the current completed release
+- kept numerical scope and ingestion scope unchanged
 
-## Milestone 1 - Semantics Freeze
+## Milestone 1 - Contract Semantics Freeze
 
-Frozen public helper:
+Frozen public helpers:
 
 ```python
-pdelie.reporting.summarize_field_batch_readiness(
-    field,
+pdelie.discovery.summarize_discovery_bridge_output(
+    trajectories,
+    time_values,
+    feature_names,
     *,
-    residual_evaluator=None,
-    expected_equation=None,
+    source_field_id=None,
+    provenance=None,
+)
+
+pdelie.discovery.summarize_discovery_result(
+    result,
+    *,
+    target_terms=None,
+    support_epsilon=1e-8,
+    train_residual=None,
+    heldout_residual=None,
+    source_result_id=None,
+)
+
+pdelie.reporting.summarize_downstream_discovery_workflow(
+    *,
+    field_readiness=None,
+    generator_confidence=None,
+    orbit_batch=None,
+    discovery_inputs=None,
+    discovery_result=None,
+    extra_metrics=None,
 )
 ```
 
 Frozen interpretation:
 
-- readiness is empirical compatibility with current stable contracts, not proof of scientific validity
 - reports are runtime summaries, not canonical objects
-- residual preflight is optional
-- metadata suggestions are report-only and conservative
-- no file loaders ship in `v0.21`
-- no Dataset support ships in `v0.21`
+- bridge reports validate arrays and provenance without returning transformed `FieldBatch` objects
+- discovery-result reports summarize coefficient matrices without copying them into output
+- `target_terms` must be feature-keyed
+- recovery summaries are empirical configured diagnostics, not benchmark success claims
+- orbit-batch provenance checks are traceability reports only
+- split/leakage diagnostics are deferred
 
-Frozen labels:
-
-- `ready`
-- `needs_attention`
-- `not_ready`
-
-Frozen component statuses:
-
-- `passed`
-- `warning`
-- `failed`
-- `not_configured`
-- `unavailable`
-
-## Milestone 2 - Readiness Helper
+## Milestone 2 - Bridge Output Summary
 
 Implemented:
 
-- `pdelie.reporting.summarize_field_batch_readiness(...)`
+- `pdelie.discovery.summarize_discovery_bridge_output(...)`
 
-The helper reports canonical dims/shape, finite values, mask state, time and x coordinate compatibility, metadata completeness, optional expected-equation matching, conservative metadata suggestions, and optional residual-evaluator preflight.
+The helper validates finite 2D trajectories, shared shape, strictly increasing time, unique feature names, and JSON-compatible provenance.
 
-## Milestone 3 - External Data Path Coverage
-
-Validation added for:
-
-- generated Heat, Burgers, KdV, Fisher-KPP, and advection-diffusion fields
-- `from_numpy(...)` fields
-- `from_xarray(...)` DataArray-derived fields when xarray is installed
-- metadata-incomplete fields
-- masked fields
-- nonfinite fields
-- multivariable fields
-- nonperiodic metadata
-- nonuniform coordinates
-- endpoint-duplicated periodic grids when a domain-length tag exposes the duplication
-- expected-equation mismatch
-- residual-evaluator mismatch
-
-## Milestone 4 - Example And Notebook Alignment
+## Milestone 3 - Discovery Result And Recovery Summary
 
 Implemented:
 
-- `pdelie.examples.run_external_data_readiness_example(...)`
-- command module: `python -m pdelie.examples.external_data_readiness`
+- `pdelie.discovery.summarize_discovery_result(...)`
 
-The example emits JSON only and demonstrates:
+The helper accepts backend-neutral and `fit_pysindy_discovery(...)`-style mappings, summarizes coefficients by compact norms/counts, handles backend failure mappings as reports, and optionally computes feature-keyed recovery summaries through `evaluate_discovery_recovery(...)`.
 
-- one ready `from_numpy(...)` Heat field
-- one metadata-incomplete field
-- one residual-evaluator mismatch
+## Milestone 4 - Workflow Summary And Example
 
-Tutorial material now points users to the public helper where external data is introduced.
+Implemented:
+
+- `pdelie.reporting.summarize_downstream_discovery_workflow(...)`
+- `pdelie.examples.run_downstream_discovery_contracts_example(...)`
+- command module: `python -m pdelie.examples.downstream_discovery_contracts`
+
+The example emits JSON only and combines field readiness, generator confidence, orbit-batch provenance, discovery bridge summaries, discovery-result summaries, and downstream workflow status.
 
 ## Milestone 5 - API / Public-surface Audit
 
 Audit result:
 
-- `summarize_field_batch_readiness(...)` is importable only from `pdelie.reporting`
-- `run_external_data_readiness_example(...)` is importable only from `pdelie.examples`
+- discovery summaries are importable only from `pdelie.discovery`
+- downstream workflow summaries are importable only from `pdelie.reporting`
+- the JSON example is importable only from `pdelie.examples`
 - root `pdelie` remains unchanged
-- `API_STABILITY.md` documents the new reporting helper and example runner
-- no file loader, Dataset adapter, PDEBench/The Well adapter, multidimensional/nonuniform stable API, resampling API, metadata mutation API, new PDE, KS runtime API, weak-form expansion, split/leakage policy, time-translation API, operator API, neural/callable generator API, or root export landed
+- `API_STABILITY.md` documents the new runtime helpers and example runner
+- no split management, leakage detection, broad backend framework, file loader, Dataset adapter, new PDE, KS runtime API, weak-form expansion, time-translation API, operator API, neural/callable generator API, or root export landed
 
 ## Milestone 6 - Release Gate And Readiness
 
 Implemented:
 
-- added compact `tests/test_v0_21_release_gate.py`
-- updated CI so the current explicit release gate is `v0_21-release-gate`
+- added compact `tests/test_v0_22_release_gate.py`
+- updated CI so the current explicit release gate is `v0_22-release-gate`
 - kept full editable `python -m pytest`
-- kept package smoke and added field-readiness smoke coverage
-- bumped package metadata to `0.21.0`
+- kept package smoke and added downstream-discovery-contracts smoke coverage
+- bumped package metadata to `0.22.0`
 - updated README, changelog, publishing notes, roadmap, and release readiness docs
-- documented direct `v0.21.0` Git-tag release path
+- documented direct `v0.22.0` Git-tag release path
 
 Required checks before tagging:
 
-- `v0_21-release-gate`
+- `v0_22-release-gate`
 - `editable-tests`
 - `package-smoke`
 
@@ -160,4 +156,5 @@ Local validation checklist:
 - `python -m pdelie.examples.formula_generator_validation`
 - `python -m pdelie.examples.generator_confidence_report`
 - `python -m pdelie.examples.external_data_readiness`
+- `python -m pdelie.examples.downstream_discovery_contracts`
 - `git diff --check`

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -453,6 +453,76 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.22` - Downstream discovery contracts
+**Status:** Completed
+
+`v0.22` is the completed downstream discovery contracts release after the `v0.21` external-data readiness release.
+
+Its purpose is:
+
+> standardize runtime reports around downstream sparse-discovery workflows without becoming a discovery-backend framework, split-policy layer, leakage detector, or manuscript benchmark.
+
+Completed release definition:
+
+`FieldBatch / orbit batch / bridge outputs / backend-native discovery result -> JSON-compatible discovery summaries -> optional recovery summary -> downstream workflow report`
+
+Completed scope:
+
+- `pdelie.discovery.summarize_discovery_bridge_output(...)`
+- `pdelie.discovery.summarize_discovery_result(...)`
+- `pdelie.reporting.summarize_downstream_discovery_workflow(...)`
+- `pdelie.examples.run_downstream_discovery_contracts_example(...)`
+- frozen report types: `discovery_bridge_output`, `discovery_result`, and `downstream_discovery_workflow`
+- bridge summaries over finite 2D trajectory arrays, strictly increasing time, and unique feature names
+- compact coefficient summaries without copying full coefficient matrices
+- optional feature-keyed recovery summaries via `evaluate_discovery_recovery(...)`
+- orbit-batch provenance traceability checks without split/leakage policy
+- compact current `v0_22-release-gate` readiness
+
+Release interpretation:
+
+- this is a runtime reporting/contracts release, not a canonical object release
+- recovery summaries are empirical configured diagnostics, not benchmark success claims
+- `v0.22.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no split management or heldout-leakage detection
+- no general discovery-backend framework
+- no file loaders or `xarray.Dataset` support
+- no PDEBench or The Well adapters
+- no multidimensional or nonuniform-grid stable support
+- no new PDEs
+- no KS runtime promotion
+- no weak-form expansion
+- no time-translation APIs
+- no neural or callable generator API
+- no operator-facing symmetry work
+- no root export expansion
+
+The authoritative `v0.22` scope freeze belongs in:
+
+- `V0_22_SCOPE.md`
+
+### Release Gate for `v0.22`
+
+`v0.22` is complete only if:
+
+- bridge summaries validate finite 2D arrays, increasing time, and unique feature names
+- discovery-result summaries handle success and failure mappings without leaking coefficient arrays
+- feature-keyed recovery summaries are covered by tests
+- workflow summaries combine readiness, confidence, orbit-batch, bridge, and discovery-result reports
+- orbit provenance checks report traceability only and do not manage splits or leakage
+- new APIs are importable from their submodules only
+- root `pdelie` remains unchanged
+- no file loader, Dataset adapter, broad backend framework, new PDE, KS runtime API, weak-form expansion, split/leakage policy, time-translation, neural/callable, or operator API lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.21` - External data readiness reports
 **Status:** Completed
 
@@ -475,7 +545,7 @@ Completed scope:
 - component statuses: `passed`, `warning`, `failed`, `not_configured`, `unavailable`
 - field shape/dim, finite-value, mask, coordinate, metadata, expected-equation, and residual-preflight diagnostics
 - conservative metadata suggestions without mutation
-- compact current `v0_21-release-gate` readiness
+- compact `v0_21-release-gate` readiness at release closeout
 
 Release interpretation:
 
@@ -1505,7 +1575,7 @@ It should **not** be edited every time a new idea appears.
 - `v0.19` = stable scalar 1D periodic constant-coefficient advection-diffusion strong path
 - `v0.20` = unified generator confidence reports
 - `v0.21` = external data readiness reports
-- `v0.22` = planned downstream discovery contracts and provenance reports
+- `v0.22` = downstream discovery contracts and provenance reports
 - `v0.23` = planned split/leakage provenance diagnostics, not split management
 - `v0.24` = planned weak-form supportability reset
 - `v0.25` = planned KdV scope decision

--- a/docs/planning/V0_15_PLUS_STRATEGY.md
+++ b/docs/planning/V0_15_PLUS_STRATEGY.md
@@ -10,7 +10,7 @@ Stable contracts remain in `docs/specs/API_STABILITY.md` only after APIs land.
 
 After `v0.14`, the highest-ROI path has been to move from read-only invariant diagnostics toward conservative user-facing data utilities, then external symmetry-candidate validation, then formula-backed generator support, then carefully scoped PDE expansion.
 
-After `v0.21`, the next planned path is to harden downstream discovery contracts and split/leakage provenance before considering more difficult axes such as weak forms, broader KdV/KS, multi-generator fitting, broad adapters, multidimensional/nonuniform grids, and time-translation actions.
+After `v0.22`, the next planned path is to harden split/leakage provenance diagnostics before considering more difficult axes such as weak forms, broader KdV/KS, multi-generator fitting, broad adapters, multidimensional/nonuniform grids, and time-translation actions.
 
 Staged sequence:
 
@@ -21,7 +21,7 @@ Staged sequence:
 - `v0.19`: stable advection-diffusion strong path
 - `v0.20`: unified generator confidence reports
 - `v0.21`: external data readiness reports
-- `v0.22`: planned downstream discovery contracts
+- `v0.22`: downstream discovery contracts
 - `v0.23`: planned split/leakage provenance diagnostics
 - `v0.24`: planned weak-form supportability reset
 - `v0.25`: planned KdV scope decision
@@ -274,15 +274,17 @@ Deferred:
 
 ## V0.22 - Downstream Discovery Contracts
 
-Planned theme:
+Completed theme:
 
 > standardize downstream discovery reporting without becoming a full experiment-policy framework.
 
-Candidate scope:
+Implemented scope:
 
-- broad downstream discovery contracts for runtime reports
+- downstream discovery bridge-output summaries
+- backend-neutral discovery result summaries
+- optional feature-keyed recovery summaries
+- downstream discovery workflow summaries
 - recovery and provenance summary reports
-- backend-native bridge-output summaries
 - orbit-materialization provenance checks
 - paper-agnostic downstream templates
 

--- a/docs/planning/V0_22_SCOPE.md
+++ b/docs/planning/V0_22_SCOPE.md
@@ -1,0 +1,122 @@
+# V0.22 Scope - Downstream Discovery Contracts
+
+**Status:** COMPLETE
+
+`v0.22` is a downstream supportability release for sparse-discovery workflows.
+
+Stable path:
+
+```text
+FieldBatch / orbit batch / bridge outputs / backend-native discovery result
+-> JSON-compatible discovery summaries
+-> optional recovery summary
+-> downstream workflow report
+```
+
+## Public Runtime APIs
+
+`v0.22` adds submodule-only runtime APIs:
+
+- `pdelie.discovery.summarize_discovery_bridge_output(...)`
+- `pdelie.discovery.summarize_discovery_result(...)`
+- `pdelie.reporting.summarize_downstream_discovery_workflow(...)`
+- `pdelie.examples.run_downstream_discovery_contracts_example(...)`
+
+No root `pdelie` exports are added.
+
+## Frozen Report Semantics
+
+Bridge summaries return JSON-compatible runtime reports with:
+
+- `summary_schema_version = "0.1"`
+- `summary_type = "discovery_bridge_output"`
+- finite trajectory checks
+- shared trajectory shape
+- strictly increasing time diagnostics
+- unique feature names
+- source/provenance metadata
+
+Discovery-result summaries return JSON-compatible runtime reports with:
+
+- `summary_schema_version = "0.1"`
+- `summary_type = "discovery_result"`
+- backend status and backend name
+- feature names and equation strings
+- sparse equation-term mappings
+- compact coefficient summaries
+- optional feature-keyed recovery summaries
+
+Workflow summaries return JSON-compatible runtime reports with:
+
+- `summary_schema_version = "0.1"`
+- `summary_type = "downstream_discovery_workflow"`
+- `workflow_label`
+- component statuses
+- nested readiness, confidence, orbit-batch, bridge, and discovery-result reports
+- orbit-provenance traceability diagnostics
+
+## Coefficient And Recovery Policy
+
+Discovery-result summaries do not copy full coefficient matrices into the report.
+
+Coefficient arrays are summarized by:
+
+- shape
+- finite status
+- L2 norm
+- L-infinity norm
+- nonzero count under `support_epsilon`
+
+When `target_terms` are supplied, they must be feature-keyed:
+
+```python
+{"u": {"u_xx": 0.1}}
+```
+
+Per-feature recovery uses the existing `evaluate_discovery_recovery(...)` support/coefficient diagnostics. Aggregate recovery counts and rates summarize exact, partial, and failed feature recovery.
+
+## Non-goals
+
+`v0.22` does not add:
+
+- split management
+- train/test split policy
+- heldout-leakage detection
+- downstream augmentation policy
+- a general discovery-backend framework
+- manuscript benchmark thresholds
+- file loaders
+- `xarray.Dataset` support
+- PDEBench or The Well adapters
+- multidimensional support
+- nonuniform-grid support
+- new PDEs
+- KS runtime promotion
+- weak-form expansion
+- time-translation APIs
+- neural or callable generator APIs
+- operator-facing APIs
+- root `pdelie` exports
+
+## Milestone Status
+
+- Milestone 0: COMPLETE - scope freeze
+- Milestone 1: COMPLETE - contract semantics freeze
+- Milestone 2: COMPLETE - bridge output summary
+- Milestone 3: COMPLETE - discovery result and recovery summary
+- Milestone 4: COMPLETE - workflow summary and example
+- Milestone 5: COMPLETE - API/public-surface audit
+- Milestone 6: COMPLETE - release gate and readiness
+
+## Release Gate Expectations
+
+`v0.22` is complete only if:
+
+- bridge summaries validate finite 2D trajectory arrays, strictly increasing time, and unique feature names
+- discovery-result summaries accept PySINDy-style and backend-neutral result mappings without leaking coefficient arrays
+- feature-keyed recovery summaries are covered by tests
+- workflow summaries combine readiness, confidence, orbit-batch, bridge, and discovery-result reports
+- orbit provenance checks report traceability only and do not manage splits or leakage
+- new APIs are importable from their submodules only
+- root `pdelie` remains unchanged
+- no file loader, Dataset adapter, broad backend framework, new PDE, KS runtime API, weak-form expansion, split/leakage policy, time translation, neural/callable generator API, or operator API lands

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.21.0`, release completion means:
+For the current `v0.x` series, including `v0.22.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.21.0` is intentionally a Git-tag-only release.
-Do not publish to TestPyPI or PyPI for `v0.21.0`.
+`v0.22.0` is intentionally a Git-tag-only release.
+Do not publish to TestPyPI or PyPI for `v0.22.0`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_22_RELEASE_READINESS.md
+++ b/docs/releases/V0_22_RELEASE_READINESS.md
@@ -1,0 +1,93 @@
+# V0.22 Release Readiness
+
+- package version: `0.22.0`
+- git tag: `v0.22.0`
+- release type: final Git-tag release
+
+`v0.22.0` is a Git-tag-only release.
+Do not publish to TestPyPI or PyPI for `v0.22.0`.
+
+## Release Summary
+
+`v0.22` closes the downstream discovery contracts slice:
+
+```text
+FieldBatch / orbit batch / bridge outputs / backend-native discovery result
+-> JSON-compatible discovery summaries
+-> optional recovery summary
+-> downstream workflow report
+```
+
+## Public API Notes
+
+New submodule-only runtime APIs:
+
+- `pdelie.discovery.summarize_discovery_bridge_output(...)`
+- `pdelie.discovery.summarize_discovery_result(...)`
+- `pdelie.reporting.summarize_downstream_discovery_workflow(...)`
+- `pdelie.examples.run_downstream_discovery_contracts_example(...)`
+
+No root `pdelie` exports are added.
+
+## Non-goals Preserved
+
+- no split management or heldout-leakage detection
+- no general discovery-backend framework
+- no manuscript benchmark policy
+- no file loaders or `xarray.Dataset` support
+- no PDEBench/The Well adapters
+- no multidimensional or nonuniform-grid stable support
+- no new PDEs
+- no KS runtime promotion
+- no weak-form expansion
+- no time-translation APIs
+- no neural/callable generator APIs
+- no operator-facing APIs
+
+## CI Expectations
+
+The current explicit release gate is:
+
+- `v0_22-release-gate`
+
+The workflow also keeps:
+
+- full editable `python -m pytest`
+- package build and clean-wheel smoke
+- example smoke, including `python -m pdelie.examples.downstream_discovery_contracts`
+
+## Local Validation Checklist
+
+Before tagging `v0.22.0`, run:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.reaction_diffusion_vertical_slice
+python -m pdelie.examples.advection_diffusion_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
+python -m pdelie.examples.symmetry_candidate_validation
+python -m pdelie.examples.formula_generator_validation
+python -m pdelie.examples.generator_confidence_report
+python -m pdelie.examples.external_data_readiness
+python -m pdelie.examples.downstream_discovery_contracts
+git diff --check
+```
+
+Expected build artifacts:
+
+- `dist/pdelie-0.22.0.tar.gz`
+- `dist/pdelie-0.22.0-py3-none-any.whl`
+
+## Direct Tag Checklist
+
+```bash
+git tag v0.22.0
+git push origin v0.22.0
+```
+
+Do not publish to TestPyPI or PyPI for `v0.22.0`.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -255,6 +255,22 @@ Runtime public API for the frozen `v0.21` Milestone 2/M4 slice:
 - this API does not add new PDEs, public KS runtime APIs, weak-form expansion, broad adapters, multidimensional or nonuniform stable support, time translation, split policy, neural/callable generators, or operator-facing APIs
 - these APIs have no root `pdelie` exports
 
+Runtime public API for the frozen `v0.22` Milestone 2/M3/M4 slice:
+
+- `pdelie.discovery.summarize_discovery_bridge_output` for JSON-compatible runtime summaries over downstream bridge arrays
+- bridge summaries use `summary_type = "discovery_bridge_output"` and `summary_schema_version = "0.1"`
+- bridge summaries validate finite 2D trajectories, shared trajectory shape, strictly increasing time, unique feature names, and JSON-compatible source/provenance metadata
+- `pdelie.discovery.summarize_discovery_result` for JSON-compatible runtime summaries over backend-neutral or `fit_pysindy_discovery(...)`-style discovery-result mappings
+- discovery-result summaries use `summary_type = "discovery_result"` and compact coefficient summaries by shape, finite status, norms, and nonzero count; they do not copy full coefficient matrices into the report
+- optional `target_terms` must be feature-keyed and recovery summaries reuse `evaluate_discovery_recovery(...)` for exact, partial, and failed per-feature recovery diagnostics
+- backend failure mappings are summarized as reports instead of raising, while malformed mappings and nonfinite coefficients raise typed validation errors
+- `pdelie.reporting.summarize_downstream_discovery_workflow` for JSON-compatible workflow reports that combine field-readiness, generator-confidence, orbit-batch, bridge, and discovery-result reports
+- downstream workflow reports use `summary_type = "downstream_discovery_workflow"` and report orbit-batch provenance traceability without detecting leakage or managing splits
+- `pdelie.examples.run_downstream_discovery_contracts_example` for a compact JSON-only runtime smoke example
+- these APIs are runtime supportability reports, not canonical objects, backend plugin frameworks, split policies, leakage detectors, manuscript benchmark summaries, file loaders, or transformed `FieldBatch` collections
+- this API does not add new PDEs, public KS runtime APIs, weak-form expansion, broad adapters, `xarray.Dataset` support, multidimensional or nonuniform stable support, time translation, neural/callable generators, or operator-facing APIs
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -19,6 +19,7 @@ It is a **library**, not a project repo.
 - canonical polynomial `GeneratorFamily` parameterizations
 - runtime-only formula-backed generator records and empirical candidate-validation reports
 - frozen invariant, reporting, uniform-translation orbit, and materialized-orbit utilities
+- runtime-only downstream discovery bridge/result/workflow reports
 - synthetic + small benchmark PDEs, currently including Heat, Burgers, normalized short-horizon KdV, frozen scalar 1D Fisher-KPP reaction-diffusion, and frozen scalar 1D constant-coefficient advection-diffusion strong paths
 
 ## Experimental
@@ -27,6 +28,7 @@ It is a **library**, not a project repo.
 - Python-callable generators and executable formula strings
 - weak-form derivatives and weak-form extensions beyond the frozen `v0.8` weak residual report slice
 - broad dataset adapters, file-based dataset loaders, and Dataset-level ingestion
+- broad discovery-backend frameworks, split management, and heldout-leakage policy
 - multidimensional, multivariable, and nonuniform-grid stable expansion
 - operator-level symmetry discovery
 - multi-generator invariant charts

--- a/notebooks/00_pde_timeseries_to_generators.ipynb
+++ b/notebooks/00_pde_timeseries_to_generators.ipynb
@@ -7,11 +7,11 @@
    "source": [
     "# PDE time series to generators with confidence\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",
-    "Quickstart for the V0.21 surface: start from a canonical PDE time series, compute derivatives and residuals, fit a translation generator, verify it on held-out data, and read the confidence evidence.\n",
+    "Quickstart for the V0.22 surface: start from a canonical PDE time series, compute derivatives and residuals, fit a translation generator, verify it on held-out data, and read the confidence evidence.\n",
     "\n",
     "## What you will learn\n",
     "\n",
@@ -272,7 +272,7 @@
    "source": [
     "## Recap\n",
     "\n",
-    "You saw the core V0.21 flow: canonical field, derivatives, residual, fitted translation generator, held-out verification, and a compact confidence card.\n",
+    "You saw the core V0.22 flow: canonical field, derivatives, residual, fitted translation generator, held-out verification, and a compact confidence card.\n",
     "\n",
     "## Common pitfalls\n",
     "\n",

--- a/notebooks/01_raw_vs_translation_canonical_discovery.ipynb
+++ b/notebooks/01_raw_vs_translation_canonical_discovery.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Raw vs translation-canonical discovery inputs\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/02_robustness_sweeps.ipynb
+++ b/notebooks/02_robustness_sweeps.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Robustness sweeps as diagnostic evidence\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/03_portability_round_trips.ipynb
+++ b/notebooks/03_portability_round_trips.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Portability round-trips with empirical revalidation\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",
@@ -102,7 +102,7 @@
    "source": [
     "manifest = export_generator_family_manifest(\n",
     "    generator,\n",
-    "    pdelie_version=\"tutorial-v0.21\",\n",
+    "    pdelie_version=\"tutorial-v0.22\",\n",
     "    provenance={\"notebook\": \"03_portability_round_trips\"},\n",
     ")\n",
     "imported = import_generator_family_manifest(manifest)\n",

--- a/notebooks/04_discovered_vs_known_translation_generators.ipynb
+++ b/notebooks/04_discovered_vs_known_translation_generators.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Comparing fitted, finite-map, formula-backed, and failed candidates\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/05_closure_algebra_diagnostics.ipynb
+++ b/notebooks/05_closure_algebra_diagnostics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Closure algebra diagnostics and formula metadata\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/06_orbit_coverage_diagnostics.ipynb
+++ b/notebooks/06_orbit_coverage_diagnostics.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Orbit, coverage, and materialized translation batches\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/07_external_symmetry_candidates.ipynb
+++ b/notebooks/07_external_symmetry_candidates.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# External and formula-backed symmetry candidates\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/08_downstream_task_template.ipynb
+++ b/notebooks/08_downstream_task_template.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Downstream task template: symmetry-aware inputs without paper policy\n",
     "\n",
-    "**Current surface:** V0.21.\n",
+    "**Current surface:** V0.22.\n",
     "\n",
     "## Purpose\n",
     "\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,6 @@
 # PDELie Tutorial Notebooks
 
-This directory is the recommended entry point for new PDELie users on the shipped `v0.21` surface.
+This directory is the recommended entry point for new PDELie users on the shipped `v0.22` surface.
 
 Tutorial promise:
 
@@ -32,6 +32,7 @@ These notebooks are tutorials, not API contracts. Example outputs are runtime su
 - Producing JSON-compatible residual, fit, verification, invariant, orbit, candidate, and formula summaries.
 - Producing categorical generator confidence reports with `summarize_generator_confidence(...)`.
 - Auditing canonical external-data readiness with `summarize_field_batch_readiness(...)` before residual or downstream workflows.
+- Summarizing downstream sparse-discovery bridge inputs, backend-neutral results, recovery, and workflow contracts.
 - Auditing finite uniform x-translation workflows with coverage, consistency, and provenance reports.
 - Materializing uniform translation orbit batches while preserving source/shift provenance.
 - Validating externally supplied `GeneratorFamily`, `InvariantMapSpec`, and `FormulaGeneratorFamily` candidates empirically.
@@ -44,7 +45,7 @@ These notebooks are tutorials, not API contracts. Example outputs are runtime su
 - Not a train/test split manager or leakage detector.
 - Not an operator-learning framework.
 - Not a paper-specific experiment pipeline.
-- Not a general nonuniform or multidimensional PDE framework in `v0.21`.
+- Not a general nonuniform or multidimensional PDE framework in `v0.22`.
 
 KS remains internal feasibility/no-go evidence. `v0.19` advection-diffusion is implemented only as a frozen scalar 1D periodic constant-coefficient strong path.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.21.0"
-description = "V0.21 external data readiness reports plus retained Heat/Burgers/weak-report/KdV/Fisher-KPP/advection-diffusion and symmetry diagnostics"
+version = "0.22.0"
+description = "V0.22 downstream discovery contracts plus retained external data readiness, confidence reports, PDE strong paths, and symmetry diagnostics"
 requires-python = ">=3.11"
 dependencies = [
   "numpy>=1.24,<2",

--- a/scripts/check_notebooks.py
+++ b/scripts/check_notebooks.py
@@ -68,8 +68,8 @@ def main() -> None:
                 failures.append(f"{path}: missing '{phrase}'")
         if not any(phrase in text for phrase in REQUIRED_SCOPE_PHRASES):
             failures.append(f"{path}: missing 'Out of scope' or 'Limitations'")
-        if "V0.21" not in text and "v0.21" not in text:
-            failures.append(f"{path}: should mention current V0.21 surface")
+        if "V0.22" not in text and "v0.22" not in text:
+            failures.append(f"{path}: should mention current V0.22 surface")
         for marker in STALE_MARKERS:
             if marker in text:
                 failures.append(f"{path}: stale marker '{marker}'")

--- a/src/pdelie/discovery/__init__.py
+++ b/src/pdelie/discovery/__init__.py
@@ -1,4 +1,5 @@
 from pdelie.discovery.evaluation import evaluate_discovery_recovery
+from pdelie.discovery.contracts import summarize_discovery_bridge_output, summarize_discovery_result
 from pdelie.discovery.pysindy_adapter import fit_pysindy_discovery
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
 from pdelie.discovery.recovery_grid import summarize_recovery_grid
@@ -8,6 +9,8 @@ __all__ = [
     "build_translation_canonical_discovery_inputs",
     "evaluate_discovery_recovery",
     "fit_pysindy_discovery",
+    "summarize_discovery_bridge_output",
+    "summarize_discovery_result",
     "summarize_recovery_grid",
     "to_pysindy_trajectories",
 ]

--- a/src/pdelie/discovery/contracts.py
+++ b/src/pdelie/discovery/contracts.py
@@ -29,8 +29,8 @@ def _json_safe(value: Any) -> Any:
 def _validate_json_compatible(value: Any, *, name: str) -> Any:
     safe_value = _json_safe(value)
     try:
-        json.dumps(safe_value)
-    except TypeError as exc:
+        json.dumps(safe_value, allow_nan=False)
+    except (TypeError, ValueError) as exc:
         raise SchemaValidationError(f"{name} must be JSON-compatible after reporting conversion.") from exc
     return safe_value
 

--- a/src/pdelie/discovery/contracts.py
+++ b/src/pdelie/discovery/contracts.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from pdelie.discovery.evaluation import evaluate_discovery_recovery
+from pdelie.errors import SchemaValidationError
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_RESULT_STATUSES = frozenset({"success", "failed"})
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _validate_json_compatible(value: Any, *, name: str) -> Any:
+    safe_value = _json_safe(value)
+    try:
+        json.dumps(safe_value)
+    except TypeError as exc:
+        raise SchemaValidationError(f"{name} must be JSON-compatible after reporting conversion.") from exc
+    return safe_value
+
+
+def _summary_payload(summary_type: str, **items: Any) -> dict[str, Any]:
+    return _validate_json_compatible(
+        {
+            "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+            "summary_type": summary_type,
+            **items,
+        },
+        name=f"{summary_type} summary",
+    )
+
+
+def _require_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaValidationError(f"{name} must be a mapping.")
+    return value
+
+
+def _finite_float(value: object, *, name: str) -> float:
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite scalar float.") from exc
+    if not np.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be a finite scalar float.")
+    return normalized
+
+
+def _support_epsilon(value: object) -> float:
+    epsilon = _finite_float(value, name="support_epsilon")
+    if epsilon < 0.0:
+        raise SchemaValidationError("support_epsilon must be non-negative.")
+    return epsilon
+
+
+def _validate_trajectories(trajectories: object) -> list[np.ndarray]:
+    if not isinstance(trajectories, (list, tuple)) or not trajectories:
+        raise SchemaValidationError("trajectories must be a non-empty list or tuple of 2D finite numeric arrays.")
+
+    normalized: list[np.ndarray] = []
+    expected_shape: tuple[int, int] | None = None
+    for index, trajectory in enumerate(trajectories):
+        try:
+            array = np.asarray(trajectory, dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise SchemaValidationError(
+                f"trajectories[{index}] must be a 2D finite numeric array."
+            ) from exc
+        if array.ndim != 2 or 0 in array.shape:
+            raise SchemaValidationError(f"trajectories[{index}] must be a non-empty 2D finite numeric array.")
+        if not np.all(np.isfinite(array)):
+            raise SchemaValidationError(f"trajectories[{index}] must contain only finite values.")
+        shape = tuple(int(dim) for dim in array.shape)
+        if expected_shape is None:
+            expected_shape = shape
+        elif shape != expected_shape:
+            raise SchemaValidationError("all trajectories must share identical shape.")
+        normalized.append(array)
+    return normalized
+
+
+def _validate_time_values(time_values: object, *, num_times: int) -> np.ndarray:
+    try:
+        array = np.asarray(time_values, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError("time_values must be a one-dimensional finite numeric array.") from exc
+    if array.ndim != 1 or array.size != num_times:
+        raise SchemaValidationError("time_values must be one-dimensional and match trajectory time dimension.")
+    if array.size < 2:
+        raise SchemaValidationError("time_values must contain at least two entries.")
+    if not np.all(np.isfinite(array)):
+        raise SchemaValidationError("time_values must contain only finite values.")
+    if not np.all(np.diff(array) > 0.0):
+        raise SchemaValidationError("time_values must be strictly increasing.")
+    return array
+
+
+def _validate_feature_names(feature_names: object, *, num_features: int) -> list[str]:
+    if isinstance(feature_names, (str, bytes)) or not isinstance(feature_names, Sequence):
+        raise SchemaValidationError("feature_names must be a sequence of unique non-empty strings.")
+    normalized = list(feature_names)
+    if len(normalized) != num_features:
+        raise SchemaValidationError("feature_names length must match trajectory feature dimension.")
+    if any(not isinstance(name, str) or not name for name in normalized):
+        raise SchemaValidationError("feature_names must contain only non-empty strings.")
+    if len(set(normalized)) != len(normalized):
+        raise SchemaValidationError("feature_names must be unique.")
+    return normalized
+
+
+def _validate_string_mapping(value: object, *, name: str, feature_names: Sequence[str]) -> dict[str, str]:
+    mapping = _require_mapping(value, name=name)
+    normalized: dict[str, str] = {}
+    expected_keys = set(feature_names)
+    if set(mapping) != expected_keys:
+        raise SchemaValidationError(f"{name} keys must exactly match feature_names.")
+    for key, item in mapping.items():
+        if not isinstance(key, str) or not key:
+            raise SchemaValidationError(f"{name} keys must be non-empty strings.")
+        if not isinstance(item, str):
+            raise SchemaValidationError(f"{name}.{key} must be a string.")
+        normalized[key] = item
+    return normalized
+
+
+def _validate_term_mapping(value: object, *, name: str) -> dict[str, float]:
+    mapping = _require_mapping(value, name=name)
+    normalized: dict[str, float] = {}
+    for term, coefficient in mapping.items():
+        if not isinstance(term, str) or not term:
+            raise SchemaValidationError(f"{name} term keys must be non-empty strings.")
+        normalized[term] = _finite_float(coefficient, name=f"{name}.{term}")
+    return normalized
+
+
+def _validate_feature_term_mapping(
+    value: object,
+    *,
+    name: str,
+    feature_names: Sequence[str],
+) -> dict[str, dict[str, float]]:
+    mapping = _require_mapping(value, name=name)
+    expected_keys = set(feature_names)
+    if set(mapping) != expected_keys:
+        raise SchemaValidationError(f"{name} keys must exactly match feature_names.")
+    return {
+        str(feature_name): _validate_term_mapping(
+            mapping[feature_name],
+            name=f"{name}.{feature_name}",
+        )
+        for feature_name in feature_names
+    }
+
+
+def _coefficient_summary(coefficients: object, *, support_epsilon: float) -> dict[str, Any]:
+    if coefficients is None:
+        return {
+            "present": False,
+            "shape": None,
+            "finite": None,
+            "l2_norm": None,
+            "linf_norm": None,
+            "nonzero_count": None,
+        }
+    try:
+        array = np.asarray(coefficients, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError("coefficients must be a finite numeric array or None.") from exc
+    if array.ndim != 2:
+        raise SchemaValidationError("coefficients must be a 2D numeric array when supplied.")
+    if not np.all(np.isfinite(array)):
+        raise SchemaValidationError("coefficients must contain only finite values.")
+    return {
+        "present": True,
+        "shape": [int(dim) for dim in array.shape],
+        "finite": True,
+        "l2_norm": float(np.linalg.norm(array)),
+        "linf_norm": float(np.max(np.abs(array))) if array.size else 0.0,
+        "nonzero_count": int(np.count_nonzero(np.abs(array) > support_epsilon)),
+    }
+
+
+def _residual_summary_or_none(value: object, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    try:
+        array = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError) as exc:
+        raise SchemaValidationError(f"{name} must be a finite numeric scalar or array-like.") from exc
+    if array.size == 0:
+        raise SchemaValidationError(f"{name} must be non-empty after flattening.")
+    if not np.all(np.isfinite(array)):
+        raise SchemaValidationError(f"{name} must contain only finite values.")
+    return {
+        "size": int(array.size),
+        "l2_norm": float(np.linalg.norm(array)),
+        "rms": float(np.sqrt(np.mean(array**2))),
+        "max_abs": float(np.max(np.abs(array))),
+    }
+
+
+def _recovery_summary(
+    target_terms: object,
+    discovered_terms: Mapping[str, Mapping[str, float]],
+    *,
+    feature_names: Sequence[str],
+    support_epsilon: float,
+    train_residual: object | None,
+    heldout_residual: object | None,
+) -> dict[str, Any]:
+    normalized_targets = _validate_feature_term_mapping(
+        target_terms,
+        name="target_terms",
+        feature_names=feature_names,
+    )
+    by_feature: dict[str, dict[str, object]] = {}
+    counts = {"exact": 0, "partial": 0, "failed": 0}
+    for feature_name in feature_names:
+        recovery = evaluate_discovery_recovery(
+            normalized_targets[feature_name],
+            discovered_terms[feature_name],
+            support_epsilon=support_epsilon,
+            train_residual=train_residual,
+            heldout_residual=heldout_residual,
+        )
+        classification = str(recovery["classification"])
+        counts[classification] = counts.get(classification, 0) + 1
+        by_feature[feature_name] = recovery
+
+    total = len(feature_names)
+    return {
+        "support_epsilon": support_epsilon,
+        "by_feature": by_feature,
+        "aggregate": {
+            "feature_count": total,
+            "exact_count": counts["exact"],
+            "partial_count": counts["partial"],
+            "failed_count": counts["failed"],
+            "exact_rate": float(counts["exact"] / total) if total else 0.0,
+            "partial_rate": float(counts["partial"] / total) if total else 0.0,
+            "failed_rate": float(counts["failed"] / total) if total else 0.0,
+        },
+    }
+
+
+def summarize_discovery_bridge_output(
+    trajectories: object,
+    time_values: object,
+    feature_names: object,
+    *,
+    source_field_id: object | None = None,
+    provenance: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Summarize downstream discovery bridge arrays without returning transformed fields."""
+
+    normalized_trajectories = _validate_trajectories(trajectories)
+    num_times, num_features = normalized_trajectories[0].shape
+    normalized_time = _validate_time_values(time_values, num_times=num_times)
+    normalized_features = _validate_feature_names(feature_names, num_features=num_features)
+    normalized_provenance = (
+        None
+        if provenance is None
+        else _validate_json_compatible(_require_mapping(provenance, name="provenance"), name="provenance")
+    )
+    normalized_source_field_id = (
+        None
+        if source_field_id is None
+        else _validate_json_compatible(source_field_id, name="source_field_id")
+    )
+
+    return _summary_payload(
+        "discovery_bridge_output",
+        source_field_id=normalized_source_field_id,
+        provenance=normalized_provenance,
+        trajectory_count=len(normalized_trajectories),
+        trajectory_shape=[int(dim) for dim in normalized_trajectories[0].shape],
+        trajectory_shapes=[[int(dim) for dim in trajectory.shape] for trajectory in normalized_trajectories],
+        num_times=int(num_times),
+        num_state_features=int(num_features),
+        feature_names=normalized_features,
+        time_start=float(normalized_time[0]),
+        time_end=float(normalized_time[-1]),
+        time_span=float(normalized_time[-1] - normalized_time[0]),
+        strictly_increasing_time=True,
+        finite=True,
+        returns_field_batch=False,
+    )
+
+
+def summarize_discovery_result(
+    result: Mapping[str, Any],
+    *,
+    target_terms: Mapping[str, Mapping[str, float]] | None = None,
+    support_epsilon: float = 1e-8,
+    train_residual: object | None = None,
+    heldout_residual: object | None = None,
+    source_result_id: object | None = None,
+) -> dict[str, Any]:
+    """Normalize backend-native discovery results into a compact JSON-compatible report."""
+
+    result_mapping = _require_mapping(result, name="result")
+    epsilon = _support_epsilon(support_epsilon)
+    status = result_mapping.get("status")
+    if status not in _RESULT_STATUSES:
+        raise SchemaValidationError(f"result.status must be one of {sorted(_RESULT_STATUSES)}.")
+    backend = result_mapping.get("backend")
+    if not isinstance(backend, str) or not backend:
+        raise SchemaValidationError("result.backend must be a non-empty string.")
+
+    feature_name_input = result_mapping.get("feature_names")
+    feature_names = _validate_feature_names(
+        feature_name_input,
+        num_features=len(feature_name_input) if isinstance(feature_name_input, Sequence) and not isinstance(feature_name_input, (str, bytes)) else -1,
+    )
+    raw_equation_terms = result_mapping.get("equation_terms", {})
+    raw_equation_strings = result_mapping.get("equation_strings", {})
+    if status == "failed" and raw_equation_terms == {}:
+        equation_terms = {feature_name: {} for feature_name in feature_names}
+    else:
+        equation_terms = _validate_feature_term_mapping(
+            raw_equation_terms,
+            name="result.equation_terms",
+            feature_names=feature_names,
+        )
+    if status == "failed" and raw_equation_strings == {}:
+        equation_strings = {feature_name: "" for feature_name in feature_names}
+    else:
+        equation_strings = _validate_string_mapping(
+            raw_equation_strings,
+            name="result.equation_strings",
+            feature_names=feature_names,
+        )
+    library_feature_names = result_mapping.get("library_feature_names", [])
+    if isinstance(library_feature_names, (str, bytes)) or not isinstance(library_feature_names, Sequence):
+        raise SchemaValidationError("result.library_feature_names must be a sequence when supplied.")
+    normalized_library_feature_names = [
+        str(name) for name in library_feature_names if isinstance(name, str) and name
+    ]
+    if len(normalized_library_feature_names) != len(list(library_feature_names)):
+        raise SchemaValidationError("result.library_feature_names must contain only non-empty strings.")
+
+    coefficient_summary = _coefficient_summary(
+        result_mapping.get("coefficients"),
+        support_epsilon=epsilon,
+    )
+    fit_diagnostics = _validate_json_compatible(
+        _require_mapping(result_mapping.get("fit_diagnostics", {}), name="result.fit_diagnostics"),
+        name="result.fit_diagnostics",
+    )
+    fit_config = _validate_json_compatible(
+        result_mapping.get("fit_config", {}),
+        name="result.fit_config",
+    )
+    normalized_source_result_id = (
+        None
+        if source_result_id is None
+        else _validate_json_compatible(source_result_id, name="source_result_id")
+    )
+    failure_reason = result_mapping.get("failure_reason")
+    if failure_reason is not None and (not isinstance(failure_reason, str) or not failure_reason):
+        raise SchemaValidationError("result.failure_reason must be a non-empty string when supplied.")
+
+    recovery = None
+    if target_terms is not None:
+        recovery = _recovery_summary(
+            target_terms,
+            equation_terms,
+            feature_names=feature_names,
+            support_epsilon=epsilon,
+            train_residual=train_residual,
+            heldout_residual=heldout_residual,
+        )
+
+    return _summary_payload(
+        "discovery_result",
+        source_result_id=normalized_source_result_id,
+        status=status,
+        backend=backend,
+        feature_names=feature_names,
+        library_feature_names=normalized_library_feature_names,
+        equation_terms=equation_terms,
+        equation_strings=equation_strings,
+        coefficient_summary=coefficient_summary,
+        support_epsilon=epsilon,
+        fit_diagnostics=fit_diagnostics,
+        fit_config=fit_config,
+        failure_reason=failure_reason,
+        residuals={
+            "train": _residual_summary_or_none(train_residual, name="train_residual"),
+            "heldout": _residual_summary_or_none(heldout_residual, name="heldout_residual"),
+        },
+        recovery=recovery,
+        returns_coefficients=False,
+    )

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "run_advection_diffusion_vertical_slice_example",
+    "run_downstream_discovery_contracts_example",
     "run_external_data_readiness_example",
     "run_heat_vertical_slice_example",
     "run_formula_generator_validation_example",
@@ -16,6 +17,14 @@ __all__ = [
 def run_advection_diffusion_vertical_slice_example() -> dict[str, object]:
     from pdelie.examples.advection_diffusion_vertical_slice import (
         run_advection_diffusion_vertical_slice_example as _impl,
+    )
+
+    return _impl()
+
+
+def run_downstream_discovery_contracts_example() -> dict[str, object]:
+    from pdelie.examples.downstream_discovery_contracts import (
+        run_downstream_discovery_contracts_example as _impl,
     )
 
     return _impl()

--- a/src/pdelie/examples/downstream_discovery_contracts.py
+++ b/src/pdelie/examples/downstream_discovery_contracts.py
@@ -109,7 +109,7 @@ def run_downstream_discovery_contracts_example() -> dict[str, object]:
 
 
 def main() -> None:
-    print(json.dumps(run_downstream_discovery_contracts_example(), indent=2))
+    print(json.dumps(run_downstream_discovery_contracts_example(), indent=2, allow_nan=False))
 
 
 if __name__ == "__main__":

--- a/src/pdelie/examples/downstream_discovery_contracts.py
+++ b/src/pdelie/examples/downstream_discovery_contracts.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.discovery import (
+    summarize_discovery_bridge_output,
+    summarize_discovery_result,
+    to_pysindy_trajectories,
+)
+from pdelie.invariants import build_uniform_translation_orbit_batch
+from pdelie.reporting import (
+    summarize_downstream_discovery_workflow,
+    summarize_field_batch_readiness,
+    summarize_generator_confidence,
+)
+from pdelie.residuals import HeatResidualEvaluator
+from pdelie.symmetry.fitting import fit_translation_generator
+from pdelie.verification import verify_translation_generator
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+_SHIFTS = (0.0, float(2.0 * np.pi), float(np.pi / 4.0))
+
+
+def _manual_discovery_result() -> dict[str, object]:
+    return {
+        "status": "success",
+        "backend": "manual_backend_neutral",
+        "feature_names": ["u"],
+        "library_feature_names": ["u_xx"],
+        "coefficients": [[0.1]],
+        "equation_terms": {"u": {"u_xx": 0.1}},
+        "equation_strings": {"u": "0.1*u_xx"},
+        "fit_diagnostics": {
+            "terms_are_backend_native": False,
+            "canonicalized": True,
+            "purpose": "contract_smoke_not_backend_benchmark",
+        },
+    }
+
+
+def run_downstream_discovery_contracts_example() -> dict[str, object]:
+    training = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=48, seed=22001)
+    heldout = generate_heat_1d_field_batch(batch_size=3, num_times=33, num_points=48, seed=22002)
+    evaluator = HeatResidualEvaluator()
+
+    derivatives = compute_spectral_fd_derivatives(training)
+    residual = evaluator.evaluate(training, derivatives)
+    generator = fit_translation_generator(training, evaluator, epsilon=1e-4)
+    verification = verify_translation_generator(heldout, generator, evaluator)
+    readiness = summarize_field_batch_readiness(
+        training,
+        residual_evaluator=evaluator,
+    )
+    confidence = summarize_generator_confidence(
+        residual=residual,
+        generator=generator,
+        verification=verification,
+        thresholds={"residual_max_abs": 1e-3, "residual_rms": 1e-4},
+    )
+
+    trajectories, time_values, feature_names = to_pysindy_trajectories(training)
+    discovery_inputs = summarize_discovery_bridge_output(
+        trajectories,
+        time_values,
+        feature_names,
+        source_field_id="heat-training-field",
+        provenance={"bridge": "to_pysindy_trajectories", "example": "downstream_discovery_contracts"},
+    )
+    discovery_result = summarize_discovery_result(
+        _manual_discovery_result(),
+        target_terms={"u": {"u_xx": 0.1}},
+        source_result_id="manual-heat-reference-result",
+    )
+    orbit_batch = build_uniform_translation_orbit_batch(
+        training,
+        shifts=_SHIFTS,
+        source_field_id="heat-training-field",
+    )
+    workflow = summarize_downstream_discovery_workflow(
+        field_readiness=readiness,
+        generator_confidence=confidence,
+        orbit_batch=orbit_batch,
+        discovery_inputs=discovery_inputs,
+        discovery_result=discovery_result,
+        extra_metrics={"example_name": "downstream_discovery_contracts"},
+    )
+
+    return {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": "downstream_discovery_contracts_example",
+        "field_readiness": readiness,
+        "generator_confidence": confidence,
+        "discovery_inputs": discovery_inputs,
+        "discovery_result": discovery_result,
+        "workflow": workflow,
+        "extra_metrics": {
+            "example_name": "downstream_discovery_contracts",
+            "workflow_label": workflow["workflow_label"],
+            "recovery_classification": discovery_result["recovery"]["by_feature"]["u"]["classification"],
+            "orbit_output_batch_size": orbit_batch.report["output_batch_size"],
+            "split_policy": "not_managed_by_pdelie",
+        },
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_downstream_discovery_contracts_example(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/reporting/__init__.py
+++ b/src/pdelie/reporting/__init__.py
@@ -1,4 +1,5 @@
 from pdelie.reporting.summaries import (
+    summarize_downstream_discovery_workflow,
     summarize_field_batch_readiness,
     summarize_formula_generator_family,
     summarize_generator_confidence,
@@ -12,6 +13,7 @@ from pdelie.reporting.summaries import (
 )
 
 __all__ = [
+    "summarize_downstream_discovery_workflow",
     "summarize_field_batch_readiness",
     "summarize_formula_generator_family",
     "summarize_generator_confidence",

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -15,6 +15,7 @@ from pdelie.contracts import (
     VerificationReport,
 )
 from pdelie.errors import PDELieValidationError, SchemaValidationError, ScopeValidationError
+from pdelie.invariants import OrbitBatchResult
 from pdelie.residuals.base import ResidualEvaluator
 from pdelie.symmetry.formula import FormulaGeneratorFamily
 from pdelie.symmetry.parameterization import translation_span_distance
@@ -217,6 +218,30 @@ def _consistency_summary_or_list_or_none(value: Any, *, name: str) -> dict[str, 
 
 def _orbit_summary_or_list_or_none(value: Any, *, name: str) -> dict[str, Any] | list[dict[str, Any]] | None:
     return _runtime_report_or_list(value, name=name, expected_summary_types={"uniform_translation_orbit"})
+
+
+def _orbit_batch_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, OrbitBatchResult):
+        return _runtime_report(
+            value.report,
+            name=name,
+            expected_summary_types={"uniform_translation_orbit_batch"},
+        )
+    return _runtime_report(value, name=name, expected_summary_types={"uniform_translation_orbit_batch"})
+
+
+def _discovery_bridge_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return _runtime_report(value, name=name, expected_summary_types={"discovery_bridge_output"})
+
+
+def _discovery_result_summary_or_none(value: Any, *, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return _runtime_report(value, name=name, expected_summary_types={"discovery_result"})
 
 
 def _thresholds_or_empty(value: Mapping[str, Any] | None) -> dict[str, float]:
@@ -1189,5 +1214,167 @@ def summarize_invariant_workflow(
         generator=generator_summary,
         fit_diagnostics=fit_summary,
         verification=_verification_summary_or_none(verification, name="verification"),
+        extra_metrics=normalized_extra_metrics,
+    )
+
+
+def _workflow_readiness_status(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if report is None:
+        return _component_status("unavailable", reason="field_readiness_not_provided")
+    label = report.get("readiness_label")
+    if label == "ready":
+        return _component_status("passed", reason="field_readiness_ready")
+    if label == "needs_attention":
+        return _component_status("warning", reason="field_readiness_needs_attention")
+    if label == "not_ready":
+        return _component_status("failed", reason="field_readiness_not_ready")
+    return _component_status("warning", reason="field_readiness_unknown")
+
+
+def _workflow_confidence_status(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if report is None:
+        return _component_status("unavailable", reason="generator_confidence_not_provided")
+    label = report.get("confidence_label")
+    if label == "strong":
+        return _component_status("passed", reason="generator_confidence_strong")
+    if label in {"qualified", "insufficient_evidence"}:
+        return _component_status("warning", reason=f"generator_confidence_{label}")
+    if label == "failed":
+        return _component_status("failed", reason="generator_confidence_failed")
+    return _component_status("warning", reason="generator_confidence_unknown")
+
+
+def _workflow_discovery_inputs_status(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if report is None:
+        return _component_status("unavailable", reason="discovery_inputs_not_provided")
+    return _component_status(
+        "passed",
+        reason="discovery_inputs_summarized",
+        details={
+            "trajectory_count": report.get("trajectory_count"),
+            "num_state_features": report.get("num_state_features"),
+        },
+    )
+
+
+def _workflow_discovery_result_status(report: Mapping[str, Any] | None) -> dict[str, Any]:
+    if report is None:
+        return _component_status("unavailable", reason="discovery_result_not_provided")
+    if report.get("status") == "success":
+        return _component_status("passed", reason="discovery_result_success")
+    if report.get("status") == "failed":
+        return _component_status("failed", reason="discovery_result_failed")
+    return _component_status("warning", reason="discovery_result_unknown_status")
+
+
+def _workflow_orbit_provenance_status(report: Mapping[str, Any] | None) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    if report is None:
+        return _component_status("unavailable", reason="orbit_batch_not_provided"), None
+
+    output_batch_size = report.get("output_batch_size")
+    source_indices = report.get("source_batch_indices")
+    shift_indices = report.get("shift_indices")
+    details = {
+        "output_batch_size": output_batch_size,
+        "source_indices_present": isinstance(source_indices, list),
+        "shift_indices_present": isinstance(shift_indices, list),
+        "source_index_count": len(source_indices) if isinstance(source_indices, list) else None,
+        "shift_index_count": len(shift_indices) if isinstance(shift_indices, list) else None,
+    }
+    if not isinstance(output_batch_size, int):
+        return (
+            _component_status("warning", reason="orbit_batch_size_unavailable", details=details),
+            details,
+        )
+    if not isinstance(source_indices, list) and not isinstance(shift_indices, list):
+        return (
+            _component_status("warning", reason="orbit_provenance_indices_not_recorded", details=details),
+            details,
+        )
+    if not isinstance(source_indices, list) or not isinstance(shift_indices, list):
+        return (
+            _component_status("warning", reason="orbit_provenance_partially_recorded", details=details),
+            details,
+        )
+    if len(source_indices) != output_batch_size or len(shift_indices) != output_batch_size:
+        return (
+            _component_status("failed", reason="orbit_provenance_index_count_mismatch", details=details),
+            details,
+        )
+    return _component_status("passed", reason="orbit_provenance_traceable", details=details), details
+
+
+def _workflow_label(component_statuses: Mapping[str, Mapping[str, Any]]) -> str:
+    statuses = [str(status["status"]) for status in component_statuses.values()]
+    if any(status == "failed" for status in statuses):
+        return "failed"
+    if any(status in {"warning", "not_configured", "unavailable"} for status in statuses):
+        return "needs_attention"
+    return "ready"
+
+
+def summarize_downstream_discovery_workflow(
+    *,
+    field_readiness: Mapping[str, Any] | None = None,
+    generator_confidence: Mapping[str, Any] | None = None,
+    orbit_batch: OrbitBatchResult | Mapping[str, Any] | None = None,
+    discovery_inputs: Mapping[str, Any] | None = None,
+    discovery_result: Mapping[str, Any] | None = None,
+    extra_metrics: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Combine downstream discovery runtime reports without imposing split or leakage policy."""
+
+    if extra_metrics is None:
+        normalized_extra_metrics: Mapping[str, Any] = {}
+    else:
+        normalized_extra_metrics = _require_mapping(extra_metrics, name="extra_metrics")
+
+    readiness_summary = (
+        None
+        if field_readiness is None
+        else _runtime_report(
+            field_readiness,
+            name="field_readiness",
+            expected_summary_types={"field_batch_readiness"},
+        )
+    )
+    confidence_summary = (
+        None
+        if generator_confidence is None
+        else _runtime_report(
+            generator_confidence,
+            name="generator_confidence",
+            expected_summary_types={"generator_confidence"},
+        )
+    )
+    orbit_batch_summary = _orbit_batch_summary_or_none(orbit_batch, name="orbit_batch")
+    discovery_inputs_summary = _discovery_bridge_summary_or_none(discovery_inputs, name="discovery_inputs")
+    discovery_result_summary = _discovery_result_summary_or_none(discovery_result, name="discovery_result")
+    orbit_provenance_status, orbit_provenance = _workflow_orbit_provenance_status(orbit_batch_summary)
+
+    component_statuses = {
+        "field_readiness": _workflow_readiness_status(readiness_summary),
+        "generator_confidence": _workflow_confidence_status(confidence_summary),
+        "orbit_provenance": orbit_provenance_status,
+        "discovery_inputs": _workflow_discovery_inputs_status(discovery_inputs_summary),
+        "discovery_result": _workflow_discovery_result_status(discovery_result_summary),
+    }
+    missing_evidence = [
+        component
+        for component, status in component_statuses.items()
+        if status["status"] == "unavailable"
+    ]
+
+    return _summary_payload(
+        "downstream_discovery_workflow",
+        workflow_label=_workflow_label(component_statuses),
+        component_statuses=component_statuses,
+        field_readiness=readiness_summary,
+        generator_confidence=confidence_summary,
+        orbit_batch=orbit_batch_summary,
+        orbit_provenance=orbit_provenance,
+        discovery_inputs=discovery_inputs_summary,
+        discovery_result=discovery_result_summary,
+        missing_evidence=missing_evidence,
         extra_metrics=normalized_extra_metrics,
     )

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -45,6 +45,7 @@ _ROOT_RUNTIME_NAMES = {
     "run_advection_diffusion_vertical_slice_example",
     "run_formula_generator_validation_example",
     "run_generator_confidence_report_example",
+    "run_downstream_discovery_contracts_example",
     "run_external_data_readiness_example",
     "run_kdv_vertical_slice_example",
     "run_orbit_coverage_diagnostics_example",
@@ -59,6 +60,9 @@ _ROOT_RUNTIME_NAMES = {
     "summarize_field_batch_readiness",
     "summarize_formula_generator_family",
     "summarize_generator_confidence",
+    "summarize_downstream_discovery_workflow",
+    "summarize_discovery_bridge_output",
+    "summarize_discovery_result",
     "summarize_generator_family",
     "summarize_invariant_workflow",
     "summarize_recovery_grid",
@@ -207,6 +211,15 @@ _V0_21_FIELD_READINESS_APIS = {
     "readiness_label",
     "pdelie.examples.run_external_data_readiness_example",
 }
+_V0_22_DOWNSTREAM_CONTRACT_APIS = {
+    "pdelie.discovery.summarize_discovery_bridge_output",
+    "pdelie.discovery.summarize_discovery_result",
+    "pdelie.reporting.summarize_downstream_discovery_workflow",
+    "pdelie.examples.run_downstream_discovery_contracts_example",
+    "summary_type = \"discovery_bridge_output\"",
+    "summary_type = \"discovery_result\"",
+    "summary_type = \"downstream_discovery_workflow\"",
+}
 
 
 def _api_stability_text() -> str:
@@ -235,6 +248,7 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_19_ADVECTION_DIFFUSION_APIS
         | _V0_20_CONFIDENCE_REPORTING_APIS
         | _V0_21_FIELD_READINESS_APIS
+        | _V0_22_DOWNSTREAM_CONTRACT_APIS
     ):
         assert api_name in text
 
@@ -290,12 +304,15 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "build_translation_canonical_discovery_inputs",
             "evaluate_discovery_recovery",
             "fit_pysindy_discovery",
+            "summarize_discovery_bridge_output",
+            "summarize_discovery_result",
             "summarize_recovery_grid",
             "to_pysindy_trajectories",
         },
         "pdelie.examples": {
             "run_formula_generator_validation_example",
             "run_generator_confidence_report_example",
+            "run_downstream_discovery_contracts_example",
             "run_external_data_readiness_example",
             "run_advection_diffusion_vertical_slice_example",
             "run_heat_vertical_slice_example",
@@ -320,6 +337,7 @@ def test_required_runtime_submodule_apis_remain_importable() -> None:
             "import_generator_family_manifest",
         },
         "pdelie.reporting": {
+            "summarize_downstream_discovery_workflow",
             "summarize_formula_generator_family",
             "summarize_field_batch_readiness",
             "summarize_generator_confidence",
@@ -381,35 +399,37 @@ def test_deferred_and_private_names_are_not_public_submodule_exports() -> None:
             assert not hasattr(module, name), f"{module.__name__}.{name}"
 
 
-def test_v0_21_planning_docs_record_external_data_readiness_and_non_goals() -> None:
+def test_v0_22_planning_docs_record_downstream_discovery_contracts_and_non_goals() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
-    scope = _repo_text("docs/planning/V0_21_SCOPE.md")
+    scope = _repo_text("docs/planning/V0_22_SCOPE.md")
     roadmap = _repo_text("docs/planning/ROADMAP.md")
 
     assert "**Status:** COMPLETE" in plan
-    assert "Milestone 2 - Readiness Helper" in plan
-    assert "Milestone 3 - External Data Path Coverage" in plan
-    assert "pdelie.reporting.summarize_field_batch_readiness" in plan
-    assert "pdelie.examples.run_external_data_readiness_example" in plan
-    assert "no file loaders" in plan
-    assert "no Dataset support" in plan
+    assert "Milestone 2 - Bridge Output Summary" in plan
+    assert "Milestone 3 - Discovery Result And Recovery Summary" in plan
+    assert "pdelie.discovery.summarize_discovery_bridge_output" in plan
+    assert "pdelie.discovery.summarize_discovery_result" in plan
+    assert "pdelie.reporting.summarize_downstream_discovery_workflow" in plan
+    assert "pdelie.examples.run_downstream_discovery_contracts_example" in plan
+    assert "split/leakage diagnostics are deferred" in plan
     assert "## Milestone 5 - API / Public-surface Audit" in plan
     assert "## Milestone 6 - Release Gate And Readiness" in plan
-    assert "updated CI so the current explicit release gate is `v0_21-release-gate`" in plan
+    assert "updated CI so the current explicit release gate is `v0_22-release-gate`" in plan
     assert "- Milestone 6: COMPLETE" in plan
 
-    assert "External Data Readiness Reports" in scope
-    assert "pdelie.reporting.summarize_field_batch_readiness" in scope
-    assert "pdelie.examples.run_external_data_readiness_example" in scope
-    assert "ready" in scope
-    assert "needs_attention" in scope
-    assert "not_ready" in scope
+    assert "Downstream Discovery Contracts" in scope
+    assert "pdelie.discovery.summarize_discovery_bridge_output" in scope
+    assert "pdelie.discovery.summarize_discovery_result" in scope
+    assert "pdelie.reporting.summarize_downstream_discovery_workflow" in scope
+    assert "pdelie.examples.run_downstream_discovery_contracts_example" in scope
+    assert "feature-keyed" in scope
+    assert "heldout-leakage detection" in scope
     assert "file loaders" in scope
     assert "train/test split policy" in scope
     assert "- Milestone 4: COMPLETE" in scope
     assert "- Milestone 5: COMPLETE" in scope
     assert "- Milestone 6: COMPLETE" in scope
 
-    assert "`v0.21` is the completed external-data readiness reporting release" in roadmap
-    assert "external data readiness reports" in roadmap
-    assert "- no file loaders" in roadmap
+    assert "`v0.22` is the completed downstream discovery contracts release" in roadmap
+    assert "downstream discovery contracts" in roadmap
+    assert "- no split management or heldout-leakage detection" in roadmap

--- a/tests/test_downstream_discovery_contracts.py
+++ b/tests/test_downstream_discovery_contracts.py
@@ -81,6 +81,13 @@ def test_summarize_discovery_bridge_output_rejects_invalid_bridge_payloads() -> 
         summarize_discovery_bridge_output([np.ones((2, 1))], [0.0, 1.0], ["u", "u"])
     with pytest.raises(SchemaValidationError):
         summarize_discovery_bridge_output([np.array([[np.nan]])], [0.0], ["u"])
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output(
+            [np.ones((2, 1))],
+            [0.0, 1.0],
+            ["u"],
+            provenance={"bad": float("nan")},
+        )
 
 
 def test_summarize_discovery_result_compacts_coefficients_and_recovery() -> None:

--- a/tests/test_downstream_discovery_contracts.py
+++ b/tests/test_downstream_discovery_contracts.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.discovery import (
+    summarize_discovery_bridge_output,
+    summarize_discovery_result,
+    to_pysindy_trajectories,
+)
+from pdelie.errors import SchemaValidationError
+from pdelie.examples import run_downstream_discovery_contracts_example
+from pdelie.invariants import build_uniform_translation_orbit_batch
+from pdelie.reporting import (
+    summarize_downstream_discovery_workflow,
+    summarize_field_batch_readiness,
+    summarize_generator_confidence,
+)
+from pdelie.residuals import HeatResidualEvaluator
+
+
+def _manual_result(*, status: str = "success", coefficients: object = [[0.1]]) -> dict[str, object]:
+    if status == "failed":
+        return {
+            "status": "failed",
+            "backend": "manual",
+            "feature_names": ["u"],
+            "library_feature_names": [],
+            "coefficients": None,
+            "equation_terms": {},
+            "equation_strings": {},
+            "fit_diagnostics": {"exception_type": "RuntimeError"},
+            "failure_reason": "backend_fit_failed",
+        }
+    return {
+        "status": "success",
+        "backend": "manual",
+        "feature_names": ["u"],
+        "library_feature_names": ["u_xx"],
+        "coefficients": coefficients,
+        "equation_terms": {"u": {"u_xx": 0.1}},
+        "equation_strings": {"u": "0.1*u_xx"},
+        "fit_diagnostics": {"terms_are_backend_native": False, "canonicalized": True},
+    }
+
+
+def test_summarize_discovery_bridge_output_accepts_pysindy_bridge_shape_and_is_json_safe() -> None:
+    field = generate_heat_1d_field_batch(batch_size=2, num_times=9, num_points=8, seed=22001)
+    trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+
+    summary = summarize_discovery_bridge_output(
+        trajectories,
+        time_values,
+        feature_names,
+        source_field_id="field-1",
+        provenance={"bridge": "to_pysindy_trajectories"},
+    )
+
+    assert json.loads(json.dumps(summary)) == summary
+    assert summary["summary_schema_version"] == "0.1"
+    assert summary["summary_type"] == "discovery_bridge_output"
+    assert summary["trajectory_count"] == 2
+    assert summary["trajectory_shape"] == [9, 8]
+    assert summary["feature_names"] == feature_names
+    assert summary["strictly_increasing_time"] is True
+    assert summary["finite"] is True
+    assert summary["returns_field_batch"] is False
+
+
+def test_summarize_discovery_bridge_output_rejects_invalid_bridge_payloads() -> None:
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output([], [0.0, 1.0], ["u"])
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output([np.ones((2, 1)), np.ones((3, 1))], [0.0, 1.0], ["u"])
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output([np.ones((2, 1))], [0.0, 0.0], ["u"])
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output([np.ones((2, 1))], [0.0, 1.0], ["u", "u"])
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_bridge_output([np.array([[np.nan]])], [0.0], ["u"])
+
+
+def test_summarize_discovery_result_compacts_coefficients_and_recovery() -> None:
+    result = _manual_result(coefficients=np.asarray([[0.1, 0.0]]))
+    result["library_feature_names"] = ["u_xx", "u"]
+    summary = summarize_discovery_result(
+        result,
+        target_terms={"u": {"u_xx": 0.1}},
+        train_residual=[0.0, 1e-3],
+        heldout_residual=[0.0, 2e-3],
+        source_result_id="result-1",
+    )
+
+    assert json.loads(json.dumps(summary)) == summary
+    assert summary["summary_type"] == "discovery_result"
+    assert summary["status"] == "success"
+    assert summary["coefficient_summary"]["shape"] == [1, 2]
+    assert summary["coefficient_summary"]["nonzero_count"] == 1
+    assert "coefficients" not in summary
+    assert summary["returns_coefficients"] is False
+    assert summary["recovery"]["aggregate"]["exact_count"] == 1
+    assert summary["recovery"]["by_feature"]["u"]["classification"] == "exact"
+    assert summary["residuals"]["heldout"]["rms"] > 0.0
+
+
+def test_summarize_discovery_result_accepts_backend_failure_mapping() -> None:
+    summary = summarize_discovery_result(_manual_result(status="failed"))
+
+    assert summary["summary_type"] == "discovery_result"
+    assert summary["status"] == "failed"
+    assert summary["failure_reason"] == "backend_fit_failed"
+    assert summary["coefficient_summary"]["present"] is False
+    assert summary["equation_terms"] == {"u": {}}
+
+
+def test_summarize_discovery_result_rejects_ambiguous_target_and_nonfinite_values() -> None:
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_result(_manual_result(), target_terms={"u_xx": 0.1})  # type: ignore[arg-type]
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_result(_manual_result(coefficients=[[np.nan]]))
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_result(_manual_result(), support_epsilon=-1.0)
+    malformed = dict(_manual_result())
+    malformed.pop("equation_terms")
+    with pytest.raises(SchemaValidationError):
+        summarize_discovery_result(malformed)
+
+
+def test_summarize_downstream_discovery_workflow_combines_reports_and_orbit_provenance() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=8, seed=22002)
+    trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+    readiness = summarize_field_batch_readiness(field, residual_evaluator=HeatResidualEvaluator())
+    confidence = summarize_generator_confidence(
+        fit_diagnostics={
+            "summary_schema_version": "0.1",
+            "summary_type": "generator_fit_diagnostics",
+            "evidence_label": "reference_fallback",
+        }
+    )
+    orbit = build_uniform_translation_orbit_batch(field, shifts=[0.0, 2.0 * np.pi])
+    bridge = summarize_discovery_bridge_output(trajectories, time_values, feature_names)
+    result = summarize_discovery_result(_manual_result(), target_terms={"u": {"u_xx": 0.1}})
+
+    workflow = summarize_downstream_discovery_workflow(
+        field_readiness=readiness,
+        generator_confidence=confidence,
+        orbit_batch=orbit,
+        discovery_inputs=bridge,
+        discovery_result=result,
+    )
+
+    assert json.loads(json.dumps(workflow)) == workflow
+    assert workflow["summary_type"] == "downstream_discovery_workflow"
+    assert workflow["workflow_label"] == "needs_attention"
+    assert workflow["component_statuses"]["orbit_provenance"]["status"] == "passed"
+    assert workflow["orbit_provenance"]["source_indices_present"] is True
+    assert workflow["orbit_provenance"]["shift_indices_present"] is True
+
+
+def test_summarize_downstream_discovery_workflow_rejects_malformed_nested_reports() -> None:
+    with pytest.raises(SchemaValidationError):
+        summarize_downstream_discovery_workflow(discovery_inputs={"summary_type": "discovery_result"})
+    with pytest.raises(SchemaValidationError):
+        summarize_downstream_discovery_workflow(orbit_batch={"summary_type": "uniform_translation_orbit"})
+
+
+def test_downstream_discovery_contracts_example_is_json_safe_and_report_only() -> None:
+    result = run_downstream_discovery_contracts_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_type"] == "downstream_discovery_contracts_example"
+    assert result["workflow"]["summary_type"] == "downstream_discovery_workflow"
+    assert result["discovery_inputs"]["returns_field_batch"] is False
+    assert result["discovery_result"]["returns_coefficients"] is False
+    assert result["extra_metrics"]["split_policy"] == "not_managed_by_pdelie"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,6 +9,7 @@ import numpy as np
 import pdelie
 from pdelie.examples import (
     run_advection_diffusion_vertical_slice_example,
+    run_downstream_discovery_contracts_example,
     run_external_data_readiness_example,
     run_formula_generator_validation_example,
     run_generator_confidence_report_example,
@@ -454,3 +455,28 @@ def test_external_data_readiness_module_prints_json_only() -> None:
 
     assert parsed["summary_type"] == "external_data_readiness_example"
     assert parsed["extra_metrics"]["readiness_labels"] == ["ready", "not_ready", "not_ready"]
+
+
+def test_downstream_discovery_contracts_example_runs_end_to_end() -> None:
+    result = run_downstream_discovery_contracts_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "downstream_discovery_contracts_example"
+    assert result["extra_metrics"]["example_name"] == "downstream_discovery_contracts"
+    assert result["field_readiness"]["summary_type"] == "field_batch_readiness"
+    assert result["generator_confidence"]["summary_type"] == "generator_confidence"
+    assert result["discovery_inputs"]["summary_type"] == "discovery_bridge_output"
+    assert result["discovery_result"]["summary_type"] == "discovery_result"
+    assert result["workflow"]["summary_type"] == "downstream_discovery_workflow"
+    assert result["workflow"]["component_statuses"]["orbit_provenance"]["status"] == "passed"
+    assert result["extra_metrics"]["recovery_classification"] == "exact"
+    assert result["extra_metrics"]["split_policy"] == "not_managed_by_pdelie"
+    assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
+
+
+def test_downstream_discovery_contracts_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.downstream_discovery_contracts")
+
+    assert parsed["summary_type"] == "downstream_discovery_contracts_example"
+    assert parsed["workflow"]["summary_type"] == "downstream_discovery_workflow"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -44,6 +44,8 @@ def test_runtime_package_api_is_importable() -> None:
         build_translation_canonical_discovery_inputs,
         evaluate_discovery_recovery,
         fit_pysindy_discovery,
+        summarize_discovery_bridge_output,
+        summarize_discovery_result,
         summarize_recovery_grid,
         to_pysindy_trajectories,
     )
@@ -68,6 +70,7 @@ def test_runtime_package_api_is_importable() -> None:
         evaluate_weak_heat_residual,
     )
     from pdelie.reporting import (
+        summarize_downstream_discovery_workflow,
         summarize_field_batch_readiness,
         summarize_formula_generator_family,
         summarize_generator_confidence,
@@ -116,6 +119,7 @@ def test_runtime_package_api_is_importable() -> None:
     assert evaluate_weak_burgers_residual is not None
     assert evaluate_weak_heat_residual is not None
     assert summarize_generator_fit_diagnostics is not None
+    assert summarize_downstream_discovery_workflow is not None
     assert summarize_field_batch_readiness is not None
     assert summarize_generator_confidence is not None
     assert summarize_formula_generator_family is not None
@@ -128,6 +132,8 @@ def test_runtime_package_api_is_importable() -> None:
     assert build_translation_canonical_discovery_inputs is not None
     assert evaluate_discovery_recovery is not None
     assert fit_pysindy_discovery is not None
+    assert summarize_discovery_bridge_output is not None
+    assert summarize_discovery_result is not None
     assert summarize_recovery_grid is not None
     assert to_pysindy_trajectories is not None
     assert coerce_generator_family is not None
@@ -168,6 +174,8 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "evaluate_weak_advection_diffusion_residual")
     assert not hasattr(pdelie, "evaluate_discovery_recovery")
     assert not hasattr(pdelie, "fit_pysindy_discovery")
+    assert not hasattr(pdelie, "summarize_discovery_bridge_output")
+    assert not hasattr(pdelie, "summarize_discovery_result")
     assert not hasattr(pdelie, "from_pdebench")
     assert not hasattr(pdelie, "from_numpy")
     assert not hasattr(pdelie, "from_the_well")
@@ -178,6 +186,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "subsample_x")
     assert not hasattr(pdelie, "summarize_recovery_grid")
     assert not hasattr(pdelie, "summarize_generator_fit_diagnostics")
+    assert not hasattr(pdelie, "summarize_downstream_discovery_workflow")
     assert not hasattr(pdelie, "summarize_field_batch_readiness")
     assert not hasattr(pdelie, "summarize_generator_confidence")
     assert not hasattr(pdelie, "summarize_formula_generator_family")
@@ -214,6 +223,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "run_formula_generator_validation_example")
     assert not hasattr(pdelie, "run_generator_confidence_report_example")
     assert not hasattr(pdelie, "run_external_data_readiness_example")
+    assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(pdelie, "run_reaction_diffusion_vertical_slice_example")
@@ -307,6 +317,7 @@ def test_residuals_package_runtime_api_matches_current_frozen_surface() -> None:
 def test_reporting_package_runtime_api_matches_frozen_m2_surface() -> None:
     reporting_module = importlib.import_module("pdelie.reporting")
 
+    assert hasattr(reporting_module, "summarize_downstream_discovery_workflow")
     assert hasattr(reporting_module, "summarize_formula_generator_family")
     assert hasattr(reporting_module, "summarize_field_batch_readiness")
     assert hasattr(reporting_module, "summarize_generator_confidence")
@@ -325,6 +336,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     examples_module = importlib.import_module("pdelie.examples")
 
     assert hasattr(examples_module, "run_advection_diffusion_vertical_slice_example")
+    assert hasattr(examples_module, "run_downstream_discovery_contracts_example")
     assert hasattr(examples_module, "run_external_data_readiness_example")
     assert hasattr(examples_module, "run_heat_vertical_slice_example")
     assert hasattr(examples_module, "run_formula_generator_validation_example")
@@ -345,6 +357,8 @@ def test_discovery_package_runtime_api_matches_frozen_milestone_surface() -> Non
     assert hasattr(discovery_module, "build_translation_canonical_discovery_inputs")
     assert hasattr(discovery_module, "evaluate_discovery_recovery")
     assert hasattr(discovery_module, "fit_pysindy_discovery")
+    assert hasattr(discovery_module, "summarize_discovery_bridge_output")
+    assert hasattr(discovery_module, "summarize_discovery_result")
     assert hasattr(discovery_module, "summarize_recovery_grid")
     assert hasattr(discovery_module, "to_pysindy_trajectories")
     assert not hasattr(discovery_module, "_fit_pysindy_smoke")

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
     for historical_job in range(4, 21):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "including `v0.22.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -67,14 +67,14 @@ def test_v0_12_release_gate_current_ci_visibility_is_v0_18_only() -> None:
     plan = _repo_text("docs/planning/PLAN.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "summarize_generator_fit_diagnostics" in readme
-    assert "including `v0.21.0`" in publishing
-    assert "V0.21 is complete" in plan
+    assert "including `v0.22.0`" in publishing
+    assert "V0.22 is complete" in plan
 
 
 def test_v0_12_release_gate_fit_diagnostic_helper_is_documented_and_submodule_only() -> None:

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
-    assert "V0.21 is complete" in plan
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
+    assert "V0.22 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.14.0" in changelog
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "summarize_invariant_workflow" in readme
     assert "summarize_uniform_translation_orbit" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap

--- a/tests/test_v0_15_release_gate.py
+++ b/tests/test_v0_15_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_14-release-gate" not in workflow
 
     assert "## 0.15.0" in changelog
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "build_uniform_translation_orbit_batch" in readme
     assert "OrbitBatchResult" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.15` - Materialized uniform translation orbit batches" in roadmap

--- a/tests/test_v0_16_release_gate.py
+++ b/tests/test_v0_16_release_gate.py
@@ -45,7 +45,7 @@ def _translation_spec(generator: GeneratorFamily) -> InvariantMapSpec:
 def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -54,18 +54,18 @@ def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
     assert "## 0.16.0" in changelog
-    assert "V0.21" in readme
+    assert "V0.22" in readme
     assert "validate_symmetry_candidate" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.16` - External symmetry-candidate validation" in roadmap

--- a/tests/test_v0_17_release_gate.py
+++ b/tests/test_v0_17_release_gate.py
@@ -58,7 +58,7 @@ def _formula_translation(*, finite_transform: bool = False) -> FormulaGeneratorF
 def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -67,18 +67,18 @@ def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
-    assert "## 0.21.0" in changelog
-    assert "V0.21" in readme
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
     assert "FormulaGeneratorFamily" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap

--- a/tests/test_v0_18_release_gate.py
+++ b/tests/test_v0_18_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,18 +31,18 @@ def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_17-release-gate" not in workflow
 
-    assert "## 0.21.0" in changelog
-    assert "V0.21" in readme
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
     assert "reaction_diffusion_fisher_kpp" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap

--- a/tests/test_v0_19_release_gate.py
+++ b/tests/test_v0_19_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_19_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,18 +31,18 @@ def test_v0_19_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_18-release-gate" not in workflow
 
-    assert "## 0.21.0" in changelog
-    assert "V0.21" in readme
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
     assert "advection_diffusion_constant_coefficient" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.19` - Stable advection-diffusion strong path" in roadmap

--- a/tests/test_v0_20_release_gate.py
+++ b/tests/test_v0_20_release_gate.py
@@ -23,7 +23,7 @@ def _repo_text(path: str) -> str:
 def test_v0_20_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -32,18 +32,18 @@ def test_v0_20_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_20-release-gate" not in workflow
 
-    assert "## 0.21.0" in changelog
-    assert "V0.21" in readme
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
     assert "summarize_generator_confidence" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.21` - External data readiness reports" in roadmap

--- a/tests/test_v0_21_release_gate.py
+++ b/tests/test_v0_21_release_gate.py
@@ -33,7 +33,7 @@ def _heat_metadata(*, equation: str | None = "heat_1d") -> dict[str, object]:
 def test_v0_21_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_21_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -42,18 +42,18 @@ def test_v0_21_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.21.0"
-    assert release_gate_jobs == ["v0_21-release-gate"]
-    assert "python -m pytest tests/test_v0_21_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
     assert "v0_20-release-gate" not in workflow
 
-    assert "## 0.21.0" in changelog
-    assert "V0.21" in readme
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
     assert "summarize_field_batch_readiness" in readme
-    assert "package version: `0.21.0`" in readiness
-    assert "git tag: `v0.21.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.21.0`" in readiness
-    assert "including `v0.21.0`" in publishing
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.21` - External data readiness reports" in roadmap

--- a/tests/test_v0_22_release_gate.py
+++ b/tests/test_v0_22_release_gate.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+import pdelie
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.discovery import (
+    summarize_discovery_bridge_output,
+    summarize_discovery_result,
+    to_pysindy_trajectories,
+)
+from pdelie.examples import run_downstream_discovery_contracts_example
+from pdelie.invariants import build_uniform_translation_orbit_batch
+from pdelie.reporting import summarize_downstream_discovery_workflow, summarize_field_batch_readiness
+from pdelie.residuals import HeatResidualEvaluator
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def _manual_result() -> dict[str, object]:
+    return {
+        "status": "success",
+        "backend": "manual",
+        "feature_names": ["u"],
+        "library_feature_names": ["u_xx"],
+        "coefficients": np.asarray([[0.1]], dtype=float),
+        "equation_terms": {"u": {"u_xx": 0.1}},
+        "equation_strings": {"u": "0.1*u_xx"},
+        "fit_diagnostics": {"terms_are_backend_native": False, "canonicalized": True},
+    }
+
+
+def test_v0_22_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_22_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_22_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.22.0"
+    assert release_gate_jobs == ["v0_22-release-gate"]
+    assert "python -m pytest tests/test_v0_22_release_gate.py" in workflow
+    assert "v0_21-release-gate" not in workflow
+
+    assert "## 0.22.0" in changelog
+    assert "V0.22" in readme
+    assert "summarize_discovery_bridge_output" in readme
+    assert "summarize_downstream_discovery_workflow" in readme
+    assert "package version: `0.22.0`" in readiness
+    assert "git tag: `v0.22.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.22.0`" in readiness
+    assert "including `v0.22.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.22` - Downstream discovery contracts" in roadmap
+    assert "**Status:** Completed" in roadmap
+
+
+def test_v0_22_release_gate_downstream_contract_apis_are_documented_and_submodule_only() -> None:
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    discovery_module = importlib.import_module("pdelie.discovery")
+    reporting_module = importlib.import_module("pdelie.reporting")
+    examples_module = importlib.import_module("pdelie.examples")
+
+    assert hasattr(discovery_module, "summarize_discovery_bridge_output")
+    assert hasattr(discovery_module, "summarize_discovery_result")
+    assert hasattr(reporting_module, "summarize_downstream_discovery_workflow")
+    assert hasattr(examples_module, "run_downstream_discovery_contracts_example")
+    assert not hasattr(pdelie, "summarize_discovery_bridge_output")
+    assert not hasattr(pdelie, "summarize_discovery_result")
+    assert not hasattr(pdelie, "summarize_downstream_discovery_workflow")
+    assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
+    assert "pdelie.discovery.summarize_discovery_bridge_output" in api_stability
+    assert "pdelie.discovery.summarize_discovery_result" in api_stability
+    assert "pdelie.reporting.summarize_downstream_discovery_workflow" in api_stability
+    assert "summary_type = \"discovery_bridge_output\"" in api_stability
+    assert "summary_type = \"discovery_result\"" in api_stability
+    assert "summary_type = \"downstream_discovery_workflow\"" in api_stability
+    assert "no root `pdelie` exports" in api_stability
+
+
+def test_v0_22_release_gate_reports_are_json_safe_and_compact() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=8, seed=22022)
+    trajectories, time_values, feature_names = to_pysindy_trajectories(field)
+    bridge = summarize_discovery_bridge_output(trajectories, time_values, feature_names)
+    result = summarize_discovery_result(_manual_result(), target_terms={"u": {"u_xx": 0.1}})
+    orbit = build_uniform_translation_orbit_batch(field, shifts=[0.0, 2.0 * np.pi])
+    readiness = summarize_field_batch_readiness(field, residual_evaluator=HeatResidualEvaluator())
+    workflow = summarize_downstream_discovery_workflow(
+        field_readiness=readiness,
+        orbit_batch=orbit,
+        discovery_inputs=bridge,
+        discovery_result=result,
+    )
+
+    assert json.loads(json.dumps(bridge)) == bridge
+    assert json.loads(json.dumps(result)) == result
+    assert json.loads(json.dumps(workflow)) == workflow
+    assert bridge["summary_type"] == "discovery_bridge_output"
+    assert result["summary_type"] == "discovery_result"
+    assert "coefficients" not in result
+    assert result["coefficient_summary"]["shape"] == [1, 1]
+    assert result["recovery"]["aggregate"]["exact_count"] == 1
+    assert workflow["summary_type"] == "downstream_discovery_workflow"
+    assert workflow["component_statuses"]["orbit_provenance"]["status"] == "passed"
+
+
+def test_v0_22_release_gate_example_outputs_downstream_workflow() -> None:
+    result = run_downstream_discovery_contracts_example()
+
+    assert json.loads(json.dumps(result)) == result
+    assert result["summary_type"] == "downstream_discovery_contracts_example"
+    assert result["workflow"]["summary_type"] == "downstream_discovery_workflow"
+    assert result["discovery_inputs"]["summary_type"] == "discovery_bridge_output"
+    assert result["discovery_result"]["summary_type"] == "discovery_result"
+    assert result["extra_metrics"]["split_policy"] == "not_managed_by_pdelie"
+
+
+def test_v0_22_release_gate_no_deferred_surface_leaked() -> None:
+    root_forbidden = {
+        "run_downstream_discovery_contracts_example",
+        "summarize_discovery_bridge_output",
+        "summarize_discovery_result",
+        "summarize_downstream_discovery_workflow",
+    }
+    deferred_forbidden = {
+        "from_pdebench",
+        "from_the_well",
+        "from_xarray_dataset",
+        "generate_ks_1d_field_batch",
+        "KSResidualEvaluator",
+        "load_field_batch",
+        "load_pdebench",
+        "load_the_well",
+        "split_orbit_train_heldout",
+        "summarize_discovery_benchmark",
+        "train_test_translation_orbit_split",
+        "WeakKSResidualEvaluator",
+    }
+
+    for name in sorted(root_forbidden | deferred_forbidden):
+        assert not hasattr(pdelie, name), f"pdelie.{name}"
+
+    modules = [
+        importlib.import_module("pdelie.data"),
+        importlib.import_module("pdelie.discovery"),
+        importlib.import_module("pdelie.invariants"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.residuals"),
+        importlib.import_module("pdelie.symmetry"),
+    ]
+    for module in modules:
+        for name in sorted(deferred_forbidden):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"


### PR DESCRIPTION
## Summary

This PR completes `v0.22.0` as a narrow downstream discovery contracts release.

It adds JSON-compatible runtime reports for downstream sparse-discovery workflows without turning PDELie into a discovery-backend framework, benchmark policy layer, split manager, or leakage detector.

Stable path:

```text
FieldBatch / orbit batch / bridge outputs / backend-native discovery result
-> discovery bridge/result summaries
-> optional recovery summary
-> downstream workflow report
```

## Public API Additions

New submodule-only APIs:

- `pdelie.discovery.summarize_discovery_bridge_output(...)`
- `pdelie.discovery.summarize_discovery_result(...)`
- `pdelie.reporting.summarize_downstream_discovery_workflow(...)`
- `pdelie.examples.run_downstream_discovery_contracts_example(...)`

Command example:

```bash
python -m pdelie.examples.downstream_discovery_contracts
```

No root `pdelie` exports were added.

## What This Adds

- Bridge-output summaries for finite 2D trajectories, strictly increasing time values, unique feature names, and JSON-compatible provenance.
- Discovery-result summaries for backend-neutral or `fit_pysindy_discovery(...)`-style mappings.
- Compact coefficient summaries by shape, finite status, norms, and nonzero counts without copying full coefficient matrices into reports.
- Optional feature-keyed recovery summaries via existing `evaluate_discovery_recovery(...)`.
- Downstream workflow summaries combining field readiness, generator confidence, orbit-batch provenance, bridge inputs, and discovery results.
- Orbit provenance traceability checks for source/shift indices without making train/test or leakage decisions.

## Explicit Non-goals

This PR does not add:

- split management or heldout-leakage detection
- downstream augmentation policy
- a general discovery-backend framework
- manuscript benchmark thresholds
- file loaders or `xarray.Dataset` support
- PDEBench/The Well adapters
- multidimensional or nonuniform stable support
- new PDEs
- KS runtime promotion
- weak-form expansion
- time translation
- neural/callable generator APIs
- operator-facing APIs
- root exports

## Release/Docs

- Bumped package metadata to `0.22.0`.
- Added `docs/planning/V0_22_SCOPE.md`.
- Reset `docs/planning/PLAN.md` for completed v0.22.
- Updated `ROADMAP.md`, `API_STABILITY.md`, `CHANGELOG.md`, README, publishing docs, release readiness, CI, and notebook current-surface references.
- Added compact `tests/test_v0_22_release_gate.py`.
- Updated CI to `v0_22-release-gate`.

## Validation

- `python -m pytest`: `825 passed, 2 skipped`
- All v0.10-v0.22 release gates: passed
- `python scripts/check_notebooks.py`: `validated 9 notebooks`
- `python -m build --sdist --wheel`: built `pdelie-0.22.0`
- Clean wheel smoke for downstream discovery contracts: passed
- `git diff --check`: clean
- Ruff not run: no Ruff config found.