### PR TITLE
feat: add v0.27 multi-generator diagnostics decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  v0_26-release-gate:
+  v0_27-release-gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,8 @@ jobs:
           retry 3 python -m pip install -e .[test]
       - name: Check dependencies
         run: python -m pip check
-      - name: Run V0.26 release gate
-        run: python -m pytest tests/test_v0_26_release_gate.py
+      - name: Run V0.27 release gate
+        run: python -m pytest tests/test_v0_27_release_gate.py
   editable-tests:
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +68,7 @@ jobs:
           python -m pdelie.examples.heat_vertical_slice
           python -m pdelie.examples.kdv_vertical_slice
           python -m pdelie.examples.kdv_scope_decision
+          python -m pdelie.examples.multi_generator_diagnostics
           python -m pdelie.examples.reaction_diffusion_vertical_slice
           python -m pdelie.examples.advection_diffusion_vertical_slice
           python -m pdelie.examples.orbit_coverage_diagnostics
@@ -143,6 +144,7 @@ jobs:
               run_downstream_discovery_contracts_example,
               run_external_data_readiness_example,
               run_kdv_scope_decision_example,
+              run_multi_generator_diagnostics_example,
               run_reaction_diffusion_vertical_slice_example,
               run_split_leakage_provenance_example,
               run_weak_form_supportability_example,
@@ -207,6 +209,7 @@ jobs:
           assert run_downstream_discovery_contracts_example is not None
           assert run_external_data_readiness_example is not None
           assert run_kdv_scope_decision_example is not None
+          assert run_multi_generator_diagnostics_example is not None
           assert run_split_leakage_provenance_example is not None
           assert run_weak_form_supportability_example is not None
           assert generate_reaction_diffusion_1d_field_batch is not None
@@ -235,6 +238,7 @@ jobs:
           assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
           assert not hasattr(pdelie, "run_external_data_readiness_example")
           assert not hasattr(pdelie, "run_kdv_scope_decision_example")
+          assert not hasattr(pdelie, "run_multi_generator_diagnostics_example")
           assert not hasattr(pdelie, "run_split_leakage_provenance_example")
           assert not hasattr(pdelie, "run_weak_form_supportability_example")
           assert not hasattr(pdelie, "generate_reaction_diffusion_1d_field_batch")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.27.0
+
+First final release for the frozen V0.27 multi-generator diagnostics decision.
+
+- adds `python -m pdelie.examples.multi_generator_diagnostics` and `pdelie.examples.run_multi_generator_diagnostics_example(...)` as JSON-only diagnostic examples
+- records the multi-generator decision `multi_generator_diagnostics_feasible_fitting_deferred`
+- freezes the bracket convention `[X_i, X_j] = X_i · ∇X_j - X_j · ∇X_i`
+- records structure constants as `[X_i, X_j] = sum_k C[i, j, k] X_k`
+- updates closure diagnostics so well-formed rank-deficient families return diagnostic reports instead of raising solely due to redundant rows
+- updates span diagnostics so rank-deficient or zero-rank well-formed comparisons return warning/failed reports instead of untyped crashes
+- extends `validate_symmetry_candidate(...)` with `closure_required=True|False` for `GeneratorFamily` candidates
+- ensures multi-row generator candidates with only algebraic closure evidence conclude at most `partially_validated`
+- adds supplied-family diagnostics for closed affine, non-closed polynomial, rank-deficient, and basis-mismatch cases
+- preserves existing single-generator translation fitting, verification, confidence reports, KdV/KS decision evidence, weak supportability, downstream contracts, split provenance, invariant/orbit diagnostics, formula-backed generator records, Fisher-KPP, and advection-diffusion paths
+
+Explicitly deferred for this final release:
+
+- public multi-generator PDE fitting
+- multi-generator finite flows
+- BCH composition
+- exponential-map finite-flow integration
+- multi-generator invariant charts
+- multi-parameter orbit charts
+- group-action atlas
+- operator-facing APIs
+- neural or callable generator APIs
+- root export expansion
+- broad adapters or file loaders
+- multidimensional, multivariable, or nonuniform-grid support
+- train/test policy or leakage prevention
+- PyPI and TestPyPI publication; package-index publishing is deferred to `v1.0` or later
+
 ## 0.26.0
 
 First final release for the frozen V0.26 KS revisit decision.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://github.com/alexgabel/pdelie/actions/workflows/ci.yml/badge.svg)](https://github.com/alexgabel/pdelie/actions/workflows/ci.yml)
 ![Python](https://img.shields.io/badge/python-%3E%3D3.11-blue)
-![Version](https://img.shields.io/badge/version-0.26.0-blue)
+![Version](https://img.shields.io/badge/version-0.27.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 PDELie is a research library for empirical Lie-symmetry workflows on controlled PDE time-series data. It turns canonical scalar 1D periodic fields into residuals, generator candidates, verification reports, confidence summaries, invariant/orbit diagnostics, and downstream discovery reports.
 
 ![PDELie pipeline](docs/assets/pdelie_pipeline.svg)
 
-The current stable release is `v0.26.0` / **V0.26**: a KS revisit decision release. PDELie confirms that the internal normalized Kuramoto-Sivashinsky fixture remains residual-feasible and verification-feasible, but translation fitting is still reference-fallback-backed, so public KS runtime APIs remain deferred. Actual KS promotion is reserved for a separate `v0.26b` scope freeze if future direct-SVD/no-fallback evidence supports it.
+The current stable release is `v0.27.0` / **V0.27**: a multi-generator diagnostics decision release. PDELie now diagnoses supplied multi-row `GeneratorFamily` objects with rank, span, closure, bracket, and structure-constant evidence while keeping PDE-context validation and fit recoverability explicitly separate. Public multi-generator fitting, finite multi-generator flows, BCH composition, invariant charts, and root exports remain deferred.
 
 ## Install
 
@@ -91,6 +91,7 @@ PDELie is intentionally conservative. The stable `v0.x` surface currently covers
 - `spectral_fd` derivatives through `u_xxxx`
 - polynomial translation-generator fitting and finite-transform verification
 - JSON-compatible reporting helpers for residuals, weak reports, weak supportability, fits, verification, confidence, readiness, invariant workflows, downstream discovery contracts, and split-provenance diagnostics
+- algebraic span/closure diagnostics for supplied polynomial `GeneratorFamily` objects, including diagnostic handling of rank-deficient well-formed families
 - uniform `x`-translation coverage, consistency, read-only orbit reports, and materialized orbit batches
 - empirical validation of `GeneratorFamily`, `InvariantMapSpec`, and safe formula-backed `FormulaGeneratorFamily` candidates
 - narrow structured ingestion through `from_numpy(...)` and optional `from_xarray(...)`
@@ -138,6 +139,7 @@ Packaged examples print JSON-compatible runtime summaries:
 python -m pdelie.examples.heat_vertical_slice
 python -m pdelie.examples.kdv_vertical_slice
 python -m pdelie.examples.kdv_scope_decision
+python -m pdelie.examples.multi_generator_diagnostics
 python -m pdelie.examples.reaction_diffusion_vertical_slice
 python -m pdelie.examples.advection_diffusion_vertical_slice
 python -m pdelie.examples.orbit_coverage_diagnostics
@@ -158,7 +160,7 @@ These are smoke/reporting examples, not canonical artifact schemas.
 
 The current release is validated by:
 
-- the explicit `v0_26-release-gate` CI job
+- the explicit `v0_27-release-gate` CI job
 - full editable `python -m pytest`
 - built-wheel package smoke
 - packaged example smoke

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Planning docs are release-management records. They do not override the specs.
 - [`releases/PUBLISHING.md`](releases/PUBLISHING.md) - publishing and tag policy
 - `releases/V0_*_RELEASE_READINESS.md` - release closeout records and local validation checklists
 
-Current `v0.x` releases, including `v0.26.0`, are Git-tag-only. PyPI/TestPyPI publishing remains deferred until `v1.0` or later.
+Current `v0.x` releases, including `v0.27.0`, are Git-tag-only. PyPI/TestPyPI publishing remains deferred until `v1.0` or later.
 
 ## Strategy Notes
 

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,32 +1,32 @@
-# PDELie - Execution Plan (V0.26)
+# PDELie - Execution Plan (V0.27)
 
 **Status:** COMPLETE
 
-**V0.26 is complete as the KS revisit decision release**
+**V0.27 is complete as the multi-generator diagnostics decision release**
 
-This file is the completed execution record for the `v0.26` release series.
+This file is the completed execution record for the `v0.27` release series.
 
 ## Release Theme
 
-`v0.26` revisits the Kuramoto-Sivashinsky no-go with modern confidence diagnostics while keeping public KS runtime promotion out of scope.
+`v0.27` diagnoses supplied multi-row `GeneratorFamily` objects without promoting public multi-generator PDE fitting or finite group-action machinery.
 
 Decision label:
 
 ```text
-current_no_go_reference_fallback
+multi_generator_diagnostics_feasible_fitting_deferred
 ```
 
 Stable investigation path:
 
 ```text
-internal normalized KS fixture
--> spectral_fd derivatives through u_xxxx
--> internal KS residual feasibility
--> translation fit / verification / confidence report
--> explicit v0.26 decision label
+canonical scalar 1D periodic FieldBatch
+-> residual evaluator
+-> supplied multi-row GeneratorFamily
+-> algebraic diagnostics + PDE-context diagnostics + fit probe diagnostics
+-> explicit public promotion decision
 ```
 
-The release adds no public KS data generator, residual evaluator, vertical-slice example, status example, weak KS API, residual-only API, or root export.
+The release adds no public multi-generator fitting API, finite-flow API, BCH composition API, invariant chart, orbit builder, operator API, neural/callable generator API, or root export.
 
 ## Milestone Status
 
@@ -40,102 +40,89 @@ The release adds no public KS data generator, residual evaluator, vertical-slice
 
 Authoritative scope:
 
-- `docs/planning/V0_26_SCOPE.md`
-
-`API_STABILITY.md` records the decision-only status but does not add a stable KS runtime contract.
+- `docs/planning/V0_27_SCOPE.md`
 
 ## Milestone 0 - Scope Freeze
 
-Freeze `v0.26` as a KS revisit decision release.
+Freeze `v0.27` as multi-generator diagnostics/decision only.
 
 Closeout:
 
-- added `docs/planning/V0_26_SCOPE.md`
-- reset `PLAN.md` as the active `v0.26` execution record
-- updated `ROADMAP.md` to record `v0.26` as the current completed release
-- reserved `v0.26b` as the follow-up KS promotion release name
-- explicitly kept KS runtime APIs out of `v0.26`
+- added `docs/planning/V0_27_SCOPE.md`
+- reset `PLAN.md` as the active `v0.27` execution record
+- updated `ROADMAP.md` to record `v0.27` as the current completed release
+- explicitly deferred multi-generator PDE fitting, finite flows, BCH composition, invariant charts, orbit charts, and root exports
 
-## Milestone 1 - Decision Criteria Freeze
+## Milestone 1 - Semantics Freeze
 
-Frozen decision labels:
+Frozen semantics:
 
-- `current_no_go_reference_fallback`
-- `residual_feasible_fit_not_promotable`
-- `direct_strong_candidate_for_v0_26b_promotion`
-- `deferred_no_go`
+- bracket convention: `[X_i, X_j] = X_i · ∇X_j - X_j · ∇X_i`
+- structure constants: `[X_i, X_j] = sum_k C[i, j, k] X_k`
+- basis order is the row order of `GeneratorFamily.coefficients`
+- closure diagnostics are algebraic evidence only
+- rank-deficient well-formed families report diagnostic status instead of raising solely due to redundancy
+- `closure_required=True|False` controls whether closure failure is a failed or warning validation check
 
-Frozen promotion-candidate thresholds:
+## Milestone 2 - Algebraic Diagnostic Matrix
 
-- residual max `< 5e-2`
-- residual RMS `< 1e-2`
-- first verification error `< 5e-4`
-- verification classification not `failed`
-- fit evidence label `direct_svd_in_tolerance`
-- `reference_fallback_used is False`
+Implemented supplied-family diagnostic coverage for:
 
-Promotion evidence must come from the frozen primary fixture. Diagnostic variants cannot define promotion.
+- abelian two-generator translations
+- affine `x` algebra
+- affine `u` algebra
+- non-closed polynomial family
+- rank-deficient family
+- basis-mismatch behavior
 
-## Milestone 2 - Minimal KS No-Go Reproduction Matrix
+No generator fitting from PDE data was added in this milestone.
 
-Implemented test-only diagnostic coverage for:
+## Milestone 3 - PDE-Context Diagnostics
 
-- frozen primary fixture
-- seed sweep
-- fit-epsilon sweep
-- one resolution variant
-- fit/fallback diagnostics
-- verification diagnostics
-- generator confidence report
-
-No helper was exported from `pdelie.data`, `pdelie.residuals`, `pdelie.examples`, or root `pdelie`.
-
-## Milestone 3 - Primary Fixture Strong-Path Re-Evaluation
-
-The frozen primary fixture remains:
-
-- residual-feasible
-- verification-feasible
-- reference-fallback-backed for translation fitting
-
-The direct SVD path is not promotable in `v0.26`.
-
-## Milestone 4 - Optional Variant Diagnostics
-
-Variant diagnostics remain test-only and diagnostic-only.
+Candidate validation now separates algebraic closure from PDE-context evidence.
 
 Closeout:
 
+- multi-row family closure checks no longer imply PDE residual symmetry
+- multi-row candidates without finite-transform or residual-preservation evidence conclude at most `partially_validated`
+- PDE-context reports use explicit algebraic-only / blocked / not-meaningful language
+- single-generator translation validation remains unchanged
+
+## Milestone 4 - Internal Fit Probe
+
+Fit-probe evidence remains diagnostic-only.
+
+Closeout:
+
+- no public fitting helper was added
+- no runtime example performs fitting
+- no API stability entry promotes multi-generator fitting
 - no best-of-sweep promotion path was added
-- variants may inform future work only
-- `v0.26b` remains a separate scope decision if future evidence justifies promotion
 
-## Milestone 5 - Decision Docs
+## Milestone 5 - Example And Docs
 
-Docs now state:
+Implemented:
 
-- KS remains deferred in `v0.26`
-- residual feasibility is not enough for public PDELie support
-- public KS promotion requires a separate `v0.26b` scope freeze
-- weak KS remains deferred
+- added `python -m pdelie.examples.multi_generator_diagnostics`
+- added `pdelie.examples.run_multi_generator_diagnostics_example(...)`
+- updated README, changelog, roadmap, API stability, release readiness, and public-surface docs
 
-No packaged KS runtime/status example was added.
+The example uses supplied `GeneratorFamily` objects only and reports diagnostic status.
 
 ## Milestone 6 - Release Gate And Readiness
 
 Implemented:
 
-- added compact `tests/test_v0_26_release_gate.py`
-- updated CI so the current explicit release gate is `v0_26-release-gate`
+- added compact `tests/test_v0_27_release_gate.py`
+- updated CI so the current explicit release gate is `v0_27-release-gate`
 - kept full editable `python -m pytest`
 - kept package smoke
-- bumped package metadata to `0.26.0`
-- updated README, changelog, publishing notes, roadmap, and release readiness docs
-- documented direct `v0.26.0` Git-tag release path
+- bumped package metadata to `0.27.0`
+- documented direct `v0.27.0` Git-tag release path
 
 Required checks before tagging:
 
-- `v0_26-release-gate`
+- `v0_27-release-gate`
 - `editable-tests`
 - `package-smoke`
 

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -25,9 +25,9 @@ Execution state belongs in:
 
 ## Current State
 
-- Current completed release: `v0.26.0`
-- Current theme: KS revisit decision with public promotion deferred to `v0.26b`
-- Next planned release: `v0.26b` KS promotion decision, only if direct-SVD/no-fallback evidence is accepted in a separate scope freeze
+- Current completed release: `v0.27.0`
+- Current theme: multi-generator diagnostics decision with fitting and invariant-action promotion deferred
+- Next planned release: not frozen; `v0.26b` remains reserved for KS promotion only if a separate scope freeze accepts direct-SVD/no-fallback evidence
 - Public package docs start at [`../../README.md`](../../README.md) and [`../README.md`](../README.md)
 - Durable contributor guidance lives in [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md)
 
@@ -463,6 +463,71 @@ The authoritative `v0.12` scope freeze belongs in:
 
 ## Current Completed Release
 
+### `v0.27` - Multi-generator diagnostics decision
+**Status:** Completed
+
+`v0.27` is the completed multi-generator diagnostics decision release after the `v0.26` KS revisit decision.
+
+Its purpose is:
+
+> diagnose supplied multi-row `GeneratorFamily` objects without promoting public multi-generator PDE fitting or finite group-action machinery.
+
+Completed release definition:
+
+`supplied multi-row GeneratorFamily + algebraic diagnostics + PDE-context diagnostic labels + internal-only fit-probe status -> explicit multi-generator promotion decision`
+
+Completed scope:
+
+- `pdelie.examples.run_multi_generator_diagnostics_example(...)`
+- `python -m pdelie.examples.multi_generator_diagnostics`
+- rank-deficient closure diagnostics report `family_rank_status = "rank_deficient"` instead of raising solely for redundant rows
+- rank-deficient/zero-rank span comparisons return warning/failed reports
+- `validate_symmetry_candidate(..., closure_required=True|False)` for `GeneratorFamily` candidates
+- supplied-family diagnostics for closed affine, non-closed polynomial, rank-deficient, and basis-mismatch cases
+- compact current `v0_27-release-gate` readiness
+
+Release interpretation:
+
+- closure, span, and structure constants are algebraic diagnostics, not proof of PDE residual symmetry
+- public multi-generator PDE fitting remains deferred
+- finite multi-generator flows, BCH composition, invariant charts, and multi-parameter orbit charts remain deferred
+- `v0.27.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
+
+Explicit non-goals:
+
+- no public multi-generator PDE fitting
+- no finite multi-generator flows
+- no BCH composition
+- no exponential-map finite-flow integration
+- no multi-generator invariant charts
+- no multi-parameter orbit charts
+- no group-action atlas
+- no broad adapters or file loaders
+- no multidimensional or nonuniform stable support
+- no time-translation APIs
+- no neural or callable generator API
+- no operator-facing symmetry work
+
+The authoritative `v0.27` scope freeze belongs in:
+
+- `V0_27_SCOPE.md`
+
+### Release Gate for `v0.27`
+
+`v0.27` is complete only if:
+
+- supplied closed families report expected structure constants under the frozen bracket convention
+- non-closed families report nonzero closure residuals
+- rank-deficient well-formed families return diagnostic reports, not automatic exceptions
+- multi-row candidate validation separates algebraic evidence from PDE-context evidence
+- no public multi-generator fitting, finite-flow, BCH, invariant-chart, orbit-chart, operator, neural/callable, or root export surface lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package/readiness docs preserve the `v1.0` package-index publishing deferral
+
+---
+
+## Recent Completed Release
+
 ### `v0.26` - KS revisit decision
 **Status:** Completed
 
@@ -476,60 +541,18 @@ Completed release definition:
 
 `internal normalized KS fixture + order-4 spectral_fd residual feasibility + translation fit / verification / confidence diagnostics + minimal no-go reproduction matrix -> explicit KS decision`
 
-Completed scope:
-
-- test-only `ks_revisit_decision` report
-- decision labels: `current_no_go_reference_fallback`, `residual_feasible_fit_not_promotable`, `direct_strong_candidate_for_v0_26b_promotion`, and `deferred_no_go`
-- primary KS fixture confidence report using `summarize_generator_confidence(...)`
-- minimal test-only matrix over seed, fit-epsilon, and one resolution variant
-- compact current `v0_26-release-gate` readiness
-
 Release interpretation:
 
 - this is a decision release, not a KS promotion release
 - the primary KS fixture remains residual-feasible and verification-feasible
 - translation fitting remains reference-fallback-backed, so public KS support remains deferred
 - `v0.26b` is reserved as the follow-up promotion release name if a separate scope freeze accepts future direct-SVD/no-fallback evidence
-- `v0.26.0` is a Git-tag-only release; PyPI and TestPyPI publication are deferred to `v1.0` or later
-
-Explicit non-goals:
-
-- no public KS data generator
-- no public KS residual evaluator
-- no public KS vertical-slice example
-- no public KS status example
-- no residual-only KS public API
-- no weak KS API
-- no custom KS initial-condition API
-- no configurable KS coefficient API
-- no broad KS regime support
-- no root KS export
-- no broad adapters or file loaders
-- no multidimensional or nonuniform stable support
-- no time-translation APIs
-- no neural or callable generator API
-- no operator-facing symmetry work
 
 The authoritative `v0.26` scope freeze belongs in:
 
 - `V0_26_SCOPE.md`
 
-### Release Gate for `v0.26`
-
-`v0.26` is complete only if:
-
-- the primary KS fixture records `current_no_go_reference_fallback`
-- residual and verification evidence remain feasible but fit evidence remains fallback-backed
-- confidence evidence is present and does not override the direct-SVD/no-fallback promotion rule
-- matrix variants remain diagnostic-only
-- no public KS runtime API, weak KS API, status example, or root KS export lands
-- API stability docs record the decision-only status without adding stable KS runtime contracts
-- CI uses one compact current release gate plus full editable tests and package smoke
-- package/readiness docs preserve the `v1.0` package-index publishing deferral
-
----
-
-## Recent Completed Release
+### Earlier Recent Release
 
 ### `v0.25` - KdV scope decision
 **Status:** Completed

--- a/docs/planning/V0_27_SCOPE.md
+++ b/docs/planning/V0_27_SCOPE.md
@@ -1,0 +1,135 @@
+# V0.27 Scope - Multi-Generator Diagnostics Decision
+
+**Status:** COMPLETE
+
+## Summary
+
+`v0.27` is a multi-generator diagnostics decision release.
+
+Stable investigation path:
+
+```text
+canonical scalar 1D periodic FieldBatch
+-> residual evaluator
+-> supplied multi-row GeneratorFamily
+-> algebraic diagnostics + PDE-context diagnostics + fit probe diagnostics
+-> explicit public promotion decision
+```
+
+Release conclusion:
+
+```text
+multi_generator_diagnostics_feasible_fitting_deferred
+```
+
+The release separates:
+
+- `algebraic_diagnostics`: span, rank, closure, brackets, and structure constants
+- `pde_context_diagnostics`: whether generator/PDE pairs are meaningful and empirically checked
+- `fit_probe_diagnostics`: internal-only recoverability probes
+- `public_promotion_decision`: whether any public API promotion is justified
+
+Closure does not imply PDE residual symmetry.
+
+## Public API Notes
+
+New submodule-only runtime example:
+
+- `pdelie.examples.run_multi_generator_diagnostics_example(...)`
+- `python -m pdelie.examples.multi_generator_diagnostics`
+
+Behavior updates to existing public diagnostic helpers:
+
+- `pdelie.symmetry.diagnose_generator_family_closure(...)` now reports well-formed rank-deficient families as diagnostic reports instead of raising solely because the rows are redundant.
+- `pdelie.symmetry.compare_generator_spans(...)` now reports zero-rank or rank-deficient span comparisons as failed/warning reports instead of crashing for well-formed families.
+- `pdelie.symmetry.validate_symmetry_candidate(...)` now accepts `closure_required=True|False` for `GeneratorFamily` candidates.
+
+No new public multi-generator fitting API, finite-flow API, invariant-chart API, orbit builder, BCH composition API, exponential-map flow integration, group-action atlas, or root export was added.
+
+## Frozen Semantics
+
+Bracket convention:
+
+```text
+[X_i, X_j] = X_i · ∇X_j - X_j · ∇X_i
+```
+
+Structure constants:
+
+```text
+[X_i, X_j] = sum_k C[i, j, k] X_k
+```
+
+Frozen diagnostic labels:
+
+- `algebraic_diagnostics_feasible`
+- `pde_context_validation_diagnostic_only`
+- `fit_probe_diagnostic_only`
+- `multi_generator_diagnostics_feasible_fitting_deferred`
+- `multi_generator_fitting_candidate_for_future_promotion`
+- `deferred_no_go`
+
+Frozen PDE-context labels:
+
+- `known_pde_symmetry`
+- `algebraic_only`
+- `blocked_no_finite_transform`
+- `blocked_parameter_policy`
+- `failed_residual_preservation`
+- `not_meaningful_for_pde`
+
+Rank policy:
+
+- malformed family -> typed validation error
+- well-formed rank-deficient family -> diagnostic status with `family_rank_status = "rank_deficient"`
+- rank-deficient reference/span comparison -> failed or warning report
+
+## Algebraic Diagnostic Matrix
+
+`v0.27` records exact supplied-family evidence for:
+
+- `abelian_two_translation_family`: `X1 = ∂x`, `X2 = ∂t`
+- `affine_x_family`: `X1 = ∂x`, `X2 = x∂x`, `[X1, X2] = X1`
+- `affine_u_family`: `X1 = ∂u`, `X2 = u∂u`, `[X1, X2] = X1`
+- `nonclosed_polynomial_family`: `X1 = ∂x`, `X2 = x^2∂x`, `[X1, X2] = 2x∂x` outside the span
+- `rank_deficient_affine_family`: redundant rows such as `X1 = ∂x`, `X2 = 2∂x`
+- `basis_mismatch_family`: same apparent rows under incompatible basis specs
+
+## Explicit Non-goals
+
+- no public multi-generator PDE fitting
+- no multi-generator invariant charts
+- no finite multi-generator flows
+- no BCH composition
+- no exponential-map finite-flow integration
+- no multi-parameter orbit charts
+- no group-action atlas
+- no operator-facing APIs
+- no neural or callable generator APIs
+- no root export expansion
+- no train/test policy or leakage prevention
+- no broad adapters or file loaders
+- no multidimensional or nonuniform stable support
+
+## Milestone Status
+
+- Milestone 0: COMPLETE
+- Milestone 1: COMPLETE
+- Milestone 2: COMPLETE
+- Milestone 3: COMPLETE
+- Milestone 4: COMPLETE
+- Milestone 5: COMPLETE
+- Milestone 6: COMPLETE
+
+## Release Gate
+
+`v0.27` is complete only if:
+
+- supplied closed families report expected structure constants under the frozen bracket convention
+- non-closed families report nonzero closure residuals
+- rank-deficient well-formed families return diagnostic reports, not automatic exceptions
+- multi-row candidate validation separates algebraic evidence from PDE-context evidence
+- the public example is diagnostic-only and performs no fitting
+- no public multi-generator fitting, finite-flow, BCH, invariant-chart, orbit-chart, operator, neural/callable, or root export surface lands
+- CI uses one compact current release gate plus full editable tests and package smoke
+- package-index publishing remains deferred until `v1.0` or later

--- a/docs/releases/PUBLISHING.md
+++ b/docs/releases/PUBLISHING.md
@@ -16,14 +16,14 @@ These files must be aligned before any release candidate or final release is pub
 
 ## V0.x Package-Index Deferral
 
-For the current `v0.x` series, including `v0.26.0`, release completion means:
+For the current `v0.x` series, including `v0.27.0`, release completion means:
 
 - metadata, docs, tests, build, and wheel-smoke checks pass
 - the release PR is merged
 - the merged commit is tagged in Git as the final version
 
-`v0.26.0` is intentionally a Git-tag-only release.
-Do not publish to TestPyPI or PyPI for `v0.26.0`.
+`v0.27.0` is intentionally a Git-tag-only release.
+Do not publish to TestPyPI or PyPI for `v0.27.0`.
 
 Package-index publishing through TestPyPI or PyPI is deferred until `v1.0` or later.
 The publishing model below remains the intended future package-index workflow once publication is re-enabled.

--- a/docs/releases/V0_27_RELEASE_READINESS.md
+++ b/docs/releases/V0_27_RELEASE_READINESS.md
@@ -1,0 +1,110 @@
+# V0.27 Release Readiness
+
+## Summary
+
+`v0.27.0` is the multi-generator diagnostics decision release.
+
+Release definition:
+
+```text
+supplied multi-row GeneratorFamily
++ algebraic diagnostics
++ PDE-context diagnostic labels
++ internal-only fit-probe status
+-> explicit multi-generator promotion decision
+```
+
+package version: `0.27.0`  
+git tag: `v0.27.0`
+
+## Public API Notes
+
+New submodule-only runtime example:
+
+- `pdelie.examples.run_multi_generator_diagnostics_example(...)`
+- `python -m pdelie.examples.multi_generator_diagnostics`
+
+Existing public diagnostic behavior updates:
+
+- `diagnose_generator_family_closure(...)` reports well-formed rank-deficient families diagnostically.
+- `compare_generator_spans(...)` reports rank-deficient/zero-rank comparisons as warning/failed reports.
+- `validate_symmetry_candidate(...)` accepts `closure_required=True|False`.
+
+No root `pdelie` exports were added.
+
+## What This Release Does
+
+- records `multi_generator_diagnostics_feasible_fitting_deferred`
+- freezes the bracket convention and structure-constant orientation
+- reports expected structure-constant error for known closed families
+- separates algebraic diagnostics from PDE-context validation
+- keeps multi-generator fit probes internal and diagnostic-only
+- adds a JSON-only diagnostic example over supplied families
+
+## What This Release Does Not Do
+
+- no public multi-generator PDE fitting
+- no finite multi-generator flows
+- no BCH composition
+- no exponential-map finite-flow integration
+- no multi-generator invariant charts
+- no multi-parameter orbit charts
+- no group-action atlas
+- no operator-facing APIs
+- no neural or callable generator APIs
+- no root export expansion
+
+## CI Expectations
+
+The current explicit release gate is:
+
+- `v0_27-release-gate`
+
+CI also keeps:
+
+- full editable `python -m pytest`
+- package build and clean-wheel smoke
+
+## Local Validation Checklist
+
+Run from the release commit:
+
+```bash
+python -m pytest
+python -m build --sdist --wheel
+python -m pdelie.examples.heat_vertical_slice
+python -m pdelie.examples.kdv_vertical_slice
+python -m pdelie.examples.kdv_scope_decision
+python -m pdelie.examples.multi_generator_diagnostics
+python -m pdelie.examples.reaction_diffusion_vertical_slice
+python -m pdelie.examples.advection_diffusion_vertical_slice
+python -m pdelie.examples.orbit_coverage_diagnostics
+python -m pdelie.examples.invariant_workflow_summary
+python -m pdelie.examples.translation_orbit_batch
+python -m pdelie.examples.symmetry_candidate_validation
+python -m pdelie.examples.formula_generator_validation
+python -m pdelie.examples.generator_confidence_report
+python -m pdelie.examples.external_data_readiness
+python -m pdelie.examples.downstream_discovery_contracts
+python -m pdelie.examples.split_leakage_provenance
+python -m pdelie.examples.weak_form_supportability
+python scripts/check_notebooks.py
+git diff --check
+```
+
+## Direct Tag Checklist
+
+`v0.27.0` remains a direct Git-tag release.
+
+1. Confirm CI is green on the release commit.
+2. Confirm package metadata says `0.27.0`.
+3. Confirm `CHANGELOG.md` contains `0.27.0`.
+4. Confirm `docs/specs/API_STABILITY.md` documents only the diagnostic example and behavior updates, not multi-generator fitting.
+5. Confirm `docs/planning/PLAN.md` and `docs/planning/V0_27_SCOPE.md` mark Milestone 6 complete.
+6. Create the tag:
+
+```bash
+git tag v0.27.0
+```
+
+Do not publish to TestPyPI or PyPI for `v0.27.0`. Package-index publishing remains deferred until `v1.0` or later.

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -321,6 +321,18 @@ Decision-only note for the frozen `v0.26` KS revisit decision:
 - this decision does not add a stable public Kuramoto-Sivashinsky data generator or residual evaluator
 - this decision does not add a public KS vertical-slice example, public KS status example, residual-only KS public API, weak KS API, custom KS initial-condition API, configurable KS coefficient API, broad KS regime support, root KS export, broad adapter, time-translation API, neural/callable generator API, or operator-facing API
 
+Runtime public API and behavior updates for the frozen `v0.27` multi-generator diagnostics decision:
+
+- `pdelie.examples.run_multi_generator_diagnostics_example` for a compact JSON-only runtime diagnostic example over supplied multi-row `GeneratorFamily` objects
+- multi-generator diagnostic examples use `summary_type = "multi_generator_diagnostics_example"` and `summary_schema_version = "0.1"`
+- `pdelie.symmetry.diagnose_generator_family_closure` now reports well-formed rank-deficient families as diagnostic reports with `family_rank_status = "rank_deficient"` instead of raising solely because structure constants are non-unique
+- `pdelie.symmetry.compare_generator_spans` now reports well-formed zero-rank/rank-deficient span comparisons with `comparison_status = "failed"` or `"warning"` instead of crashing solely because rank is deficient
+- `pdelie.symmetry.validate_symmetry_candidate` now accepts `closure_required=True|False` for `GeneratorFamily` candidates
+- multi-row `GeneratorFamily` validation keeps algebraic closure diagnostics separate from PDE-context evidence; closure passing alone does not prove PDE residual symmetry
+- the recorded `v0.27` decision is `multi_generator_diagnostics_feasible_fitting_deferred`
+- this release does not add public multi-generator PDE fitting, finite multi-generator flows, BCH composition, exponential-map integration, invariant charts, multi-parameter orbit charts, group-action atlases, operator APIs, neural/callable generator APIs, or root exports
+- these APIs have no root `pdelie` exports
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 
@@ -334,7 +346,7 @@ These must not change without version bump.
 - weak-form derivatives and weak-form methods beyond the frozen `v0.8` weak residual report slice and the `v0.24` weak supportability reporting layer
 - operator symmetry
 - advanced invariant maps
-- multi-generator invariant machinery
+- multi-generator invariant machinery, finite flows, BCH composition, and public multi-generator PDE fitting
 
 These may change without warning.
 

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -17,6 +17,7 @@ It is a **library**, not a project repo.
 - uniform rectilinear grids
 - Lie point symmetries
 - canonical polynomial `GeneratorFamily` parameterizations
+- algebraic span and closure diagnostics for supplied polynomial `GeneratorFamily` objects
 - runtime-only formula-backed generator records and empirical candidate-validation reports
 - frozen invariant, reporting, uniform-translation orbit, and materialized-orbit utilities
 - runtime-only downstream discovery bridge/result/workflow reports
@@ -33,7 +34,8 @@ It is a **library**, not a project repo.
 - broad discovery-backend frameworks, split management, leakage prevention, and heldout-leakage policy
 - multidimensional, multivariable, and nonuniform-grid stable expansion
 - operator-level symmetry discovery
-- multi-generator invariant charts
+- public multi-generator PDE fitting
+- multi-generator invariant charts, finite flows, BCH composition, and multi-parameter orbit atlases
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdelie"
-version = "0.26.0"
-description = "V0.26 KS revisit decision plus retained KdV scope decision, weak supportability, provenance, downstream contracts, confidence reports, PDE strong paths, and symmetry diagnostics"
+version = "0.27.0"
+description = "V0.27 multi-generator diagnostics decision plus retained KS/KdV decisions, weak supportability, provenance, downstream contracts, confidence reports, PDE strong paths, and symmetry diagnostics"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/pdelie/examples/__init__.py
+++ b/src/pdelie/examples/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "run_invariant_workflow_summary_example",
     "run_kdv_scope_decision_example",
     "run_kdv_vertical_slice_example",
+    "run_multi_generator_diagnostics_example",
     "run_orbit_coverage_diagnostics_example",
     "run_reaction_diffusion_vertical_slice_example",
     "run_split_leakage_provenance_example",
@@ -71,6 +72,12 @@ def run_kdv_vertical_slice_example() -> dict[str, object]:
 
 def run_kdv_scope_decision_example() -> dict[str, object]:
     from pdelie.examples.kdv_scope_decision import run_kdv_scope_decision_example as _impl
+
+    return _impl()
+
+
+def run_multi_generator_diagnostics_example() -> dict[str, object]:
+    from pdelie.examples.multi_generator_diagnostics import run_multi_generator_diagnostics_example as _impl
 
     return _impl()
 

--- a/src/pdelie/examples/multi_generator_diagnostics.py
+++ b/src/pdelie/examples/multi_generator_diagnostics.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from pdelie import GeneratorFamily
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.reporting import summarize_generator_confidence
+from pdelie.residuals import HeatResidualEvaluator
+from pdelie.symmetry import compare_generator_spans, diagnose_generator_family_closure, validate_symmetry_candidate
+
+
+_SUMMARY_SCHEMA_VERSION = "0.1"
+
+
+def _x_basis_spec(labels: list[str] | None = None, powers: list[list[int]] | None = None) -> dict[str, object]:
+    powers = [[0], [1]] if powers is None else powers
+    if labels is None:
+        labels = ["1", "x"] if powers == [[0], [1]] else [("1" if item == [0] else f"x^{item[0]}") for item in powers]
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": label, "powers": power}
+            for label, power in zip(labels, powers)
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": list(labels),
+        "layout": "component_major",
+    }
+
+
+def _generator(
+    coefficients: list[list[float]],
+    *,
+    basis_spec: dict[str, object] | None = None,
+    name: str,
+) -> GeneratorFamily:
+    coefficients_array = np.asarray(coefficients, dtype=float)
+    return GeneratorFamily(
+        parameterization="algebraic_diagnostic_fixture",
+        coefficients=coefficients_array,
+        basis_spec=_x_basis_spec() if basis_spec is None else basis_spec,
+        normalization="runtime_fixture",
+        generator_names=[f"{name}_{index}" for index in range(coefficients_array.shape[0])],
+        diagnostics={"fixture_name": name},
+    )
+
+
+def _expected_affine_x_structure_constants() -> list[list[list[float]]]:
+    expected = np.zeros((2, 2, 2), dtype=float)
+    expected[0, 1, 0] = 1.0
+    expected[1, 0, 0] = -1.0
+    return expected.tolist()
+
+
+def run_multi_generator_diagnostics_example() -> dict[str, object]:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=27027)
+    evaluator = HeatResidualEvaluator()
+
+    closed_affine = _generator([[1.0, 0.0], [0.0, 1.0]], name="affine_x")
+    nonclosed = _generator(
+        [[1.0, 0.0], [0.0, 1.0]],
+        basis_spec=_x_basis_spec(labels=["1", "x^2"], powers=[[0], [2]]),
+        name="nonclosed_polynomial",
+    )
+    rank_deficient = _generator([[1.0, 0.0], [2.0, 0.0]], name="rank_deficient_affine")
+
+    closed_closure = diagnose_generator_family_closure(
+        closed_affine,
+        expected_structure_constants=_expected_affine_x_structure_constants(),
+    )
+    nonclosed_closure = diagnose_generator_family_closure(nonclosed)
+    rank_deficient_closure = diagnose_generator_family_closure(rank_deficient)
+    rank_deficient_span = compare_generator_spans(closed_affine, rank_deficient)
+
+    closed_validation = validate_symmetry_candidate(
+        field,
+        closed_affine,
+        residual_evaluator=evaluator,
+        source_candidate_id="example_affine_x_closed_supplied_family",
+    )
+    nonclosed_required_validation = validate_symmetry_candidate(
+        field,
+        nonclosed,
+        residual_evaluator=evaluator,
+        source_candidate_id="example_nonclosed_required",
+    )
+    nonclosed_optional_validation = validate_symmetry_candidate(
+        field,
+        nonclosed,
+        residual_evaluator=evaluator,
+        source_candidate_id="example_nonclosed_optional",
+        closure_required=False,
+    )
+
+    confidence = summarize_generator_confidence(
+        candidate_validation=closed_validation,
+        extra_metrics={
+            "diagnostic_only": True,
+            "public_multi_generator_fitting_promoted": False,
+            "finite_multi_generator_action_available": False,
+        },
+    )
+
+    return {
+        "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
+        "summary_type": "multi_generator_diagnostics_example",
+        "decision": {
+            "release": "v0.27.0",
+            "conclusion": "multi_generator_diagnostics_feasible_fitting_deferred",
+            "public_promotion_decision": "no_public_multi_generator_fitting_or_invariant_action",
+        },
+        "algebraic_diagnostics": {
+            "closed_affine_x": closed_closure,
+            "nonclosed_polynomial": nonclosed_closure,
+            "rank_deficient_affine": rank_deficient_closure,
+            "rank_deficient_span_comparison": rank_deficient_span,
+        },
+        "pde_context_diagnostics": {
+            "closed_affine_x": closed_validation,
+            "nonclosed_required": nonclosed_required_validation,
+            "nonclosed_optional": nonclosed_optional_validation,
+        },
+        "fit_probe_diagnostics": {
+            "label": "fit_probe_diagnostic_only",
+            "runtime_example_runs_fit_probe": False,
+            "public_fitting_api_promoted": False,
+        },
+        "confidence": confidence,
+        "extra_metrics": {
+            "example_name": "multi_generator_diagnostics",
+            "field_equation": "heat_1d",
+            "generator_source": "supplied_generator_family_objects",
+            "closure_does_not_imply_pde_symmetry": True,
+            "no_bch_composition": True,
+            "no_exponential_flow_integration": True,
+            "no_multi_parameter_orbit_chart": True,
+        },
+    }
+
+
+def main() -> None:
+    print(json.dumps(run_multi_generator_diagnostics_example(), indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdelie/symmetry/candidate_validation.py
+++ b/src/pdelie/symmetry/candidate_validation.py
@@ -32,6 +32,12 @@ _RELATIVE_L2_EPS = 1e-12
 _FORMULA_RECIPROCAL_DENOMINATOR_FLOOR = FormulaGeneratorFamily.RECIPROCAL_DENOMINATOR_FLOOR
 
 
+def _require_bool(value: Any, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise SchemaValidationError(f"{name} must be a bool.")
+    return value
+
+
 def _json_safe(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return [_json_safe(item) for item in value.tolist()]
@@ -225,6 +231,8 @@ def _conclusion(checks: Mapping[str, Mapping[str, Any]]) -> str:
 
 
 def _span_passed(report: Mapping[str, Any]) -> bool:
+    if report.get("comparison_status") != "passed":
+        return False
     angles = np.asarray(report["principal_angles_radians"], dtype=float)
     projection = report["projection_residual"]
     return bool(
@@ -235,6 +243,10 @@ def _span_passed(report: Mapping[str, Any]) -> bool:
 
 
 def _closure_passed(report: Mapping[str, Any]) -> bool:
+    if report.get("family_rank_status") != "full_rank":
+        return False
+    if report["closure"].get("status") != "available":
+        return False
     return bool(
         float(report["closure"]["summary"]) <= _CLOSURE_TOLERANCE
         and float(report["antisymmetry"]["summary"]) <= _CLOSURE_TOLERANCE
@@ -249,6 +261,7 @@ def _validate_generator_candidate(
     residual_evaluator: ResidualEvaluator,
     reference_generator: GeneratorFamily | None,
     finite_transform_epsilons: np.ndarray,
+    closure_required: bool,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     from pdelie.reporting import summarize_generator_family, summarize_verification_report
 
@@ -294,8 +307,9 @@ def _validate_generator_candidate(
             closure_report = diagnose_generator_family_closure(generator)
         except PDELieValidationError as exc:
             checks["closure_diagnostics"] = {
-                "required": True,
-                "status": "failed",
+                "required": closure_required,
+                "status": "failed" if closure_required else "warning",
+                "required_by_closure_policy": closure_required,
                 "threshold": {
                     "closure": _CLOSURE_TOLERANCE,
                     "antisymmetry": _CLOSURE_TOLERANCE,
@@ -304,9 +318,15 @@ def _validate_generator_candidate(
                 "error": str(exc),
             }
         else:
+            closure_passed = _closure_passed(closure_report)
             checks["closure_diagnostics"] = {
-                "required": True,
-                "status": "passed" if _closure_passed(closure_report) else "failed",
+                "required": closure_required,
+                "status": (
+                    "passed"
+                    if closure_passed
+                    else ("failed" if closure_required else "warning")
+                ),
+                "required_by_closure_policy": closure_required,
                 "threshold": {
                     "closure": _CLOSURE_TOLERANCE,
                     "antisymmetry": _CLOSURE_TOLERANCE,
@@ -314,9 +334,17 @@ def _validate_generator_candidate(
                 },
                 "report": closure_report,
             }
+        checks["pde_context_diagnostics"] = {
+            "required": False,
+            "status": "warning",
+            "label": "algebraic_only",
+            "reason": (
+                "multi-row GeneratorFamily validation in v0.27 reports algebraic diagnostics only; "
+                "no finite multi-generator transform or residual-preservation check was configured."
+            ),
+        }
 
     return summarize_generator_family(generator), checks
-
 
 def _validate_invariant_map_scope(spec: InvariantMapSpec) -> float:
     if spec.construction_method != "uniform_translation":
@@ -464,6 +492,7 @@ def validate_symmetry_candidate(
     reference_generator: GeneratorFamily | Mapping[str, Any] | None = None,
     finite_transform_epsilons: Any | None = None,
     source_candidate_id: Any | None = None,
+    closure_required: bool = True,
 ) -> dict[str, Any]:
     """Validate an externally supplied symmetry candidate under configured empirical checks."""
 
@@ -471,6 +500,7 @@ def validate_symmetry_candidate(
     if not isinstance(residual_evaluator, ResidualEvaluator):
         raise SchemaValidationError("residual_evaluator must be a ResidualEvaluator.")
     epsilons = _validate_epsilon_values(finite_transform_epsilons)
+    closure_required = _require_bool(closure_required, name="closure_required")
     normalized_source_id = _validate_json_compatible(source_candidate_id, name="source_candidate_id")
     normalized_reference = _coerce_reference_generator(reference_generator)
     candidate_kind, normalized_candidate = _coerce_candidate(candidate)
@@ -483,6 +513,7 @@ def validate_symmetry_candidate(
             residual_evaluator=residual_evaluator,
             reference_generator=normalized_reference,
             finite_transform_epsilons=epsilons,
+            closure_required=closure_required,
         )
     elif candidate_kind == "invariant_map_spec":
         assert isinstance(normalized_candidate, InvariantMapSpec)
@@ -523,6 +554,7 @@ def validate_symmetry_candidate(
                 "closure": _CLOSURE_TOLERANCE,
                 "formula_reciprocal_denominator_floor": _FORMULA_RECIPROCAL_DENOMINATOR_FLOOR,
             },
+            "closure_required": closure_required,
             "candidate_summary": candidate_summary,
             "configured_validation_checks": list(checks.keys()),
             "check_reports": checks,

--- a/src/pdelie/symmetry/closure.py
+++ b/src/pdelie/symmetry/closure.py
@@ -21,6 +21,7 @@ _SAMPLED_GRID_POINTS_PER_AXIS = 5
 _MAX_SAMPLED_GRID_POINTS = 15625
 _FALLBACK_DOMAIN_BOUND = 1.0
 _SYMMETRY_ALGEBRA_CLASSIFICATIONS = frozenset({"exact", "approximate"})
+_BRACKET_CONVENTION = "[X_i, X_j] = X_i · ∇X_j - X_j · ∇X_i"
 
 _Polynomial = dict[tuple[int, ...], float]
 _VectorField = dict[str, _Polynomial]
@@ -279,6 +280,35 @@ def _family_metric_summary(metric_matrix: np.ndarray) -> tuple[int, float]:
     return int(positive.size), _condition_number(positive)
 
 
+def _json_finite_or_none(value: float) -> float | None:
+    normalized = float(value)
+    return normalized if np.isfinite(normalized) else None
+
+
+def _basis_order(generator: GeneratorFamily) -> list[str]:
+    if generator.generator_names is not None:
+        return [str(name) for name in generator.generator_names]
+    return [f"row_{index}" for index in range(int(generator.coefficients.shape[0]))]
+
+
+def _normalize_expected_structure_constants(
+    expected_structure_constants: Any | None,
+    *,
+    family_size: int,
+) -> np.ndarray | None:
+    if expected_structure_constants is None:
+        return None
+    normalized = np.asarray(expected_structure_constants, dtype=float)
+    if normalized.shape != (family_size, family_size, family_size):
+        raise ShapeValidationError(
+            "expected_structure_constants must have shape "
+            f"({family_size}, {family_size}, {family_size})."
+        )
+    if not np.all(np.isfinite(normalized)):
+        raise ShapeValidationError("expected_structure_constants must contain only finite values.")
+    return normalized
+
+
 def _solve_projection_coefficients(metric_matrix: np.ndarray, rhs: np.ndarray) -> tuple[np.ndarray, float]:
     coefficients, _, _, singular_values = np.linalg.lstsq(metric_matrix, rhs, rcond=None)
     return np.asarray(coefficients, dtype=float), _condition_number(np.asarray(singular_values, dtype=float))
@@ -385,6 +415,7 @@ def diagnose_generator_family_closure(
     component_targets: Mapping[str, str] | None = None,
     inner_product: str = "normalized_polynomial_l2",
     computation_mode: str = "auto",
+    expected_structure_constants: Any | None = None,
 ) -> dict[str, object]:
     """Diagnose runtime closure properties for a canonical polynomial GeneratorFamily."""
 
@@ -410,6 +441,10 @@ def diagnose_generator_family_closure(
         for row in np.asarray(generator.coefficients, dtype=float)
     ]
     family_size = len(family_fields)
+    expected_tensor = _normalize_expected_structure_constants(
+        expected_structure_constants,
+        family_size=family_size,
+    )
 
     if resolved_mode == "exact_polynomial":
         metric_matrix = np.empty((family_size, family_size), dtype=float)
@@ -443,10 +478,59 @@ def diagnose_generator_family_closure(
         domain["grid_points_per_axis"] = _SAMPLED_GRID_POINTS_PER_AXIS
 
     family_rank, family_condition = _family_metric_summary(metric_matrix)
+    family_rank_status = "full_rank" if family_rank == family_size else "rank_deficient"
+    base_report: dict[str, object] = {
+        "interpretation_label": interpretation_label,
+        "verification_classifications": verification_classifications,
+        "bracket_convention": _BRACKET_CONVENTION,
+        "basis_order": _basis_order(generator),
+        "inner_product": inner_product,
+        "computation_mode": resolved_mode,
+        "domain": domain,
+        "component_weights": component_weights,
+        "component_targets": resolved_component_targets,
+        "family_rank": family_rank,
+        "family_rank_status": family_rank_status,
+    }
     if family_rank != family_size:
-        raise ShapeValidationError(
-            "diagnose_generator_family_closure requires full effective family rank under the runtime metric policy; structure constants are not uniquely defined for a rank-deficient family."
-        )
+        conditioning = {
+            "family_gram": _json_finite_or_none(family_condition),
+            "structure_constant_solve": None,
+        }
+        return {
+            **base_report,
+            "structure_constants": {
+                "tensor": None,
+                "estimation_mode": "unavailable_rank_deficient",
+                "conditioning": conditioning,
+                "status": "unavailable",
+                "reason": "structure constants are not uniquely defined for a rank-deficient family.",
+                "expected_structure_constants": (
+                    None if expected_tensor is None else expected_tensor.tolist()
+                ),
+                "structure_constant_error": None,
+            },
+            "closure": {
+                "summary": None,
+                "pairwise_residuals": None,
+                "status": "unavailable",
+                "reason": "closure residuals are not uniquely diagnosable for a rank-deficient family.",
+            },
+            "antisymmetry": {
+                "summary": None,
+                "pairwise_residuals": None,
+                "status": "unavailable",
+                "reason": "antisymmetry residuals are not uniquely diagnosable for a rank-deficient family.",
+            },
+            "jacobi": {
+                "summary": None,
+                "triple_residuals": None,
+                "mode": "unavailable_rank_deficient",
+                "status": "unavailable",
+                "reason": "Jacobi residuals are not uniquely diagnosable for a rank-deficient family.",
+            },
+            "conditioning": conditioning,
+        }
 
     structure_tensor = np.zeros((family_size, family_size, family_size), dtype=float)
     closure_residuals = np.zeros((family_size, family_size), dtype=float)
@@ -558,39 +642,42 @@ def diagnose_generator_family_closure(
         jacobi_summary = float(np.max(jacobi_array))
 
     conditioning = {
-        "family_gram": family_condition,
-        "structure_constant_solve": solve_condition,
+        "family_gram": _json_finite_or_none(family_condition),
+        "structure_constant_solve": _json_finite_or_none(solve_condition),
     }
+    structure_constant_error = (
+        None
+        if expected_tensor is None
+        else float(np.max(np.abs(structure_tensor - expected_tensor)))
+    )
 
     return {
-        "interpretation_label": interpretation_label,
-        "verification_classifications": verification_classifications,
-        "inner_product": inner_product,
-        "computation_mode": resolved_mode,
-        "domain": domain,
-        "component_weights": component_weights,
-        "component_targets": resolved_component_targets,
-        "family_rank": family_rank,
+        **base_report,
         "structure_constants": {
             "tensor": structure_tensor.tolist(),
             "estimation_mode": resolved_mode,
-            "conditioning": {
-                "family_gram": family_condition,
-                "structure_constant_solve": solve_condition,
-            },
+            "conditioning": conditioning,
+            "status": "available",
+            "expected_structure_constants": (
+                None if expected_tensor is None else expected_tensor.tolist()
+            ),
+            "structure_constant_error": structure_constant_error,
         },
         "closure": {
             "summary": float(np.max(closure_residuals)),
             "pairwise_residuals": closure_residuals.tolist(),
+            "status": "available",
         },
         "antisymmetry": {
             "summary": float(np.max(antisymmetry_residuals)),
             "pairwise_residuals": antisymmetry_residuals.tolist(),
+            "status": "available",
         },
         "jacobi": {
             "summary": jacobi_summary,
             "triple_residuals": jacobi_residuals,
             "mode": "structure_constants",
+            "status": "available",
         },
         "conditioning": conditioning,
     }

--- a/src/pdelie/symmetry/span.py
+++ b/src/pdelie/symmetry/span.py
@@ -100,6 +100,19 @@ def _orthonormal_row_span(matrix: np.ndarray) -> tuple[np.ndarray, int, float]:
     return vh[:rank], rank, _condition_number_from_values(retained)
 
 
+def _rank_status(rank: int, row_count: int) -> str:
+    if rank == 0:
+        return "zero_rank"
+    if rank < row_count:
+        return "rank_deficient"
+    return "full_rank"
+
+
+def _json_finite_or_none(value: float) -> float | None:
+    normalized = float(value)
+    return normalized if np.isfinite(normalized) else None
+
+
 def _projection_residual(source_basis: np.ndarray, target_basis: np.ndarray) -> float:
     projector = target_basis.T @ target_basis
     residual = source_basis - source_basis @ projector
@@ -116,7 +129,7 @@ def compare_generator_spans(
 
     Raises:
         SchemaValidationError: for unsupported inner products or non-equivalent basis semantics.
-        ShapeValidationError: if either effective span has zero numerical rank.
+        ShapeValidationError: if the ambient metric is not positive semidefinite.
     """
 
     reference.validate()
@@ -138,17 +151,11 @@ def compare_generator_spans(
     reference_basis, reference_rank, reference_condition = _orthonormal_row_span(reference_transformed)
     candidate_basis, candidate_rank, candidate_condition = _orthonormal_row_span(candidate_transformed)
 
-    if reference_rank == 0 or candidate_rank == 0:
-        raise ShapeValidationError("compare_generator_spans requires both generator families to have nonzero rank.")
-
-    comparison_rank = min(reference_rank, candidate_rank)
-    singular_values = np.linalg.svd(reference_basis @ candidate_basis.T, compute_uv=False)
-    principal_angles = np.arccos(np.clip(singular_values[:comparison_rank], -1.0, 1.0))
-
-    reference_to_candidate = _projection_residual(reference_basis, candidate_basis)
-    candidate_to_reference = _projection_residual(candidate_basis, reference_basis)
-
-    return {
+    reference_row_count = int(reference.coefficients.shape[0])
+    candidate_row_count = int(candidate.coefficients.shape[0])
+    reference_rank_status = _rank_status(reference_rank, reference_row_count)
+    candidate_rank_status = _rank_status(candidate_rank, candidate_row_count)
+    base_report: dict[str, object] = {
         "inner_product": inner_product,
         "evaluation_mode": "exact_polynomial",
         "domain": {
@@ -159,6 +166,51 @@ def compare_generator_spans(
         "component_weights": component_weights,
         "reference_rank": reference_rank,
         "candidate_rank": candidate_rank,
+        "reference_rank_status": reference_rank_status,
+        "candidate_rank_status": candidate_rank_status,
+    }
+
+    if reference_rank == 0 or candidate_rank == 0:
+        return {
+            **base_report,
+            "comparison_status": "failed",
+            "status_reason": "effective span rank is zero for at least one family.",
+            "comparison_rank": 0,
+            "principal_angles_radians": [],
+            "projection_residual": {
+                "summary": None,
+                "reference_to_candidate": None,
+                "candidate_to_reference": None,
+            },
+            "conditioning": {
+                "ambient_metric": _json_finite_or_none(ambient_condition_number),
+                "reference_span": _json_finite_or_none(reference_condition),
+                "candidate_span": _json_finite_or_none(candidate_condition),
+            },
+        }
+
+    comparison_status = (
+        "passed"
+        if reference_rank_status == "full_rank" and candidate_rank_status == "full_rank"
+        else "warning"
+    )
+    status_reason = (
+        None
+        if comparison_status == "passed"
+        else "one or both families are rank-deficient under the runtime metric policy."
+    )
+
+    comparison_rank = min(reference_rank, candidate_rank)
+    singular_values = np.linalg.svd(reference_basis @ candidate_basis.T, compute_uv=False)
+    principal_angles = np.arccos(np.clip(singular_values[:comparison_rank], -1.0, 1.0))
+
+    reference_to_candidate = _projection_residual(reference_basis, candidate_basis)
+    candidate_to_reference = _projection_residual(candidate_basis, reference_basis)
+
+    return {
+        **base_report,
+        "comparison_status": comparison_status,
+        "status_reason": status_reason,
         "comparison_rank": comparison_rank,
         "principal_angles_radians": principal_angles.tolist(),
         "projection_residual": {
@@ -167,9 +219,9 @@ def compare_generator_spans(
             "candidate_to_reference": candidate_to_reference,
         },
         "conditioning": {
-            "ambient_metric": ambient_condition_number,
-            "reference_span": reference_condition,
-            "candidate_span": candidate_condition,
+            "ambient_metric": _json_finite_or_none(ambient_condition_number),
+            "reference_span": _json_finite_or_none(reference_condition),
+            "candidate_span": _json_finite_or_none(candidate_condition),
         },
     }
 

--- a/tests/_helpers/multi_generator_diagnostics.py
+++ b/tests/_helpers/multi_generator_diagnostics.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from pdelie import GeneratorFamily
+from pdelie.symmetry import compare_generator_spans
+
+
+_FIT_PROBE_SEEDS = (2701, 2702, 2703)
+
+
+def _x_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0]},
+            {"label": "x", "powers": [1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "x"],
+        "layout": "component_major",
+    }
+
+
+def _family(coefficients: np.ndarray, *, name: str) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="internal_multi_generator_fit_probe",
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=_x_basis_spec(),
+        normalization="runtime_fixture",
+        generator_names=[f"{name}_{index}" for index in range(int(coefficients.shape[0]))],
+        diagnostics={"visibility": "internal_test_only"},
+    )
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def run_internal_multi_generator_fit_probe() -> dict[str, object]:
+    """Return deterministic, internal-only span-recoverability diagnostics.
+
+    The probe uses a frozen linear design surrogate whose row space is the
+    target two-generator affine span. It is deliberately test-only and does
+    not define a public fitting algorithm.
+    """
+
+    reference = _family(np.eye(2, dtype=float), name="reference_affine_x")
+    cases: list[dict[str, object]] = []
+    for seed in _FIT_PROBE_SEEDS:
+        rng = np.random.default_rng(seed)
+        mixing = rng.normal(size=(5, 2))
+        design_matrix = mixing @ np.asarray(reference.coefficients, dtype=float)
+        _, singular_values, vh = np.linalg.svd(design_matrix, full_matrices=False)
+        candidate = _family(vh[:2], name=f"probe_seed_{seed}")
+        span_report = compare_generator_spans(reference, candidate)
+        passed = (
+            span_report["comparison_status"] == "passed"
+            and float(span_report["projection_residual"]["summary"]) <= 1e-12
+        )
+        cases.append(
+            {
+                "seed": seed,
+                "design_shape": list(design_matrix.shape),
+                "singular_values": singular_values.tolist(),
+                "span_report": span_report,
+                "passed": bool(passed),
+            }
+        )
+
+    passed = all(bool(case["passed"]) for case in cases)
+    return _json_safe(
+        {
+            "summary_schema_version": "0.1",
+            "summary_type": "multi_generator_fit_probe",
+            "visibility": "internal_test_only",
+            "label": "fit_probe_diagnostic_only",
+            "passed": passed,
+            "future_promotion_candidate": False,
+            "public_api_promoted": False,
+            "probe_policy": {
+                "no_public_import_path": True,
+                "no_runtime_example": True,
+                "no_best_of_sweep_promotion": True,
+            },
+            "cases": cases,
+        }
+    )

--- a/tests/test_api_stability_audit.py
+++ b/tests/test_api_stability_audit.py
@@ -44,6 +44,7 @@ _ROOT_RUNTIME_NAMES = {
     "run_heat_vertical_slice_example",
     "run_advection_diffusion_vertical_slice_example",
     "run_kdv_scope_decision_example",
+    "run_multi_generator_diagnostics_example",
     "run_formula_generator_validation_example",
     "run_generator_confidence_report_example",
     "run_downstream_discovery_contracts_example",
@@ -125,6 +126,13 @@ _DEFERRED_OR_PRIVATE_NAMES = {
     "summarize_orbit_coverage",
     "summarize_orbit_coverage_feasibility",
     "train_test_translation_orbit_split",
+    "fit_multi_generator_family",
+    "fit_generator_family_span",
+    "MultiGeneratorInvariantChart",
+    "build_multi_generator_orbit",
+    "compose_bch",
+    "integrate_generator_flow",
+    "build_multi_parameter_orbit_chart",
 }
 _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.data.augment_translation_orbit",
@@ -160,6 +168,12 @@ _DEFERRED_API_STABILITY_NAMES = {
     "pdelie.residuals.WeakAdvectionDiffusionResidualEvaluator",
     "pdelie.symmetry.OperatorSymmetry",
     "pdelie.symmetry.CallableGeneratorFamily",
+    "pdelie.symmetry.fit_multi_generator_family",
+    "pdelie.symmetry.fit_generator_family_span",
+    "pdelie.symmetry.MultiGeneratorInvariantChart",
+    "pdelie.symmetry.build_multi_generator_orbit",
+    "pdelie.symmetry.compose_bch",
+    "pdelie.symmetry.integrate_generator_flow",
     "pdelie.symmetry.validate_generator_candidate",
 }
 _V0_10_REPORTING_APIS = {
@@ -257,6 +271,13 @@ _V0_25_KDV_SCOPE_DECISION_APIS = {
     "current_frozen_supported",
     "deferred_no_go",
 }
+_V0_27_MULTI_GENERATOR_DIAGNOSTICS_APIS = {
+    "pdelie.examples.run_multi_generator_diagnostics_example",
+    "summary_type = \"multi_generator_diagnostics_example\"",
+    "family_rank_status = \"rank_deficient\"",
+    "closure_required=True|False",
+    "multi_generator_diagnostics_feasible_fitting_deferred",
+}
 
 
 def _api_stability_text() -> str:
@@ -289,6 +310,7 @@ def test_api_stability_doc_covers_current_stable_runtime_surface() -> None:
         | _V0_23_SPLIT_PROVENANCE_APIS
         | _V0_24_WEAK_SUPPORTABILITY_APIS
         | _V0_25_KDV_SCOPE_DECISION_APIS
+        | _V0_27_MULTI_GENERATOR_DIAGNOSTICS_APIS
     ):
         assert api_name in text
 
@@ -533,12 +555,6 @@ def test_v0_26_planning_docs_record_ks_revisit_decision_and_non_goals() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     api_stability = _api_stability_text()
 
-    assert "**Status:** COMPLETE" in plan
-    assert "KS revisit decision" in plan
-    assert "current_no_go_reference_fallback" in plan
-    assert "v0.26b" in plan
-    assert "- Milestone 6: COMPLETE" in plan
-
     assert "KS Revisit Decision" in scope
     assert "current_no_go_reference_fallback" in scope
     assert "direct_strong_candidate_for_v0_26b_promotion" in scope
@@ -553,3 +569,33 @@ def test_v0_26_planning_docs_record_ks_revisit_decision_and_non_goals() -> None:
     assert "`v0.26` is the completed Kuramoto-Sivashinsky revisit decision release" in roadmap
     assert "`v0.26b` - KS promotion" in roadmap
     assert "Decision-only note for the frozen `v0.26` KS revisit decision" in api_stability
+
+
+def test_v0_27_planning_docs_record_multi_generator_diagnostics_decision_and_non_goals() -> None:
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_27_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    api_stability = _api_stability_text()
+
+    assert "**Status:** COMPLETE" in plan
+    assert "multi-generator diagnostics decision" in plan
+    assert "multi_generator_diagnostics_feasible_fitting_deferred" in plan
+    assert "no public multi-generator fitting API" in plan
+    assert "- Milestone 6: COMPLETE" in plan
+
+    assert "Multi-Generator Diagnostics Decision" in scope
+    assert "bracket convention" in scope
+    assert "family_rank_status" in scope
+    assert "rank_deficient" in scope
+    assert "closure_required=True|False" in scope
+    assert "no BCH composition" in scope
+    assert "no exponential-map finite-flow integration" in scope
+    assert "- Milestone 4: COMPLETE" in scope
+    assert "- Milestone 5: COMPLETE" in scope
+    assert "- Milestone 6: COMPLETE" in scope
+
+    assert "`v0.27` - Multi-generator diagnostics decision" in roadmap
+    assert "no public multi-generator fitting" in roadmap
+    assert "Runtime public API and behavior updates for the frozen `v0.27`" in api_stability
+    assert "pdelie.examples.run_multi_generator_diagnostics_example" in api_stability
+    assert "multi_generator_diagnostics_feasible_fitting_deferred" in api_stability

--- a/tests/test_closure_runtime.py
+++ b/tests/test_closure_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from pdelie import GeneratorFamily, ScopeValidationError, ShapeValidationError, VerificationReport
+from pdelie import GeneratorFamily, ScopeValidationError, VerificationReport
 from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.symmetry import diagnose_generator_family_closure
 
@@ -125,11 +125,16 @@ def test_diagnose_generator_family_closure_reports_expected_affine_structure_con
         np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
         basis_spec=_x_basis_spec(),
     )
+    expected = np.zeros((2, 2, 2), dtype=float)
+    expected[0, 1, 0] = 1.0
+    expected[1, 0, 0] = -1.0
 
-    report = diagnose_generator_family_closure(generator)
+    report = diagnose_generator_family_closure(generator, expected_structure_constants=expected)
     tensor = np.asarray(report["structure_constants"]["tensor"], dtype=float)
 
     assert report["closure"]["summary"] == pytest.approx(0.0, abs=1e-12)
+    assert report["structure_constants"]["structure_constant_error"] == pytest.approx(0.0, abs=1e-12)
+    np.testing.assert_allclose(report["structure_constants"]["expected_structure_constants"], expected, atol=1e-12)
     np.testing.assert_allclose(tensor[0, 1], [1.0, 0.0], atol=1e-12)
     np.testing.assert_allclose(tensor[1, 0], [-1.0, 0.0], atol=1e-12)
     np.testing.assert_allclose(tensor[0, 0], [0.0, 0.0], atol=1e-12)
@@ -288,14 +293,22 @@ def test_diagnose_generator_family_closure_uses_family_aware_interpretation_labe
     assert report["verification_classifications"] == expected_classifications
 
 
-def test_diagnose_generator_family_closure_rejects_rank_deficient_family_with_degeneracy_message() -> None:
+def test_diagnose_generator_family_closure_reports_rank_deficient_family_without_exception() -> None:
     generator = _make_generator(
         np.array([[1.0, 0.0], [2.0, 0.0]], dtype=float),
         basis_spec=_x_basis_spec(),
     )
 
-    with pytest.raises(ShapeValidationError, match="rank-deficient family"):
-        diagnose_generator_family_closure(generator)
+    report = diagnose_generator_family_closure(generator)
+
+    assert report["family_rank"] == 1
+    assert report["family_rank_status"] == "rank_deficient"
+    assert report["structure_constants"]["status"] == "unavailable"
+    assert report["structure_constants"]["tensor"] is None
+    assert report["structure_constants"]["structure_constant_error"] is None
+    assert report["closure"]["status"] == "unavailable"
+    assert report["closure"]["summary"] is None
+    assert report["jacobi"]["mode"] == "unavailable_rank_deficient"
 
 
 def test_diagnose_generator_family_closure_returns_required_core_report_schema() -> None:
@@ -309,19 +322,32 @@ def test_diagnose_generator_family_closure_returns_required_core_report_schema()
     assert set(report) == {
         "interpretation_label",
         "verification_classifications",
+        "bracket_convention",
+        "basis_order",
         "inner_product",
         "computation_mode",
         "domain",
         "component_weights",
         "component_targets",
         "family_rank",
+        "family_rank_status",
         "structure_constants",
         "closure",
         "antisymmetry",
         "jacobi",
         "conditioning",
     }
-    assert set(report["structure_constants"]) == {"tensor", "estimation_mode", "conditioning"}
-    assert set(report["closure"]) == {"summary", "pairwise_residuals"}
-    assert set(report["antisymmetry"]) == {"summary", "pairwise_residuals"}
-    assert set(report["jacobi"]) == {"summary", "triple_residuals", "mode"}
+    assert set(report["structure_constants"]) == {
+        "tensor",
+        "estimation_mode",
+        "conditioning",
+        "status",
+        "expected_structure_constants",
+        "structure_constant_error",
+    }
+    assert set(report["closure"]) == {"summary", "pairwise_residuals", "status"}
+    assert set(report["antisymmetry"]) == {"summary", "pairwise_residuals", "status"}
+    assert set(report["jacobi"]) == {"summary", "triple_residuals", "mode", "status"}
+    assert report["bracket_convention"] == "[X_i, X_j] = X_i · ∇X_j - X_j · ∇X_i"
+    assert report["basis_order"] == ["row_0", "row_1"]
+    assert report["family_rank_status"] == "full_rank"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,7 @@ from pdelie.examples import (
     run_invariant_workflow_summary_example,
     run_kdv_scope_decision_example,
     run_kdv_vertical_slice_example,
+    run_multi_generator_diagnostics_example,
     run_orbit_coverage_diagnostics_example,
     run_reaction_diffusion_vertical_slice_example,
     run_split_leakage_provenance_example,
@@ -189,6 +190,38 @@ def test_kdv_scope_decision_module_prints_json_only() -> None:
     assert parsed["summary_type"] == "kdv_scope_decision_example"
     assert parsed["decision"]["conclusion"] == "keep_public_kdv_surface_frozen"
     assert parsed["current_frozen_path"]["confidence"]["confidence_label"] == "strong"
+
+
+def test_multi_generator_diagnostics_example_runs_end_to_end() -> None:
+    result = run_multi_generator_diagnostics_example()
+
+    assert json.loads(json.dumps(result, allow_nan=False)) == result
+    assert result["summary_schema_version"] == "0.1"
+    assert result["summary_type"] == "multi_generator_diagnostics_example"
+    assert result["decision"]["conclusion"] == "multi_generator_diagnostics_feasible_fitting_deferred"
+    assert result["decision"]["public_promotion_decision"] == "no_public_multi_generator_fitting_or_invariant_action"
+    assert result["algebraic_diagnostics"]["closed_affine_x"]["family_rank_status"] == "full_rank"
+    assert result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"] == 0.0
+    assert result["algebraic_diagnostics"]["nonclosed_polynomial"]["closure"]["summary"] > 0.0
+    assert result["algebraic_diagnostics"]["rank_deficient_affine"]["family_rank_status"] == "rank_deficient"
+    assert (
+        result["algebraic_diagnostics"]["rank_deficient_span_comparison"]["comparison_status"]
+        == "warning"
+    )
+    assert result["pde_context_diagnostics"]["closed_affine_x"]["conclusion"] == "partially_validated"
+    assert result["pde_context_diagnostics"]["nonclosed_required"]["conclusion"] == "failed"
+    assert result["pde_context_diagnostics"]["nonclosed_optional"]["conclusion"] == "partially_validated"
+    assert result["fit_probe_diagnostics"]["label"] == "fit_probe_diagnostic_only"
+    assert result["confidence"]["confidence_label"] == "qualified"
+    assert result["extra_metrics"]["closure_does_not_imply_pde_symmetry"] is True
+    assert not hasattr(pdelie, "run_multi_generator_diagnostics_example")
+
+
+def test_multi_generator_diagnostics_module_prints_json_only() -> None:
+    parsed = _run_module_json("pdelie.examples.multi_generator_diagnostics")
+
+    assert parsed["summary_type"] == "multi_generator_diagnostics_example"
+    assert parsed["fit_probe_diagnostics"]["runtime_example_runs_fit_probe"] is False
 
 
 def test_reaction_diffusion_vertical_slice_example_runs_end_to_end_and_is_json_serializable() -> None:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -201,7 +201,10 @@ def test_multi_generator_diagnostics_example_runs_end_to_end() -> None:
     assert result["decision"]["conclusion"] == "multi_generator_diagnostics_feasible_fitting_deferred"
     assert result["decision"]["public_promotion_decision"] == "no_public_multi_generator_fitting_or_invariant_action"
     assert result["algebraic_diagnostics"]["closed_affine_x"]["family_rank_status"] == "full_rank"
-    assert result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"] == 0.0
+    assert (
+        result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"]
+        <= 1e-12
+    )
     assert result["algebraic_diagnostics"]["nonclosed_polynomial"]["closure"]["summary"] > 0.0
     assert result["algebraic_diagnostics"]["rank_deficient_affine"]["family_rank_status"] == "rank_deficient"
     assert (

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -234,6 +234,7 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "run_downstream_discovery_contracts_example")
     assert not hasattr(pdelie, "run_kdv_scope_decision_example")
     assert not hasattr(pdelie, "run_kdv_vertical_slice_example")
+    assert not hasattr(pdelie, "run_multi_generator_diagnostics_example")
     assert not hasattr(pdelie, "run_orbit_coverage_diagnostics_example")
     assert not hasattr(pdelie, "run_reaction_diffusion_vertical_slice_example")
     assert not hasattr(pdelie, "run_split_leakage_provenance_example")
@@ -256,6 +257,12 @@ def test_root_package_does_not_export_runtime_invariant_applier() -> None:
     assert not hasattr(pdelie, "plot_verification_curve")
     assert not hasattr(pdelie, "plot_span_diagnostics")
     assert not hasattr(pdelie, "plot_closure_diagnostics")
+    assert not hasattr(pdelie, "fit_multi_generator_family")
+    assert not hasattr(pdelie, "fit_generator_family_span")
+    assert not hasattr(pdelie, "MultiGeneratorInvariantChart")
+    assert not hasattr(pdelie, "build_multi_generator_orbit")
+    assert not hasattr(pdelie, "compose_bch")
+    assert not hasattr(pdelie, "integrate_generator_flow")
 
 
 def test_invariants_package_runtime_api_matches_frozen_milestone_surface() -> None:
@@ -365,6 +372,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(examples_module, "run_generator_confidence_report_example")
     assert hasattr(examples_module, "run_invariant_workflow_summary_example")
     assert hasattr(examples_module, "run_kdv_vertical_slice_example")
+    assert hasattr(examples_module, "run_multi_generator_diagnostics_example")
     assert hasattr(examples_module, "run_orbit_coverage_diagnostics_example")
     assert hasattr(examples_module, "run_reaction_diffusion_vertical_slice_example")
     assert hasattr(examples_module, "run_split_leakage_provenance_example")
@@ -372,6 +380,7 @@ def test_examples_package_runtime_api_matches_current_frozen_surface() -> None:
     assert hasattr(examples_module, "run_translation_orbit_batch_example")
     assert hasattr(examples_module, "run_weak_form_supportability_example")
     assert not hasattr(examples_module, "run_ks_vertical_slice_example")
+    assert not hasattr(examples_module, "run_multi_generator_feasibility_example")
     assert not hasattr(examples_module, "run_orbit_coverage_feasibility")
 
 
@@ -410,6 +419,12 @@ def test_symmetry_package_runtime_api_matches_frozen_m4_surface() -> None:
     assert not hasattr(symmetry_module, "CallableGeneratorFamily")
     assert not hasattr(symmetry_module, "OperatorSymmetry")
     assert not hasattr(symmetry_module, "build_translation_orbit_views")
+    assert not hasattr(symmetry_module, "fit_multi_generator_family")
+    assert not hasattr(symmetry_module, "fit_generator_family_span")
+    assert not hasattr(symmetry_module, "MultiGeneratorInvariantChart")
+    assert not hasattr(symmetry_module, "build_multi_generator_orbit")
+    assert not hasattr(symmetry_module, "compose_bch")
+    assert not hasattr(symmetry_module, "integrate_generator_flow")
 
 
 def test_viz_package_runtime_api_matches_frozen_m5_surface() -> None:

--- a/tests/test_span_runtime.py
+++ b/tests/test_span_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from pdelie import GeneratorFamily, SchemaValidationError, ShapeValidationError
+from pdelie import GeneratorFamily, SchemaValidationError
 from pdelie.contracts import _translation_generator_basis_spec
 from pdelie.symmetry import compare_generator_spans
 
@@ -153,6 +153,35 @@ def test_compare_generator_spans_reports_directional_residual_for_strict_contain
     )
 
 
+def test_compare_generator_spans_warns_for_rank_deficient_but_nonzero_family() -> None:
+    reference = _make_generator(
+        np.array([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec={
+            "variables": ["x"],
+            "component_names": ["xi"],
+            "basis_terms": [
+                {"label": "1", "powers": [0]},
+                {"label": "x", "powers": [1]},
+            ],
+            "component_ordering": ["xi"],
+            "term_ordering": ["1", "x"],
+            "layout": "component_major",
+        },
+    )
+    candidate = _make_generator(
+        np.array([[1.0, 0.0], [2.0, 0.0]], dtype=float),
+        basis_spec=reference.basis_spec,
+    )
+
+    report = compare_generator_spans(reference, candidate)
+
+    assert report["comparison_status"] == "warning"
+    assert report["reference_rank_status"] == "full_rank"
+    assert report["candidate_rank_status"] == "rank_deficient"
+    assert report["candidate_rank"] == 1
+    assert report["status_reason"] == "one or both families are rank-deficient under the runtime metric policy."
+
+
 def test_compare_generator_spans_accepts_structurally_equivalent_basis_specs() -> None:
     reordered_basis_spec = {
         "layout": "component_major",
@@ -213,7 +242,7 @@ def test_compare_generator_spans_rejects_non_equivalent_basis_semantics() -> Non
         compare_generator_spans(reference, candidate)
 
 
-def test_compare_generator_spans_rejects_zero_rank_spans() -> None:
+def test_compare_generator_spans_reports_zero_rank_spans_without_exception() -> None:
     reference = _make_generator(
         np.zeros((1, 4), dtype=float),
         basis_spec=_translation_generator_basis_spec(),
@@ -225,8 +254,14 @@ def test_compare_generator_spans_rejects_zero_rank_spans() -> None:
         parameterization="polynomial_translation_affine",
     )
 
-    with pytest.raises(ShapeValidationError, match="nonzero rank"):
-        compare_generator_spans(reference, candidate)
+    report = compare_generator_spans(reference, candidate)
+
+    assert report["comparison_status"] == "failed"
+    assert report["reference_rank_status"] == "zero_rank"
+    assert report["candidate_rank_status"] == "full_rank"
+    assert report["comparison_rank"] == 0
+    assert report["principal_angles_radians"] == []
+    assert report["projection_residual"]["summary"] is None
 
 
 def test_compare_generator_spans_returns_required_core_report_schema() -> None:
@@ -250,6 +285,10 @@ def test_compare_generator_spans_returns_required_core_report_schema() -> None:
         "component_weights",
         "reference_rank",
         "candidate_rank",
+        "reference_rank_status",
+        "candidate_rank_status",
+        "comparison_status",
+        "status_reason",
         "comparison_rank",
         "principal_angles_radians",
         "projection_residual",

--- a/tests/test_symmetry_candidate_validation.py
+++ b/tests/test_symmetry_candidate_validation.py
@@ -93,6 +93,36 @@ def _closed_two_generator_family() -> GeneratorFamily:
     )
 
 
+def _nonclosed_two_generator_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="algebraic_fixture",
+        coefficients=np.asarray([[1.0, 0.0], [0.0, 1.0]], dtype=float),
+        basis_spec={
+            "variables": ["x"],
+            "component_names": ["xi"],
+            "basis_terms": [
+                {"label": "1", "powers": [0]},
+                {"label": "x^2", "powers": [2]},
+            ],
+            "component_ordering": ["xi"],
+            "term_ordering": ["1", "x^2"],
+            "layout": "component_major",
+        },
+        normalization="runtime_fixture",
+        diagnostics={},
+    )
+
+
+def _rank_deficient_two_generator_family() -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="algebraic_fixture",
+        coefficients=np.asarray([[1.0, 0.0], [2.0, 0.0]], dtype=float),
+        basis_spec=_x_basis_spec(),
+        normalization="runtime_fixture",
+        diagnostics={},
+    )
+
+
 def _assert_json_plain(value: object) -> None:
     assert not isinstance(value, (np.ndarray, np.generic))
     if isinstance(value, dict):
@@ -199,10 +229,50 @@ def test_validate_symmetry_candidate_runs_closure_for_multi_generator_family_onl
     )
 
     assert report["candidate_kind"] == "generator_family"
-    assert report["conclusion"] == "validated"
+    assert report["conclusion"] == "partially_validated"
     assert "closure_diagnostics" in report["check_reports"]
     assert report["check_reports"]["closure_diagnostics"]["status"] == "passed"
+    assert report["check_reports"]["pde_context_diagnostics"]["label"] == "algebraic_only"
     assert "finite_transform_verification" not in report["check_reports"]
+
+
+def test_validate_symmetry_candidate_closure_required_controls_nonclosed_family_status() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1613)
+
+    required = validate_symmetry_candidate(
+        field,
+        _nonclosed_two_generator_family(),
+        residual_evaluator=HeatResidualEvaluator(),
+    )
+    optional = validate_symmetry_candidate(
+        field,
+        _nonclosed_two_generator_family(),
+        residual_evaluator=HeatResidualEvaluator(),
+        closure_required=False,
+    )
+
+    assert required["conclusion"] == "failed"
+    assert required["check_reports"]["closure_diagnostics"]["status"] == "failed"
+    assert required["check_reports"]["closure_diagnostics"]["required"] is True
+    assert optional["conclusion"] == "partially_validated"
+    assert optional["check_reports"]["closure_diagnostics"]["status"] == "warning"
+    assert optional["check_reports"]["closure_diagnostics"]["required"] is False
+
+
+def test_validate_symmetry_candidate_reports_rank_deficient_family_as_diagnostic_failure() -> None:
+    field = generate_heat_1d_field_batch(batch_size=3, num_times=9, num_points=32, seed=1614)
+
+    report = validate_symmetry_candidate(
+        field,
+        _rank_deficient_two_generator_family(),
+        residual_evaluator=HeatResidualEvaluator(),
+    )
+
+    assert report["conclusion"] == "failed"
+    closure = report["check_reports"]["closure_diagnostics"]
+    assert closure["status"] == "failed"
+    assert closure["report"]["family_rank_status"] == "rank_deficient"
+    assert closure["report"]["structure_constants"]["status"] == "unavailable"
 
 
 def test_validate_symmetry_candidate_accepts_invariant_map_spec_object_and_payload() -> None:

--- a/tests/test_v0_10_release_gate.py
+++ b/tests/test_v0_10_release_gate.py
@@ -95,8 +95,8 @@ def test_v0_10_release_gate_ci_uses_single_current_release_gate_job() -> None:
     workflow = _repo_text(".github/workflows/ci.yml")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "run: python -m pytest\n" in workflow
     for historical_job in range(4, 21):
         assert f"v0_{historical_job}-release-gate:" not in workflow

--- a/tests/test_v0_11_release_gate.py
+++ b/tests/test_v0_11_release_gate.py
@@ -80,14 +80,14 @@ def test_v0_11_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     publishing = _repo_text("docs/releases/PUBLISHING.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
 
     assert "## 0.11.0" in changelog
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "stable KS runtime" in readme
     assert "package version: `0.11.0`" in readiness
     assert "git tag: `v0.11.0`" in readiness
     assert "no-go/defer" in readiness
     assert "Do not run TestPyPI or PyPI publishing for `v0.11`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "including `v0.27.0`" in publishing

--- a/tests/test_v0_12_release_gate.py
+++ b/tests/test_v0_12_release_gate.py
@@ -67,14 +67,14 @@ def test_v0_12_release_gate_current_ci_visibility_tracks_latest_release() -> Non
     plan = _repo_text("docs/planning/PLAN.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_12-release-gate" not in workflow
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "summarize_generator_fit_diagnostics" in readme
-    assert "including `v0.26.0`" in publishing
-    assert "V0.26 is complete" in plan
+    assert "including `v0.27.0`" in publishing
+    assert "V0.27 is complete" in plan
 
 
 def test_v0_12_release_gate_fit_diagnostic_helper_is_documented_and_submodule_only() -> None:

--- a/tests/test_v0_13_release_gate.py
+++ b/tests/test_v0_13_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,20 +30,20 @@ def test_v0_13_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.13.0" in changelog
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "compute_periodic_window_coverage" in readme
     assert "diagnose_uniform_translation_consistency" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
-    assert "V0.26 is complete" in plan
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
+    assert "V0.27 is complete" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.13` - Public orbit and coverage diagnostics" in roadmap
     assert "**Status:** Completed" in roadmap

--- a/tests/test_v0_14_release_gate.py
+++ b/tests/test_v0_14_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_14_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_13-release-gate" not in workflow
 
     assert "## 0.14.0" in changelog
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "summarize_invariant_workflow" in readme
     assert "summarize_uniform_translation_orbit" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.14` - Invariant workflow summaries and read-only orbit reports" in roadmap

--- a/tests/test_v0_15_release_gate.py
+++ b/tests/test_v0_15_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,19 +31,19 @@ def test_v0_15_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_14-release-gate" not in workflow
 
     assert "## 0.15.0" in changelog
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "build_uniform_translation_orbit_batch" in readme
     assert "OrbitBatchResult" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.15` - Materialized uniform translation orbit batches" in roadmap

--- a/tests/test_v0_16_release_gate.py
+++ b/tests/test_v0_16_release_gate.py
@@ -45,7 +45,7 @@ def _translation_spec(generator: GeneratorFamily) -> InvariantMapSpec:
 def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -54,18 +54,18 @@ def test_v0_16_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
     assert "## 0.16.0" in changelog
-    assert "V0.26" in readme
+    assert "V0.27" in readme
     assert "validate_symmetry_candidate" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.16` - External symmetry-candidate validation" in roadmap

--- a/tests/test_v0_17_release_gate.py
+++ b/tests/test_v0_17_release_gate.py
@@ -58,7 +58,7 @@ def _formula_translation(*, finite_transform: bool = False) -> FormulaGeneratorF
 def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -67,18 +67,18 @@ def test_v0_17_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_16-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "FormulaGeneratorFamily" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap

--- a/tests/test_v0_18_release_gate.py
+++ b/tests/test_v0_18_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,18 +31,18 @@ def test_v0_18_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_17-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "reaction_diffusion_fisher_kpp" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.18` - Stable Fisher-KPP reaction-diffusion strong path" in roadmap

--- a/tests/test_v0_19_release_gate.py
+++ b/tests/test_v0_19_release_gate.py
@@ -22,7 +22,7 @@ def _repo_text(path: str) -> str:
 def test_v0_19_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -31,18 +31,18 @@ def test_v0_19_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_18-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "advection_diffusion_constant_coefficient" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.19` - Stable advection-diffusion strong path" in roadmap

--- a/tests/test_v0_20_release_gate.py
+++ b/tests/test_v0_20_release_gate.py
@@ -23,7 +23,7 @@ def _repo_text(path: str) -> str:
 def test_v0_20_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -32,18 +32,18 @@ def test_v0_20_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_20-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "summarize_generator_confidence" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.21` - External data readiness reports" in roadmap

--- a/tests/test_v0_21_release_gate.py
+++ b/tests/test_v0_21_release_gate.py
@@ -33,7 +33,7 @@ def _heat_metadata(*, equation: str | None = "heat_1d") -> dict[str, object]:
 def test_v0_21_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -42,18 +42,18 @@ def test_v0_21_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_20-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "summarize_field_batch_readiness" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.21` - External data readiness reports" in roadmap

--- a/tests/test_v0_22_release_gate.py
+++ b/tests/test_v0_22_release_gate.py
@@ -40,7 +40,7 @@ def _manual_result() -> dict[str, object]:
 def test_v0_22_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -49,19 +49,19 @@ def test_v0_22_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_21-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "summarize_discovery_bridge_output" in readme
     assert "summarize_downstream_discovery_workflow" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.22` - Downstream discovery contracts" in roadmap

--- a/tests/test_v0_23_release_gate.py
+++ b/tests/test_v0_23_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_23_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,18 +30,18 @@ def test_v0_23_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_22-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "summarize_split_leakage_provenance" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.23` - Split/leakage provenance diagnostics" in roadmap

--- a/tests/test_v0_24_release_gate.py
+++ b/tests/test_v0_24_release_gate.py
@@ -21,7 +21,7 @@ def _repo_text(path: str) -> str:
 def test_v0_24_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -30,18 +30,18 @@ def test_v0_24_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_23-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "summarize_weak_form_supportability" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.24` - Weak-form supportability reset" in roadmap

--- a/tests/test_v0_25_release_gate.py
+++ b/tests/test_v0_25_release_gate.py
@@ -18,7 +18,7 @@ def _repo_text(path: str) -> str:
 def test_v0_25_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -27,18 +27,18 @@ def test_v0_25_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_24-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
     assert "kdv_scope_decision" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.25` - KdV scope decision" in roadmap

--- a/tests/test_v0_26_release_gate.py
+++ b/tests/test_v0_26_release_gate.py
@@ -17,7 +17,7 @@ def _repo_text(path: str) -> str:
 def test_v0_26_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     pyproject = tomllib.loads(_repo_text("pyproject.toml"))
     workflow = _repo_text(".github/workflows/ci.yml")
-    readiness = _repo_text("docs/releases/V0_26_RELEASE_READINESS.md")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
     readme = _repo_text("README.md")
     changelog = _repo_text("CHANGELOG.md")
     publishing = _repo_text("docs/releases/PUBLISHING.md")
@@ -26,18 +26,18 @@ def test_v0_26_release_gate_metadata_docs_and_ci_are_aligned() -> None:
     roadmap = _repo_text("docs/planning/ROADMAP.md")
     release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
 
-    assert pyproject["project"]["version"] == "0.26.0"
-    assert release_gate_jobs == ["v0_26-release-gate"]
-    assert "python -m pytest tests/test_v0_26_release_gate.py" in workflow
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
     assert "v0_25-release-gate" not in workflow
 
-    assert "## 0.26.0" in changelog
-    assert "V0.26" in readme
-    assert "KS revisit decision" in readme
-    assert "package version: `0.26.0`" in readiness
-    assert "git tag: `v0.26.0`" in readiness
-    assert "Do not publish to TestPyPI or PyPI for `v0.26.0`" in readiness
-    assert "including `v0.26.0`" in publishing
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
+    assert "KS remains internal feasibility/no-go evidence" in readme
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
     assert "Milestone 6: COMPLETE" in plan
     assert "Milestone 6: COMPLETE" in scope
     assert "`v0.26` - KS revisit decision" in roadmap

--- a/tests/test_v0_27_release_gate.py
+++ b/tests/test_v0_27_release_gate.py
@@ -79,7 +79,10 @@ def test_v0_27_release_gate_example_records_diagnostic_only_decision() -> None:
     assert result["summary_type"] == "multi_generator_diagnostics_example"
     assert result["decision"]["conclusion"] == "multi_generator_diagnostics_feasible_fitting_deferred"
     assert result["decision"]["public_promotion_decision"] == "no_public_multi_generator_fitting_or_invariant_action"
-    assert result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"] == 0.0
+    assert (
+        result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"]
+        <= 1e-12
+    )
     assert result["algebraic_diagnostics"]["rank_deficient_affine"]["family_rank_status"] == "rank_deficient"
     assert result["pde_context_diagnostics"]["closed_affine_x"]["conclusion"] == "partially_validated"
     assert result["fit_probe_diagnostics"]["label"] == "fit_probe_diagnostic_only"

--- a/tests/test_v0_27_release_gate.py
+++ b/tests/test_v0_27_release_gate.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import numpy as np
+
+import pdelie
+from pdelie import GeneratorFamily
+from pdelie.examples import run_multi_generator_diagnostics_example
+from pdelie.symmetry import compare_generator_spans, diagnose_generator_family_closure
+from tests._helpers.multi_generator_diagnostics import run_internal_multi_generator_fit_probe
+
+
+def _repo_text(path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8")
+
+
+def _x_basis_spec() -> dict[str, object]:
+    return {
+        "variables": ["x"],
+        "component_names": ["xi"],
+        "basis_terms": [
+            {"label": "1", "powers": [0]},
+            {"label": "x", "powers": [1]},
+        ],
+        "component_ordering": ["xi"],
+        "term_ordering": ["1", "x"],
+        "layout": "component_major",
+    }
+
+
+def _family(coefficients: list[list[float]]) -> GeneratorFamily:
+    return GeneratorFamily(
+        parameterization="algebraic_fixture",
+        coefficients=np.asarray(coefficients, dtype=float),
+        basis_spec=_x_basis_spec(),
+        normalization="runtime_fixture",
+        diagnostics={},
+    )
+
+
+def test_v0_27_release_gate_metadata_docs_and_ci_are_aligned() -> None:
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    workflow = _repo_text(".github/workflows/ci.yml")
+    readiness = _repo_text("docs/releases/V0_27_RELEASE_READINESS.md")
+    readme = _repo_text("README.md")
+    changelog = _repo_text("CHANGELOG.md")
+    publishing = _repo_text("docs/releases/PUBLISHING.md")
+    plan = _repo_text("docs/planning/PLAN.md")
+    scope = _repo_text("docs/planning/V0_27_SCOPE.md")
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+
+    assert pyproject["project"]["version"] == "0.27.0"
+    assert release_gate_jobs == ["v0_27-release-gate"]
+    assert "python -m pytest tests/test_v0_27_release_gate.py" in workflow
+    assert "v0_26-release-gate" not in workflow
+
+    assert "## 0.27.0" in changelog
+    assert "V0.27" in readme
+    assert "multi-generator diagnostics decision" in readme
+    assert "package version: `0.27.0`" in readiness
+    assert "git tag: `v0.27.0`" in readiness
+    assert "Do not publish to TestPyPI or PyPI for `v0.27.0`" in readiness
+    assert "including `v0.27.0`" in publishing
+    assert "Milestone 6: COMPLETE" in plan
+    assert "Milestone 6: COMPLETE" in scope
+    assert "`v0.27` - Multi-generator diagnostics decision" in roadmap
+
+
+def test_v0_27_release_gate_example_records_diagnostic_only_decision() -> None:
+    result = run_multi_generator_diagnostics_example()
+
+    assert json.loads(json.dumps(result, allow_nan=False)) == result
+    assert result["summary_type"] == "multi_generator_diagnostics_example"
+    assert result["decision"]["conclusion"] == "multi_generator_diagnostics_feasible_fitting_deferred"
+    assert result["decision"]["public_promotion_decision"] == "no_public_multi_generator_fitting_or_invariant_action"
+    assert result["algebraic_diagnostics"]["closed_affine_x"]["structure_constants"]["structure_constant_error"] == 0.0
+    assert result["algebraic_diagnostics"]["rank_deficient_affine"]["family_rank_status"] == "rank_deficient"
+    assert result["pde_context_diagnostics"]["closed_affine_x"]["conclusion"] == "partially_validated"
+    assert result["fit_probe_diagnostics"]["label"] == "fit_probe_diagnostic_only"
+    assert result["extra_metrics"]["no_bch_composition"] is True
+
+
+def test_v0_27_release_gate_rank_deficient_families_are_diagnostic_not_exceptions() -> None:
+    full = _family([[1.0, 0.0], [0.0, 1.0]])
+    rank_deficient = _family([[1.0, 0.0], [2.0, 0.0]])
+
+    closure = diagnose_generator_family_closure(rank_deficient)
+    span = compare_generator_spans(full, rank_deficient)
+
+    assert closure["family_rank_status"] == "rank_deficient"
+    assert closure["structure_constants"]["status"] == "unavailable"
+    assert span["comparison_status"] == "warning"
+    assert span["candidate_rank_status"] == "rank_deficient"
+
+
+def test_v0_27_release_gate_internal_fit_probe_stays_diagnostic_only() -> None:
+    report = run_internal_multi_generator_fit_probe()
+
+    assert json.loads(json.dumps(report, allow_nan=False)) == report
+    assert report["summary_type"] == "multi_generator_fit_probe"
+    assert report["visibility"] == "internal_test_only"
+    assert report["label"] == "fit_probe_diagnostic_only"
+    assert report["passed"] is True
+    assert report["future_promotion_candidate"] is False
+    assert report["public_api_promoted"] is False
+    assert report["probe_policy"]["no_public_import_path"] is True
+    assert report["probe_policy"]["no_runtime_example"] is True
+    assert report["probe_policy"]["no_best_of_sweep_promotion"] is True
+    for case in report["cases"]:
+        assert case["span_report"]["comparison_status"] == "passed"
+        assert case["span_report"]["projection_residual"]["summary"] <= 1e-12
+
+
+def test_v0_27_release_gate_no_deferred_surface_leaked() -> None:
+    forbidden = {
+        "fit_multi_generator_family",
+        "fit_generator_family_span",
+        "MultiGeneratorInvariantChart",
+        "build_multi_generator_orbit",
+        "compose_bch",
+        "integrate_generator_flow",
+        "build_multi_parameter_orbit_chart",
+        "run_multi_generator_feasibility_example",
+    }
+
+    modules = [
+        importlib.import_module("pdelie.discovery"),
+        importlib.import_module("pdelie.examples"),
+        importlib.import_module("pdelie.invariants"),
+        importlib.import_module("pdelie.reporting"),
+        importlib.import_module("pdelie.symmetry"),
+    ]
+    for name in sorted(forbidden | {"run_multi_generator_diagnostics_example"}):
+        assert not hasattr(pdelie, name), f"pdelie.{name}"
+    for module in modules:
+        for name in sorted(forbidden):
+            assert not hasattr(module, name), f"{module.__name__}.{name}"
+
+    examples_module = importlib.import_module("pdelie.examples")
+    assert hasattr(examples_module, "run_multi_generator_diagnostics_example")


### PR DESCRIPTION
## Summary

This PR implements `v0.27.0` as a **multi-generator diagnostics decision release**.

The release improves support for supplied multi-row `GeneratorFamily` objects while explicitly avoiding public multi-generator fitting, finite group actions, BCH composition, invariant charts, orbit builders, or root exports.

The key outcome is:

```text
multi_generator_diagnostics_feasible_fitting_deferred
```

PDELie can now diagnose supplied multi-generator families more honestly, but public multi-generator PDE fitting and invariant-action machinery remain deferred.

## What Changed

### Multi-Generator Algebraic Diagnostics

- Hardened `diagnose_generator_family_closure(...)` for multi-row families.
- Added explicit reporting for:
  - bracket convention
  - basis order
  - family rank status
  - structure constants
  - expected structure constants
  - structure-constant error
  - closure, antisymmetry, and Jacobi summaries
- Well-formed rank-deficient families now return diagnostic reports instead of raising solely because they are rank-deficient.
- Rank-deficient reports mark closure and structure constants as unavailable/non-unique rather than pretending the algebra is uniquely identified.

### Span Comparison Guardrails

- Updated `compare_generator_spans(...)` so rank-deficient but well-formed families return failed or warning comparison reports.
- Malformed or structurally incompatible inputs still raise typed validation errors.
- Span diagnostics now include rank-status and comparison-status fields.

### Candidate Validation Semantics

- Added `closure_required: bool = True` to `validate_symmetry_candidate(...)`.
- Multi-row `GeneratorFamily` validation now separates algebraic closure evidence from PDE-context evidence.
- If closure fails:
  - `closure_required=True` -> failed validation
  - `closure_required=False` -> warning / partial validation
- Multi-row families with only algebraic evidence conclude at most `partially_validated`; closure alone no longer implies PDE symmetry.

### Diagnostic Example

Added:

```python
pdelie.examples.run_multi_generator_diagnostics_example(...)
```

and command module:

```bash
python -m pdelie.examples.multi_generator_diagnostics
```

The example uses supplied `GeneratorFamily` objects only. It demonstrates:

- closed affine family
- non-closed polynomial family
- rank-deficient family
- span comparison
- closure diagnostics
- candidate validation with `closure_required`
- confidence reporting marked diagnostic-only

It performs no fitting and promotes no new runtime surface.

## Explicit Non-Goals

This PR intentionally does **not** add:

- public multi-generator fitting
- `fit_multi_generator_family`
- invariant charts
- finite multi-generator flow integration
- BCH composition
- multi-parameter orbit charts
- group-action atlases
- operator, neural, callable, or learned-generator APIs
- root `pdelie` exports

Closure diagnostics remain algebraic evidence only. They do not imply PDE residual invariance or valid augmentation workflows.

## Docs and Release Work

- Added `docs/planning/V0_27_SCOPE.md`.
- Added `docs/releases/V0_27_RELEASE_READINESS.md`.
- Updated `PLAN.md`, `ROADMAP.md`, `CHANGELOG.md`, `README.md`, docs index, publishing docs, `SPEC.md`, and `API_STABILITY.md`.
- Bumped package metadata to `0.27.0`.
- Updated CI release gate to `v0_27-release-gate`.

## Validation

Ran:

```bash
.venv/bin/python -m pytest
.venv/bin/python scripts/check_notebooks.py
.venv/bin/python -m build --sdist --wheel
git diff --check
```

Results:

- Full test suite: `897 passed, 2 skipped`
- Notebook structural check: passed, `9 notebooks`
- Build: passed
- Clean wheel smoke: passed for `pdelie-0.27.0`
- Diff check: passed

`ruff` was not run because it is not installed in the local `.venv`.