### PR TITLE
v0.30a/b/c — scope freeze + BoundaryConditionSpec runtime + FD backend

### DIFF
--- a/configs/planning/v0_30_nonperiodic_readiness_scope.json
+++ b/configs/planning/v0_30_nonperiodic_readiness_scope.json
@@ -1,0 +1,125 @@
+{
+  "summary_schema_version": "0.1",
+  "summary_type": "pdelie_release_scope",
+  "release": "0.30a",
+  "status": "in_progress",
+  "parent_release": "0.30",
+  "decision_label": "nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only",
+  "scope_in": [
+    "scalar 1D nonperiodic readiness design",
+    "low-order finite-difference derivative backend design (u_t, u_x, u_xx only)",
+    "BoundaryConditionSpec structured schema design",
+    "derivative backend dispatch policy design",
+    "residual domain policy design",
+    "cross-cutting hygiene audit",
+    "release-gate consolidation proposal"
+  ],
+  "scope_out": [
+    "PDEBench support claim",
+    "The Well support claim",
+    "file loaders or broad adapter framework",
+    "KdV nonperiodic",
+    "KS nonperiodic",
+    "KS runtime API",
+    "weak nonperiodic",
+    "public weak derivative backend",
+    "high-order nonperiodic finite differences (u_xxx, u_xxxx)",
+    "finite-transform verification for nonperiodic translations",
+    "symmetry-method registry",
+    "root pdelie.discover_symmetries",
+    "external symmetry-method ports",
+    "neural or callable generator APIs",
+    "train/test policy or leakage prevention",
+    "PyPI or TestPyPI publication",
+    "version bump"
+  ],
+  "forbidden_root_attributes": [
+    "discover_symmetries",
+    "from_pdebench",
+    "from_the_well",
+    "from_netcdf",
+    "from_zarr",
+    "compute_finite_difference_derivatives",
+    "compute_derivatives",
+    "SymmetryMethod",
+    "SymmetryCandidate",
+    "SymmetryMethodResult",
+    "register_symmetry_method"
+  ],
+  "forbidden_submodule_attributes": {
+    "pdelie.data": [
+      "from_pdebench",
+      "from_the_well",
+      "from_netcdf",
+      "from_zarr"
+    ],
+    "pdelie.symmetry": [
+      "SymmetryMethod",
+      "SymmetryCandidate",
+      "SymmetryMethodResult",
+      "register_symmetry_method",
+      "get_symmetry_method",
+      "list_symmetry_methods"
+    ]
+  },
+  "required_design_documents": [
+    "docs/planning/V0_30_SCOPE.md",
+    "docs/design/BOUNDARY_CONDITION_SPEC.md",
+    "docs/design/DERIVATIVE_BACKEND_POLICY.md",
+    "docs/design/V0_30_HYGIENE_AUDIT.md"
+  ],
+  "required_phrases_in_scope_doc": [
+    "nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only",
+    "scalar 1D",
+    "u_t, u_x, u_xx",
+    "no KdV nonperiodic",
+    "no KS nonperiodic",
+    "no weak nonperiodic",
+    "no PDEBench support claim",
+    "no The Well support claim",
+    "no symmetry-method registry",
+    "no root `pdelie.discover_symmetries`",
+    "no finite-transform verification for nonperiodic translations",
+    "no high-order nonperiodic finite differences"
+  ],
+  "required_phrases_in_roadmap": [
+    "v0.30a",
+    "Scope freeze + design contracts"
+  ],
+  "required_phrases_in_plan": [
+    "nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only",
+    "V0.30a"
+  ],
+  "required_phrases_in_api_stability": [
+    "Decision-only note for the frozen `v0.30a`"
+  ],
+  "planned_schema_migration": {
+    "field": "FieldBatch.SCHEMA_VERSION",
+    "from_version": "0.1",
+    "to_version": "0.2",
+    "reason": "structured BoundaryConditionSpec",
+    "implements_in_release": "0.30",
+    "backwards_compatible_loader": true
+  },
+  "guard_no_version_bump": "0.29.0",
+  "guard_no_premature_pyproject_sections": [
+    "tool.ruff",
+    "tool.mypy",
+    "tool.coverage",
+    "tool.black",
+    "tool.flake8"
+  ],
+  "guard_no_premature_ci_jobs": [
+    "lint",
+    "typecheck",
+    "coverage",
+    "mypy",
+    "ruff"
+  ],
+  "expected_ci_jobs": [
+    "v0_29-release-gate",
+    "docs-build",
+    "editable-tests",
+    "package-smoke"
+  ]
+}

--- a/docs/design/BOUNDARY_CONDITION_SPEC.md
+++ b/docs/design/BOUNDARY_CONDITION_SPEC.md
@@ -1,0 +1,149 @@
+# BoundaryConditionSpec — Design Document
+
+**Status:** DESIGN-FROZEN in v0.30a; **RUNTIME IMPLEMENTED in v0.30b** (internal helpers and FieldBatch 0.2 migration). Adapters accept structured nonperiodic specs in v0.30b; nonperiodic derivative and residual backends are deferred to v0.30c.
+
+This document defines the structured representation that will replace the current string-only `metadata["boundary_conditions"]["x"]` in canonical `FieldBatch` objects. It is normative for v0.30 proper. The runtime in v0.30a is unchanged.
+
+## Motivation
+
+The current canonical `FieldBatch` carries boundary information as a free-form string under `metadata["boundary_conditions"]["x"]`. The only accepted value across the runtime is `"periodic"`, and this is enforced at every consumer site:
+
+- ingestion: `src/pdelie/data/numpy_adapter.py:120-121` rejects everything ≠ `"periodic"`
+- ingestion: `src/pdelie/data/xarray_adapter.py:114-115` rejects the same
+- derivatives: `src/pdelie/derivatives/spectral_fd.py:32-33` rejects the same
+- residuals: three sites in `src/pdelie/residuals/` enforce periodic-x at runtime — `advection_diffusion_1d.py:51-53`, `reaction_diffusion_1d.py:44-46`, `kdv_1d.py:32`
+- weak residuals: `src/pdelie/residuals/weak_1d.py:106-107` enforces the same
+- symmetry: two sites in `src/pdelie/symmetry/parameterization/polynomial_translation.py:34-35` and `:82-83`
+- verification: `src/pdelie/verification/finite_transform.py:22-23`
+
+Lifting any one of these requires knowing more about the boundary than a string can carry.
+
+### Operational problem
+
+A Dirichlet boundary without the boundary value cannot be used by a one-sided finite-difference stencil to produce a correct derivative at the boundary. A 2nd-order one-sided stencil that must extrapolate the missing boundary point produces O(h) error rather than O(h²). A string label `"dirichlet"` hides three pieces of information:
+
+- the boundary value (e.g. `u(a) = 0`)
+- which side the value applies to (left, right, or both)
+- whether the value is time-dependent
+
+A library that accepts string-only boundary metadata cannot tell whether `"dirichlet"` means "homogeneous Dirichlet" (boundary value zero), "inhomogeneous Dirichlet with the value embedded in `field.values`", or "Dirichlet, value not specified, user error to fit residuals here". Existing FD libraries (DeepXDE, deal.II, FEniCS) all use typed boundary objects for the same reason.
+
+### Why not a wider string set
+
+Widening to `{"periodic", "dirichlet", "neumann", "open"}` has the same problem at a different scale. `"dirichlet"` without a value is still unusable; `"open"` is ambiguous across PDE communities (outflow, absorbing, Sommerfeld, "finite domain unstated"); and time-dependent boundaries have no expression in a string.
+
+## Proposed structured spec
+
+`metadata["boundary_conditions"]["x"]` becomes a structured dict:
+
+```
+{
+    "type": Literal["periodic", "dirichlet", "neumann", "open_unknown"],
+    "left": BoundaryFace | None,
+    "right": BoundaryFace | None,
+    "specified": bool,
+    "time_dependent": bool | None,
+    "notes": str | None,
+}
+```
+
+`BoundaryFace` is:
+
+```
+{
+    "value": float | None,
+    "time_dependent": bool,
+    "source": Literal["user_supplied", "default", "inferred_unspecified"],
+}
+```
+
+### Field semantics
+
+- `type`: the boundary class. The set is closed; new types require a scope freeze.
+- `left`, `right`: per-face data. `None` for the side where the boundary class makes no per-face value meaningful (e.g. `"periodic"` has no faces; both are `None`). Required for `"dirichlet"` and `"neumann"`; either may be `None` for one-sided constraints.
+- `specified`: `True` iff every face that the boundary class requires has `value is not None` AND `source != "inferred_unspecified"`. Periodic is always `specified=True`. `open_unknown` is always `specified=False`.
+- `time_dependent`: top-level convenience flag. `True` iff any face has `time_dependent=True`. `None` for boundary classes where the question doesn't apply (`periodic`, `open_unknown`).
+- `notes`: free-form string for human-readable context; never load-bearing.
+
+### Rename: `"open"` → `"open_unknown"`
+
+In v0.30 the unspecified-finite-domain case is named `"open_unknown"`. The string `"open"` is intentionally not accepted because it carries different meanings in different PDE communities (outflow, absorbing, Sommerfeld, free-boundary). `"open_unknown"` makes the meaning explicit: "finite domain, boundary character unstated/unknown to PDELie; treat as needing user attention."
+
+## Legacy compatibility
+
+v0.30 bumps `FieldBatch.SCHEMA_VERSION` from `"0.1"` to `"0.2"` because the structural change is not a pure widening of accepted values.
+
+`FieldBatch.from_dict` accepts both `"0.1"` and `"0.2"` payloads under a backwards-compatible loader:
+
+- A `"0.2"` payload presents `boundary_conditions["x"]` already in structured form. The loader validates the structure against the spec above.
+- A `"0.1"` payload presents `boundary_conditions["x"]` as a string. The loader normalizes:
+  - `"periodic"` → `{"type": "periodic", "left": None, "right": None, "specified": True, "time_dependent": None, "notes": None}`
+  - `"dirichlet"` → `{"type": "dirichlet", "left": {"value": None, "time_dependent": False, "source": "inferred_unspecified"}, "right": {"value": None, "time_dependent": False, "source": "inferred_unspecified"}, "specified": False, "time_dependent": False, "notes": "normalized from legacy 0.1 string"}`
+  - `"neumann"` → analogous to `"dirichlet"`
+  - `"open"` or `"open_unknown"` → `{"type": "open_unknown", "left": None, "right": None, "specified": False, "time_dependent": None, "notes": "normalized from legacy 0.1 string"}`
+  - any other string → `ScopeValidationError`
+
+In all `"0.1"` normalization cases the loader appends one entry to `preprocess_log`:
+
+```
+{
+    "operation": "schema_0_1_to_0_2_boundary_normalization",
+    "parameters": {
+        "legacy_x_boundary": "<original string>",
+        "normalized_specified": <bool>,
+    },
+}
+```
+
+This preserves provenance; downstream readiness reports can detect the synthetic normalization and warn appropriately.
+
+`"0.1"` payloads whose boundary classes other than `"periodic"` are normalized **always** materialize with `"specified": False`. The library never invents boundary values.
+
+## Readiness signaling
+
+`summarize_field_batch_readiness` (in `src/pdelie/reporting/summaries.py`) gains a new field `"boundary_condition_warnings"`: a list of strings drawn from a frozen vocabulary:
+
+- `"dirichlet_value_unspecified"` — type is `"dirichlet"` but `specified` is False
+- `"neumann_value_unspecified"` — analogous for Neumann
+- `"open_unknown_boundary"` — type is `"open_unknown"`
+- `"boundary_normalized_from_legacy_schema"` — provenance recorded in `preprocess_log`
+- `"boundary_time_dependent"` — any face has `time_dependent=True`; v0.30 derivative backends do not support time-dependent BCs
+
+Any non-empty `boundary_condition_warnings` list downgrades the report's `readiness_label` from `"ready"` to at most `"needs_attention"`. The existing `_READINESS_LABELS = frozenset({"ready", "needs_attention", "not_ready"})` vocabulary is sufficient; no new label.
+
+`"not_ready"` is reserved for hard failures (missing required metadata keys, non-finite values, non-uniform grid). Under-specified boundary conditions are recoverable by the user, so they degrade to `"needs_attention"`, not `"not_ready"`.
+
+## Out of scope for v0.30
+
+The following are deliberately deferred to later releases:
+
+- time-dependent boundary value tables (Dirichlet/Neumann values that vary with `t`)
+- mixed / Robin boundaries (`αu + β u_x = γ`)
+- free-boundary problems (Stefan-type, moving interfaces)
+- vector or tensor boundary conditions (multi-channel data, deferred to v0.34 multi-D/multi-channel scope)
+- 2D and 3D boundary conditions (deferred to v0.34)
+- nonuniform grids (`from_numpy` currently requires uniform; this does not change in v0.30)
+- time-axis boundary conditions (initial / terminal-time conditions)
+
+The scope of v0.30 is intentionally narrow: structured BC metadata, scalar 1D, uniform grids, time-independent boundary values only.
+
+## Validation requirements (for v0.30 proper, not v0.30a)
+
+When `BoundaryConditionSpec` lands:
+
+- `FieldBatch.validate()` must enforce that `metadata["boundary_conditions"]["x"]` matches the structured shape exactly (for `schema_version == "0.2"`)
+- `FieldBatch.from_dict` round-trip: `from_dict(d.to_dict()) == d` for both `"0.1"` and `"0.2"` payloads
+- Strict JSON: `json.dumps(field.to_dict(), allow_nan=False)` succeeds for any valid `FieldBatch`
+- All consumers (residuals, derivatives, weak, symmetry, verification) read `metadata["boundary_conditions"]["x"]["type"]` and not the raw string
+- Adapters (`from_numpy`, `from_xarray`, `from_xarray_dataset`) accept both legacy string inputs (normalized internally) and pre-structured dict inputs
+
+## Implementation pointer (for v0.30 proper)
+
+The most surgical implementation places a new module `src/pdelie/contracts/boundary.py` (or extends `src/pdelie/contracts.py`) with:
+
+- `BoundaryConditionSpec` dataclass and `BoundaryFace` dataclass
+- `normalize_legacy_x_boundary(value: str) -> BoundaryConditionSpec` for the loader path
+- `validate_x_boundary(spec: dict | BoundaryConditionSpec) -> BoundaryConditionSpec` for ingestion
+- `_ALLOWED_X_BOUNDARY_TYPES = frozenset({"periodic", "dirichlet", "neumann", "open_unknown"})` matching the existing `frozenset` discipline (e.g. `_READINESS_LABELS`, `_CONFIDENCE_LABELS` in `summaries.py`)
+
+The existing JSON-strict helpers (`_validate_strict_json_compatible` and `_json_safe` in the reporting layer) handle the serialization of the structured form without modification.

--- a/docs/design/DERIVATIVE_BACKEND_POLICY.md
+++ b/docs/design/DERIVATIVE_BACKEND_POLICY.md
@@ -1,0 +1,183 @@
+# Derivative Backend Policy — Design Document
+
+**Status:** DESIGN-FROZEN in v0.30a; **`finite_difference` v1 IMPLEMENTED in v0.30c** along with the `compute_derivatives(backend="auto")` dispatcher. Boundary-aware readiness warnings and the `residual_domain_policy` reporting field also land in v0.30c. Residual evaluator auto-dispatch is deferred to v0.30d.
+
+This document defines the policies governing PDELie's derivative backends after v0.30. The runtime in v0.30a is unchanged.
+
+## Backends covered
+
+After v0.30, two derivative backends exist:
+
+- `spectral_fd` (existing): FFT-based spectral spatial derivatives + 2nd-order centered finite differences in time. Periodic-x only.
+- `finite_difference` (new in v0.30 proper): centered finite differences with one-sided stencils at boundaries. Nonperiodic-x only.
+
+A third name, `compute_derivatives(..., backend="auto")`, is a dispatcher, not a backend.
+
+## `spectral_fd` policy
+
+**Unchanged from current behavior.**
+
+- Periodic-x is required. The check at `src/pdelie/derivatives/spectral_fd.py:32-33` stays in place.
+- Spatial derivatives are computed via FFT phase factors `(ik)^n`. This is mathematically correct only for periodic data; loosening the check would silently produce garbage at the boundaries due to Gibbs ringing.
+- Output is unchanged: `DerivativeBatch(backend="spectral_fd", ...)`.
+
+After v0.30 the BC check reads `metadata["boundary_conditions"]["x"]["type"] == "periodic"` against the new structured spec, not the legacy string. The semantics are identical for callers.
+
+## `finite_difference` policy (v0.30 proper)
+
+A new module `src/pdelie/derivatives/finite_difference.py` will implement `compute_finite_difference_derivatives(field, *, max_spatial_order=2)`.
+
+### Accepted BCs
+
+- `"dirichlet"`
+- `"neumann"`
+- `"open_unknown"`
+
+Periodic data passed to `finite_difference` raises `ScopeValidationError`. Periodic users must use `spectral_fd`. The dispatcher (below) handles the auto-routing.
+
+### Order limits
+
+The stable v0.30 surface supports:
+
+- `u_t` via `np.gradient(values, dt, axis=t_axis, edge_order=2)` (unchanged from the time-derivative computation in `spectral_fd`)
+- `u_x` via `np.gradient(values, dx, axis=x_axis, edge_order=2)`
+- `u_xx` via `np.gradient(u_x, dx, axis=x_axis, edge_order=2)`
+
+`u_xxx` and `u_xxxx` are **not** part of the stable v0.30 surface on nonperiodic data. Calling `compute_finite_difference_derivatives(field, max_spatial_order=3)` or higher raises `ScopeValidationError` unless an `experimental_high_order=True` flag is set, and even then the output is documented as advisory and may change.
+
+#### Why no high-order FD on nonperiodic data
+
+Repeated `np.gradient` propagates boundary error. The one-sided edge stencil at order 2 has the same asymptotic O(h²) interior accuracy as centered FD, but a larger constant. Each derivative step pulls the boundary error one stencil width into the interior. By `u_xxxx` on N≈64-point grids, the boundary-corrupted region dominates the interior region; the residual statistics become unreliable.
+
+For periodic data the same chain works because FFT-based derivatives have no boundary problem at all. For nonperiodic data the right answer is a higher-order one-sided stencil family (Fornberg-style), or weak/Galerkin integration to bypass derivative estimation entirely. Neither is in scope for v0.30; both are candidates for later releases.
+
+### `DerivativeBatch.config` requirements
+
+The backend must populate:
+
+```
+{
+    "spatial_method": "finite_difference_centered",
+    "temporal_method": "finite_difference",
+    "temporal_edge_order": 2,
+    "spatial_edge_order": 2,
+    "spatial_max_order": <int>,
+    "boundary_handling": "dirichlet" | "neumann" | "open_unknown",
+    "boundary_left_specified": <bool>,
+    "boundary_right_specified": <bool>,
+}
+```
+
+`boundary_left_specified` and `boundary_right_specified` read directly from the structured `BoundaryConditionSpec` faces. They allow downstream consumers (residual evaluators, readiness reports) to flag derivative results that depended on an unspecified boundary.
+
+`DerivativeBatch.boundary_assumptions` records `"<bc_type> in x; finite differences in time"` for human inspection.
+
+## Dispatcher: `compute_derivatives(field, *, backend="auto", max_spatial_order=2)`
+
+A new helper, exported from `pdelie.derivatives`, selects the right backend based on the field's BC.
+
+### Dispatch table
+
+- `field.metadata["boundary_conditions"]["x"]["type"] == "periodic"` → `spectral_fd`
+- `field.metadata["boundary_conditions"]["x"]["type"] in {"dirichlet", "neumann", "open_unknown"}` → `finite_difference`
+
+### Explicit backend selection
+
+- `backend="spectral_fd"` on nonperiodic data → `ScopeValidationError`
+- `backend="finite_difference"` on periodic data → `ScopeValidationError`
+- `backend="auto"` always succeeds for any supported BC type
+
+### Never silent
+
+The dispatcher must record its selection in `DerivativeBatch.config`:
+
+```
+{
+    ...,
+    "backend_selected_by_boundary_condition": True,
+    "backend_selection_reason": "periodic_x_boundary" | "nonperiodic_x_boundary",
+}
+```
+
+This is non-negotiable. A user reading a `DerivativeBatch` from disk must be able to tell which backend produced it without re-deriving the choice from `boundary_conditions`.
+
+### Order capping under dispatch
+
+When `backend="auto"` resolves to `finite_difference`, requesting `max_spatial_order > 2` raises `ScopeValidationError` with the same message as the direct path. The dispatcher does not silently downgrade orders.
+
+## Residual evaluation domain policy
+
+The existing residual evaluators (`HeatResidualEvaluator`, `BurgersResidualEvaluator`, `AdvectionDiffusionResidualEvaluator`, etc.) currently compute residuals over the full grid. On nonperiodic FD-derived data, near-boundary residuals are dominated by one-sided-stencil error and are not representative of interior residual quality.
+
+### New summary field
+
+`summarize_residual_batch` (in `src/pdelie/reporting/summaries.py`) gains a new field `"residual_domain_policy"` with vocabulary:
+
+- `"full_grid"` — RMS / max over all grid points (the historical behavior for periodic data)
+- `"interior_only"` — RMS / max over the interior excluding a boundary band
+- `"drop_boundary_width_k"` — explicit boundary width `k` dropped from both ends
+
+### Default policy
+
+- Periodic data: `"full_grid"`. No boundary problem exists for spectral derivatives, so no need to trim.
+- Nonperiodic FD-derived data: `"interior_only"` with default boundary width `k = 4`. The choice of `k = 4` matches the effective stencil width of `u_xx` computed as `np.gradient(np.gradient(u))`: centered second derivative consumes a 5-point stencil, edge-order-2 handling at each boundary consumes up to 3 extra points of error propagation; `k = 4` provides a safe margin.
+
+### Reporting both
+
+When a residual is computed on nonperiodic data, the summary SHOULD include both `"residual_domain_policy": "interior_only"` (the primary statistic) and a nested `"full_grid_diagnostic"` block with the same metrics computed over the full grid, so users can see the boundary contamination explicitly. This is recommended, not required, in v0.30 proper.
+
+## Translation finite-transform policy on nonperiodic data
+
+`verify_translation_generator` at `src/pdelie/verification/finite_transform.py:64` and `_apply_uniform_translation` at `:21` remain **periodic-only**. The FFT phase-shift method requires periodicity; there is no correct alternative on a finite domain without a domain policy.
+
+### What is explicitly rejected
+
+A `_apply_uniform_translation_open` that uses `np.roll` + extrapolation is **not approved**. `np.roll` does not translate a non-periodic function — it wraps values that have no physical meaning at the wrap point, and any extrapolation scheme (constant, linear, reflective) introduces O(1) artifacts in the residual.
+
+### What is deferred
+
+The correct approach for nonperiodic translation is overlap-crop:
+
+1. Apply translation `ε`: shift the coordinate axis by `ε`.
+2. Crop the field to the overlap interval `[a + |ε|, b − |ε|]` where `[a, b]` is the original domain.
+3. Compute the residual on the cropped interior only.
+
+This requires a domain policy (how to handle multiple overlapping translations, what minimum overlap is acceptable, how to compare orbits of different lengths). The full design is deferred to **v0.31.5 — Nonperiodic Orbit/Action Scope Decision** in the roadmap.
+
+## Numerical sanity tests required for v0.30 proper
+
+These are not implemented in v0.30a (it ships no runtime code). They are specified here so v0.30 proper has a clear acceptance contract.
+
+### Manufactured analytic functions
+
+For each backend × order combination, test against closed-form derivatives of:
+
+- `u(t, x) = sin(k·x − ω·t)` on `[0, 2π]` (periodic check for spectral; reflected to `[0, π]` for FD where periodicity does not apply)
+- `u(t, x) = tanh(α·x − v·t)` on `[−5, 5]` (smooth, non-periodic, Dirichlet boundaries known)
+- `u(t, x) = x³ − 3xt²` on `[−1, 1]` (polynomial, exact closed-form derivatives at all orders)
+
+For each test:
+- Compare `compute_finite_difference_derivatives` outputs against the closed-form `u_t`, `u_x`, `u_xx` evaluated at the grid points.
+- Assert max-absolute error in the interior decreases at rate O(h²) as the grid is refined.
+- Assert max-absolute error in the **boundary band** (first/last `k` points for `k = 4`) is bounded but does **not** assert O(h²) — boundary stencils have a larger error constant.
+
+### What not to test
+
+**Do not test against `np.gradient`.** The new backend is built on `np.gradient` internally; testing it against itself is meaningless. Tests must use closed-form analytic derivatives.
+
+### Convergence study
+
+For at least one manufactured solution, run the backend at `N = 32, 64, 128, 256` and assert the interior-only max error halves to within 10% per grid doubling (the expected O(h²) order). The boundary-band max error must not blow up — a coarse bound like `< 10× interior_max` is sufficient.
+
+## Implementation pointer (for v0.30 proper)
+
+The most surgical path:
+
+1. Add `src/pdelie/derivatives/finite_difference.py` with `compute_finite_difference_derivatives` mirroring the structure of `src/pdelie/derivatives/spectral_fd.py`.
+2. Add `compute_derivatives` to `src/pdelie/derivatives/__init__.py` as a thin dispatcher.
+3. Update `src/pdelie/residuals/heat_1d.py`, `burgers_1d.py`, `advection_diffusion_1d.py`, `reaction_diffusion_1d.py` to call `compute_derivatives(..., backend="auto")` instead of `compute_spectral_fd_derivatives(...)` when no derivatives are supplied. KdV stays periodic-only (its evaluator already requires `equation == "kdv_normalized"`, which only the periodic generator produces).
+4. Update `summarize_residual_batch` to surface `residual_domain_policy`.
+5. Add `compute_finite_difference_derivatives` to `tests/test_public_api.py::test_runtime_package_api_is_importable` and `tests/test_api_stability_audit.py::_ROOT_RUNTIME_NAMES`-style negative checks (it must not be a root export).
+6. Update `docs/specs/API_STABILITY.md` with a "Runtime public API for the frozen `v0.30` Milestone 2 slice" subsection describing `compute_finite_difference_derivatives` and `compute_derivatives`.
+
+The lazy-import pattern at `src/pdelie/discovery/pysindy_adapter.py:12-20` does not apply: `finite_difference` uses only `numpy`, which is already a core dependency.

--- a/docs/design/V0_30_HYGIENE_AUDIT.md
+++ b/docs/design/V0_30_HYGIENE_AUDIT.md
@@ -1,0 +1,173 @@
+# V0.30 Hygiene Audit
+
+**Status:** AUDIT-ONLY in v0.30a. No `pyproject.toml`, `.github/workflows/`, or CI behavior changes here. The audit records the current baseline; staged enforcement lands in v0.30 proper and beyond.
+
+This document audits the current state of cross-cutting code-quality infrastructure (lint, type-checking, coverage, Python matrix, NumPy upper bound, release-gate proliferation, optional-dependency import policy, JSON-strict reporting policy) and proposes staged enforcement.
+
+## Lint status
+
+No `[tool.ruff]`, `[tool.black]`, or `[tool.flake8]` configuration is present in `pyproject.toml`. The current file contains only `[build-system]`, `[project]`, `[project.urls]`, `[project.optional-dependencies]`, `[tool.setuptools]`, `[tool.setuptools.packages.find]`, and `[tool.pytest.ini_options]`.
+
+There is no `.pre-commit-config.yaml` at the repository root.
+
+The project's documented manual lint step is the whitespace check `git diff --check` (referenced in `CONTRIBUTING.md:88` under "Check whitespace"). This is run by hand at PR time.
+
+Codebase shape: a quick scan of `src/pdelie/` shows consistent `from __future__ import annotations` and inline PEP-604 unions (`str | None`). A default ruff configuration with selections `["E", "W", "F", "B", "I", "UP", "RUF", "NPY"]` is plausible without large refactor cost.
+
+## Type-checker status
+
+No `[tool.mypy]`, `[tool.pyright]`, or equivalent configuration in `pyproject.toml`. No `mypy.ini`, `.mypy.ini`, `pyrightconfig.json`, or equivalent at the repository root.
+
+The codebase uses typed parameters and return annotations throughout (e.g. `src/pdelie/derivatives/spectral_fd.py` carries full annotations, `src/pdelie/symmetry/fitting/translation_baseline.py` annotates SVD results). A strict-on-`src/pdelie/contracts.py` and `src/pdelie/derivatives/` configuration is plausible immediately; broader strictness will require some tightening (untyped dictionaries in `diagnostics: dict[str, object]` fields where the values are heterogeneous).
+
+## Coverage status
+
+No `[tool.coverage]` in `pyproject.toml`. No `coverage` or `pytest-cov` in the `test` optional-dependency group (verified in `pyproject.toml` lines 55-62, which lists `build`, `matplotlib`, `pysindy`, `scikit-learn`, `pytest`, `xarray`). CI emits no `coverage.xml` artifact.
+
+The test suite is large — 689 test functions across 106 test files. Coverage measurement is feasible once `pytest-cov` is added; the absolute coverage number on `src/pdelie/` is likely high given the inventory of release-gate, public-API audit, and per-module tests.
+
+## Python version matrix
+
+CI runs only `python-version: "3.11"`, verified across all four jobs in `.github/workflows/ci.yml`:
+
+- `v0_29-release-gate` — Python 3.11
+- `docs-build` — Python 3.11
+- `editable-tests` — Python 3.11
+- `package-smoke` — Python 3.11
+
+`pyproject.toml` declares `requires-python = ">=3.11"`. No upper bound is declared. There is no validation against Python 3.12 or 3.13.
+
+## NumPy upper bound
+
+`pyproject.toml` line 32: `numpy>=1.24,<2`. This excludes the entire NumPy 2.x line.
+
+The scientific Python ecosystem completed the NumPy 2.x migration during 2024. Major downstream consumers (SciPy, scikit-learn, xarray, PyTorch) are all on 2.x-compatible code paths. The `numpy<2` cap is now an adoption blocker rather than a safety measure.
+
+A NumPy 2.x compatibility validation side job is feasible; the codebase uses NumPy in mainstream ways (FFT, gradient, SVD, linspace, basic broadcasting), all of which have stable APIs across the 1.x/2.x boundary. Likely-affected sites are limited to:
+
+- type-hint usage of `np.bool_` / `np.integer` / `np.generic` (compatible across versions)
+- `np.fft` calls (compatible)
+- `np.random.default_rng` (compatible, used as `np.random.default_rng(seed)`)
+
+Estimated 1–2 days to validate and lift the cap, but this work is **not** in scope for v0.30 proper.
+
+## Release-gate proliferation
+
+Counted at v0.30a baseline: **26 per-version release-gate test files** in `tests/`:
+
+- `tests/test_v0_4_release_gate.py` through `tests/test_v0_9_release_gate.py` (6 files)
+- `tests/test_v0_10_release_gate.py` through `tests/test_v0_29_release_gate.py` (20 files)
+
+Releases `v0.1`, `v0.2`, `v0.3` did not produce dedicated release-gate test files; the modern pattern began at `v0.4`.
+
+Each file follows the same structural pattern: read several documents by path, assert specific phrases are present, assert forbidden names are not on `pdelie` or any submodule, validate JSON manifests for strict JSON compatibility. The structure is mechanical; the duplication is significant.
+
+This audit recommends consolidation in v0.30 proper. See "Release-gate consolidation" below.
+
+## Optional-dependency import pattern
+
+The current pattern is correct. Reference implementation at `src/pdelie/discovery/pysindy_adapter.py:12-20`:
+
+```
+def _require_discovery_dependencies():
+    try:
+        pysindy = importlib.import_module("pysindy")
+        importlib.import_module("sklearn")
+    except (ModuleNotFoundError, ImportError, ValueError) as exc:
+        raise ImportError(
+            "PySINDy discovery adapter requires pdelie[downstream] or pdelie[test]."
+        ) from exc
+    return pysindy
+```
+
+Key properties:
+
+- Optional dependencies are imported on first use, not at module load time.
+- The import error is raised with an actionable message naming the optional-extras install target.
+- The function is private (leading underscore) and called only from inside `fit_pysindy_discovery`, never at package-level import.
+
+The viz layer follows the same pattern. `tests/test_public_api.py:462-487` verifies this by mocking out `matplotlib` and confirming that `import pdelie.viz` still succeeds; only at first call to `plot_*` does the `ImportError` surface.
+
+This policy must remain unchanged through v0.30 and beyond. New optional extras (e.g., a future `pdelie[generative]` for LieGAN-style methods) must follow this exact pattern.
+
+## Strict JSON / no-NaN policy
+
+The current policy is correct. Reference helpers exist in the reporting layer:
+
+- `_validate_strict_json_compatible(value, *, name)` is called by `summarize_*` helpers throughout `src/pdelie/reporting/summaries.py` and elsewhere
+- The pattern `json.loads(json.dumps(matrix, allow_nan=False)) == matrix` is the gate (verified in `tests/test_v0_29_release_gate.py:93`)
+- `_json_safe(value)` (in `src/pdelie/verification/__init__.py:28-37`) normalizes numpy arrays and scalars to Python natives before serialization
+
+Any new reporting output landed in v0.30 proper must follow this discipline:
+
+- No `float("nan")` in serialized output. Use `None` or an explicit unavailable-status string.
+- No `numpy.ndarray`, `numpy.generic`, or `pandas` objects in serialized output. Convert to nested Python lists/dicts.
+- No tensor objects, file paths, or model handles in serialized output.
+
+This policy is non-negotiable for new APIs.
+
+## Staged enforcement
+
+No `pyproject.toml` or CI change in v0.30a. The audit recommends:
+
+### Phase 0 — v0.30a (this release)
+
+Audit-only. This document records the baseline. No `pyproject.toml` change, no CI change. The negative tests in `tests/test_v0_30_hygiene_audit.py` confirm that no premature enforcement has landed.
+
+### Phase 1 — v0.30 proper
+
+- Add `[tool.ruff]` with `target-version = "py311"`, selections `["E", "W", "F", "B", "I", "UP", "RUF", "NPY"]`, and the project's whitespace-conscious line length (likely 100 or 120). Add a `lint` CI job that runs `ruff check .` as **warning-only / non-blocking**.
+- Add `[tool.mypy]` with `strict = true` initially scoped to:
+  - `src/pdelie/contracts.py`
+  - `src/pdelie/derivatives/`
+  - `src/pdelie/data/`
+  - `src/pdelie/residuals/`
+  Leave the rest lenient. Add a `typecheck` CI job as **warning-only / non-blocking**.
+- Add `[tool.coverage.run]` with `source = ["src/pdelie"]` and `branch = true`; add `[tool.coverage.report]` with an initial floor `fail_under = 80` (conservative; raise later). Add `pytest-cov` to the `test` optional-dependency group. Coverage job runs but **does not gate merges** initially.
+
+Phase 1 is opt-in by CI: the existing `editable-tests`, `package-smoke`, `docs-build`, and `v0_29-release-gate` (which becomes `v0_30-release-gate`) jobs continue unchanged and remain the merge gates.
+
+### Phase 2 — v0.30.1 or v0.31
+
+- Tighten `[tool.mypy].strict` across all of `src/pdelie/`. Address strictness violations site by site.
+- Promote `lint` and `typecheck` CI jobs to **blocking**.
+
+### Phase 3 — v0.32
+
+- Expand CI matrix to `python-version: ["3.11", "3.12", "3.13"]` for `editable-tests` and `package-smoke`.
+- Add a NumPy 2.x side job: `editable-tests-numpy2x` that installs `numpy>=2,<3` and runs the test suite. Initially warning-only.
+
+### Phase 4 — v1.0
+
+- Lift the `numpy<2` upper bound to `numpy<3` once the 2.x side job has soaked for at least two releases without regressions.
+
+## Release-gate consolidation
+
+Recommendation for v0.30 proper:
+
+Replace the 26 per-version release-gate test files with **one parameterized test** driven by a manifest file at `configs/release_gate_manifest.json`. The manifest lists, per past release:
+
+- the file paths that must exist (`docs/planning/V0_NN_SCOPE.md`, `docs/releases/V0_NN_RELEASE_READINESS.md`)
+- the phrases that must appear in `docs/planning/V0_NN_SCOPE.md`, `docs/planning/ROADMAP.md`, `docs/specs/API_STABILITY.md`, and `docs/planning/PLAN.md` for the *current* release
+- the names that must not appear on `pdelie` or any submodule at the time of that release
+
+The consolidated test reads the manifest and parameterizes its assertions over the listed releases. The existing `tests/test_v0_29_release_gate.py` is the template for the parameterized test body: helpers `_repo_path`, `_repo_text`, `_repo_json`; per-release assertions on file existence, phrase presence, forbidden-name absence, and JSON-strict manifest validation.
+
+The current `tests/test_v0_NN_release_gate.py` files (for `NN ∈ {4..29}`) are removed in the same release that adds the consolidated test. The consolidated test must pass at parity with the removed files before deletion.
+
+This change reduces 26 hand-maintained files to 1 parameterized test + 1 JSON manifest. The maintenance burden becomes editing the manifest, not adding a new test file per release.
+
+**This consolidation is scoped to v0.30 proper, not v0.30a.** v0.30a only specifies the consolidation contract. The `tests/test_v0_30_hygiene_audit.py::test_v0_30_hygiene_audit_documents_release_gate_consolidation_proposal` test verifies this section contains the required text and that the consolidation lands in v0.30 proper, not v0.30a.
+
+## Summary table
+
+| Concern | Current state | v0.30 proper target | Final target |
+| --- | --- | --- | --- |
+| Lint | none | ruff non-blocking | ruff blocking (v0.30.1+) |
+| Type-checker | none | mypy strict on core, non-blocking | mypy strict everywhere, blocking (v0.30.1+) |
+| Coverage | none | pytest-cov non-blocking, floor 80 | gate at 85 (v0.30.1+) |
+| Python matrix | 3.11 only | 3.11 only (no change) | 3.11/3.12/3.13 (v0.32) |
+| numpy upper bound | `<2` | `<2` (no change) | `<3` (v1.0) |
+| Release-gate files | 26 hand-maintained | 1 parameterized + manifest | 1 (stable) |
+| Optional imports | lazy via `importlib.import_module` | unchanged | unchanged |
+| JSON strictness | `allow_nan=False` enforced | unchanged | unchanged |

--- a/docs/design/index.rst
+++ b/docs/design/index.rst
@@ -1,0 +1,13 @@
+Design
+======
+
+In-flight design documents. These freeze the shape of upcoming runtime
+contracts before implementation lands; they are not stable API references.
+Once a design is implemented and validated it is folded into the specs.
+
+.. toctree::
+   :maxdepth: 1
+
+   BOUNDARY_CONDITION_SPEC
+   DERIVATIVE_BACKEND_POLICY
+   V0_30_HYGIENE_AUDIT

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,5 +23,6 @@ and API stability pages when changing runtime behavior or public interfaces.
    workflows/index
    specs/index
    planning/index
+   design/index
    releases/index
    strategy/index

--- a/docs/planning/PLAN.md
+++ b/docs/planning/PLAN.md
@@ -1,3 +1,230 @@
+# PDELie - Execution Plan (V0.30c)
+
+**Status:** IN_PROGRESS
+
+`v0.30c` lands the second runtime step of the v0.30 sequence: the low-order finite-difference derivative backend, the `compute_derivatives(backend="auto")` dispatcher, boundary-aware readiness warnings, and the `residual_domain_policy` field on residual summaries. Residual evaluator auto-dispatch is deferred to v0.30d.
+
+## Release Theme
+
+`v0.30c` implements the v1 `finite_difference` derivative backend (`u_t`, `u_x`, `u_xx` only on nonperiodic 1D scalar uniform grids) and the explicit-and-auditable `compute_derivatives` dispatcher. `spectral_fd` is unchanged. The reporting layer now surfaces boundary-condition warnings and an additive `residual_domain_policy` field. No new optional dependency, no version bump, no root export, no CI workflow change.
+
+Decision label:
+
+```text
+low_order_finite_difference_backend_and_boundary_aware_readiness
+```
+
+## Implemented Surfaces
+
+- `src/pdelie/derivatives/finite_difference.py` (NEW) — `compute_finite_difference_derivatives(field, *, max_spatial_order=2)` for `u_t`, `u_x`, `u_xx` only on Dirichlet, Neumann, or `open_unknown` data. Uses `np.gradient(edge_order=2)` for both axes.
+- `src/pdelie/derivatives/__init__.py` (UPDATED) — exports `compute_finite_difference_derivatives` and a new `compute_derivatives(field, *, backend="auto", max_spatial_order=2)` dispatcher. `backend="auto"` picks `spectral_fd` for periodic data and `finite_difference` for any supported nonperiodic boundary type; the selection is recorded in `DerivativeBatch.config` as `backend_selected_by_boundary_condition=True` plus a non-null `backend_selection_reason`. Explicit `backend="spectral_fd"` on nonperiodic data and explicit `backend="finite_difference"` on periodic data both raise `ScopeValidationError`. The dispatcher never silently falls back from one backend to the other.
+- `src/pdelie/contracts.py` (UPDATED) — `ALLOWED_DERIVATIVE_BACKENDS` now includes `"finite_difference"` (the legacy `"finite"` entry is retained).
+- `src/pdelie/reporting/summaries.py` (UPDATED) — two remaining direct periodic compares migrated to `get_x_boundary_type`. `summarize_field_batch_readiness` now emits `boundary_condition_warnings: list[str]` and downgrades a would-be `"ready"` label to `"needs_attention"` when warnings are present. `summarize_xarray_dataset_readiness` does the same. `summarize_residual_batch` now records a `residual_domain_policy` field, sourced from `residual.diagnostics["residual_domain_policy"]` if present, else `"not_configured"`.
+
+## Documents Added or Updated
+
+- `docs/design/DERIVATIVE_BACKEND_POLICY.md` (updated status — `finite_difference` v1 implemented)
+- `docs/planning/PLAN.md` (this file; v0.30b record retained below)
+- `docs/specs/API_STABILITY.md` (new "Decision-only note for the frozen `v0.30c`" subsection appended after the v0.30b note)
+- `docs/planning/ROADMAP.md` (v0.30c row updated; v0.30b row flipped to Completed)
+- `configs/planning/v0_30_nonperiodic_readiness_scope.json` (removed `pdelie.derivatives.compute_finite_difference_derivatives` and `pdelie.derivatives.compute_derivatives` from `forbidden_submodule_attributes` — they ship in v0.30c)
+
+## Tests Added
+
+- `tests/test_finite_difference_backend.py` — manufactured-polynomial accuracy, max_spatial_order limits, JSON-strict config, periodic-input rejection, nonuniform-grid rejection, too-few-points rejection, structured/legacy nonperiodic BC acceptance.
+- `tests/test_derivative_dispatcher.py` — `backend="auto"` periodic + nonperiodic routing, explicit-backend success/mismatch behavior, unknown backend rejection, no-fallback semantics, `backend_selected_by_boundary_condition` only true under auto.
+- `tests/test_boundary_readiness_reporting.py` — `boundary_condition_warnings` for legacy/structured periodic/nonperiodic/open_unknown, readiness label downgrade, residual-domain-policy passthrough, strict JSON compatibility, unsupported BC string routes to failure.
+
+## Tests Updated
+
+- `tests/test_reporting.py`:
+  - `_FIELD_BATCH_READINESS_SUMMARY_KEYS` and `_XARRAY_DATASET_READINESS_SUMMARY_KEYS` now include `boundary_condition_warnings`.
+  - the residual-batch frozen-keys assertion now includes `residual_domain_policy` and pins its default to `"not_configured"`.
+  - the nonperiodic-field readiness case now expects `"needs_attention"` plus the `x_boundary_dirichlet_unspecified` and `x_boundary_legacy_string_under_schema_0_2` warnings (the v0.30c behavior change).
+- `tests/test_boundary_condition_internal_usage.py`:
+  - dropped the `reporting/summaries.py` allowlist entry (no longer needed; the file now goes through the helper).
+  - `must_import_helper` enlarged to also list the new derivative-backend module, the dispatcher module, and `reporting/summaries.py`.
+- `configs/planning/v0_30_nonperiodic_readiness_scope.json`: `pdelie.derivatives.compute_finite_difference_derivatives` and `pdelie.derivatives.compute_derivatives` removed from `forbidden_submodule_attributes`.
+
+## Public-Surface Audit
+
+Confirmed in `v0.30c`:
+
+- no new `pdelie` root export
+- `pdelie.derivatives.compute_finite_difference_derivatives` and `pdelie.derivatives.compute_derivatives` are submodule-only
+- no new optional dependency
+- no new PDE
+- no PDEBench / The Well support claim
+- no KdV nonperiodic
+- no KS nonperiodic
+- no weak nonperiodic
+- no symmetry-method registry yet
+- no residual evaluator auto-dispatch (deferred to v0.30d)
+- no `u_xxx` / `u_xxxx` on nonperiodic data (`max_spatial_order ∈ {1, 2}` only)
+- no version bump (`pyproject.toml` remains at `0.29.0`)
+- no CI workflow change
+
+## v0.30c Sub-Release Gate
+
+`v0.30c` is complete when:
+
+- `pdelie.derivatives.compute_finite_difference_derivatives` is importable and produces correct `u_t`, `u_x`, `u_xx` on manufactured polynomials
+- `pdelie.derivatives.compute_derivatives(backend="auto")` routes by BC and records the selection in `DerivativeBatch.config`
+- `summarize_field_batch_readiness` exposes `boundary_condition_warnings` and downgrades the label when warnings exist
+- `summarize_residual_batch` exposes `residual_domain_policy`
+- all v0.30c new tests pass plus the existing v0.30a/b tests
+- the full test suite passes
+- `git diff --check` reports no whitespace damage
+
+---
+
+# PDELie - Execution Plan (V0.30b)
+
+**Status:** COMPLETE
+
+`v0.30b` lands the first runtime step of the v0.30 sequence: the structured `BoundaryConditionSpec`, the `FieldBatch` 0.1 → 0.2 schema migration with backwards-compatible loader, and internal helpers that centralize the x-boundary-type check. Adapter ingestion is loosened to accept supported nonperiodic specs; downstream derivative and residual consumers remain strict-periodic.
+
+## Release Theme
+
+`v0.30b` implements the contracts frozen in `v0.30a` for boundary metadata. It modifies `src/pdelie/` but adds no new optional dependency, no version bump, no root export, no CI workflow change.
+
+Decision label:
+
+```text
+boundary_condition_spec_runtime_and_field_batch_0_2_migration
+```
+
+## Implemented Surfaces
+
+- `src/pdelie/_boundary.py` (NEW) — internal helpers `BoundaryFace`, `BoundaryConditionSpec`, `normalize_x_boundary_condition`, `get_x_boundary_type`, `is_x_periodic`; module is intentionally underscore-prefixed (no submodule re-export).
+- `FieldBatch.SCHEMA_VERSION` bumped from `"0.1"` to `"0.2"`.
+- `FieldBatch.LEGACY_SCHEMA_VERSIONS = frozenset({"0.1"})`; `from_dict` accepts both versions.
+- `FieldBatch.from_dict` normalizes legacy `boundary_conditions["x"]` strings via `normalize_x_boundary_condition` and records a `schema_0_1_to_0_2_boundary_normalization` entry in `preprocess_log` for migrated payloads.
+- 14 downstream consumer sites refactored to use `is_x_periodic(field)` (preserves reject-nonperiodic semantics; no behavior change for periodic data).
+- `from_numpy` and `from_xarray` accept structured nonperiodic specs and supported legacy nonperiodic strings; unsupported strings still raise `ScopeValidationError`.
+
+## Documents Added or Updated
+
+- `docs/design/BOUNDARY_CONDITION_SPEC.md` (updated status — design frozen + runtime implemented)
+- `docs/planning/PLAN.md` (this file; v0.30a record retained below)
+- `docs/specs/API_STABILITY.md` (new "Decision-only note for the frozen `v0.30b`" subsection appended after the v0.30a note)
+- `docs/planning/ROADMAP.md` (new v0.30b row)
+
+## Tests Added
+
+- `tests/test_boundary_condition_spec.py` — direct tests for the helper module.
+- `tests/test_field_batch_schema_0_2_migration.py` — `FieldBatch` schema 0.1 → 0.2 migration tests.
+- `tests/test_boundary_condition_internal_usage.py` — invariants: downstream consumers still reject nonperiodic, adapters accept structured nonperiodic, no new direct periodic compares outside the helper module, all migrated modules import the helper.
+
+## Tests Updated
+
+- `tests/test_v0_30_scope_freeze.py`:
+  - removed `test_v0_30_no_src_changes_against_main` (v0.30b modifies src by design).
+  - replaced `test_v0_30_schema_migration_is_documented_but_not_yet_applied` with two tests: `test_v0_30_schema_migration_design_is_documented` (still passes against the design docs) and `test_v0_30b_schema_migration_is_applied_at_runtime` (asserts `FieldBatch.SCHEMA_VERSION == "0.2"`).
+- `tests/test_data_numpy_adapter.py` and `tests/test_data_xarray_adapter.py`:
+  - replaced the rejection-of-`dirichlet` tests with acceptance tests for `dirichlet`/`neumann`/`open_unknown` (the new loosened adapter behavior).
+  - added new rejection tests for unsupported BC strings (`"insulating"`).
+
+## Public-Surface Audit
+
+Confirmed in `v0.30b`:
+
+- no new `pdelie` root export
+- no new submodule runtime API
+- no new optional dependency
+- no new PDE
+- no PDEBench or The Well support claim
+- no KdV nonperiodic
+- no KS nonperiodic
+- no weak nonperiodic
+- no `compute_finite_difference_derivatives` module yet (deferred to v0.30c)
+- no `compute_derivatives` dispatcher yet (deferred to v0.30c)
+- no symmetry-method registry yet
+- no root `pdelie.discover_symmetries`
+- no version bump (`pyproject.toml` remains at `0.29.0`)
+- no CI workflow change
+
+## v0.30b Sub-Release Gate
+
+`v0.30b` is complete when:
+
+- `FieldBatch.SCHEMA_VERSION == "0.2"`
+- `FieldBatch.from_dict` accepts both `"0.1"` and `"0.2"` payloads
+- legacy `boundary_conditions["x"]` strings are normalized via `normalize_x_boundary_condition`
+- all 14 downstream consumer sites use `is_x_periodic` (no new direct compares)
+- `from_numpy` / `from_xarray` accept structured nonperiodic specs; downstream consumers still reject
+- the three new tests pass plus the updated v0.30 scope-freeze tests
+- the full test suite passes
+- `git diff --check` reports no whitespace damage
+
+---
+
+# PDELie - Execution Plan (V0.30a)
+
+**Status:** COMPLETE
+
+`v0.30a` is the scope-freeze, compatibility-audit, and design-contract sub-release that precedes `v0.30`.
+
+## Release Theme
+
+`v0.30a` freezes the design of nonperiodic-readiness ingestion, the low-order finite-difference derivative backend, the dispatch and residual-domain policies, and the cross-cutting hygiene audit. It adds no runtime API, bumps no package version, and modifies no file under `src/pdelie/`.
+
+Decision label:
+
+```text
+nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only
+```
+
+## Implemented Surfaces
+
+None at runtime. The sub-release is design-only.
+
+## Documents Added
+
+- `docs/planning/V0_30_SCOPE.md`
+- `docs/design/BOUNDARY_CONDITION_SPEC.md`
+- `docs/design/DERIVATIVE_BACKEND_POLICY.md`
+- `docs/design/V0_30_HYGIENE_AUDIT.md`
+- `configs/planning/v0_30_nonperiodic_readiness_scope.json`
+- `tests/test_v0_30_scope_freeze.py`
+- `tests/test_v0_30_hygiene_audit.py`
+
+## Documents Updated
+
+- `docs/planning/ROADMAP.md` (new `v0.30a` row in Next Planned Work; refined `v0.30` theme; appended deferred surfaces)
+- `docs/planning/PLAN.md` (this file; v0.29 record retained below)
+- `docs/specs/API_STABILITY.md` (new "Decision-only note for the frozen `v0.30a`" subsection appended after the v0.29 note)
+
+## Public-Surface Audit
+
+Confirmed in `v0.30a`:
+
+- no new `pdelie` root export
+- no new submodule runtime API
+- no new optional dependency
+- no new PDE
+- no PDEBench or The Well support claim
+- no KdV nonperiodic
+- no KS nonperiodic
+- no weak nonperiodic
+- no `compute_finite_difference_derivatives` module yet
+- no symmetry-method registry yet
+- no root `pdelie.discover_symmetries`
+- no version bump (`pyproject.toml` remains at `0.29.0`)
+- no CI workflow change
+
+## v0.30a Sub-Release Gate
+
+`v0.30a` is complete when:
+
+- the four design documents in `docs/design/` and `docs/planning/V0_30_SCOPE.md` are in place
+- `tests/test_v0_30_scope_freeze.py` and `tests/test_v0_30_hygiene_audit.py` pass
+- the full test suite still passes
+- `git diff --check` reports no whitespace damage
+- no file under `src/pdelie/` is modified
+
+---
+
 # PDELie - Execution Plan (V0.29)
 
 **Status:** COMPLETE

--- a/docs/planning/ROADMAP.md
+++ b/docs/planning/ROADMAP.md
@@ -25,17 +25,26 @@ Long historical release detail is archived in `archive/ROADMAP_HISTORY.md`.
 
 ## Next Planned Work
 
-No next release is frozen until a scope file is accepted.
+The next release `v0.30` is design-frozen by the `v0.30a` sub-release (audit-only, no runtime change, no version bump). Runtime implementation lands in `v0.30` proper.
 
 Planned direction:
 
 | Target | Theme | Status | Notes |
 | --- | --- | --- | --- |
 | `v0.26b` | KS promotion | Reserved | Only if a separate scope freeze accepts direct-SVD/no-fallback KS evidence. |
-| `v0.30` | Grid-domain feasibility | Planned | Decide whether any grid-domain extension is ready without broad nonuniform/multidimensional promotion. |
-| `v0.31` | Orbit/action scope decision | Planned | Decide whether finite-transform/orbit action machinery can be promoted beyond current diagnostics. |
-| `v0.32` | `v1.0` readiness hardening | Planned | Stabilize contracts, docs, error policy, optional dependencies, release gates, and publishing policy. |
-| `v1.0` | Stable public engine | Planned | Stabilization milestone, not a scope-expansion milestone. |
+| `v0.30a` | Scope freeze + design contracts | Completed | Audit-only sub-release. No runtime change, no version bump. Froze BoundaryConditionSpec and derivative-backend policy. |
+| `v0.30b` | BoundaryConditionSpec runtime + FieldBatch 0.2 migration | Completed | Implemented the structured boundary spec, `FieldBatch.from_dict` 0.1->0.2 migration, and the `is_x_periodic` helper centralization. Adapters accept structured nonperiodic specs; downstream consumers stay strict-periodic. |
+| `v0.30c` | Finite-difference derivative backend (low-order) + boundary-aware reporting | In progress | Implements `compute_finite_difference_derivatives` (`u_t`, `u_x`, `u_xx` only), the `compute_derivatives(backend="auto")` dispatcher, `boundary_condition_warnings` on readiness summaries, and the `residual_domain_policy` field on residual summaries. Residual evaluator auto-dispatch deferred to v0.30d. No version bump. |
+| `v0.30d` | Residual evaluator auto-dispatch + hygiene phase 1 | Planned | Nonperiodic Heat/Burgers/advection-diffusion residual preflight via the dispatcher; interior-only residual domain policy; ruff/mypy/coverage non-blocking CI. |
+| `v0.30` | Release close: Nonperiodic readiness + low-order FD diagnostics + hygiene preparation | Planned | Final v0.30 release; bumps `pyproject.toml` version to `0.30.0` and tags. |
+| `v0.30.1` | Submodule-only SymmetryMethod registry MVP | Planned | One built-in adapter (`polynomial_translation_svd`). No root API. No external method ports. |
+| `v0.31` | Downstream discovery task bridge | Planned | Unlock PySINDy `PDELibrary` config, add `WeakPDELibrary` diagnostic wrapper. Tasks live under `pdelie.tasks.discovery`, not under the symmetry registry. |
+| `v0.31.5` | Nonperiodic orbit/action scope decision | Planned | Overlap-crop design for nonperiodic translation; decision on whether finite-transform/orbit action machinery can be promoted beyond diagnostics. |
+| `v0.32` | External dataset readiness cookbooks | Planned | One scalar 1D PDEBench slice readiness and, if feasible, one scalar 1D The Well slice readiness. No recovery benchmark claim. |
+| `v0.33` | First external symmetry candidate-generator method | Planned | Ko-style sparse generator behind an experimental flag. LieGAN/LaLiGAN as a later optional stochastic extra. |
+| `v0.34` | Multi-channel / 2D contract widening scope decision | Planned | Required for any meaningful The Well coverage. Relaxes `var_names` length-1 and the canonical `('batch','time','x','var')` dim layout. |
+| `v0.35` | Trained-model extraction layer | Planned | `TrainedModelArtifact` contract; LieGG-style extraction adapter. Distinct API path from `fit(field, residual_evaluator=...)`. |
+| `v1.0` | Stable public engine; PyPI publish; optional root-entry decision | Planned | Stabilization milestone. Reopens the root one-call API question explicitly rather than pre-banning it. |
 
 ## Planning Labels
 
@@ -120,6 +129,10 @@ The following remain deferred unless explicitly frozen in a later scope:
 - neural/callable generator APIs and operator symmetry
 - split creation, split optimization, benchmark policy, and leakage-prevention enforcement
 - root export expansion for runtime helpers
+- high-order finite-difference derivatives on nonperiodic data (no `u_xxx`, `u_xxxx` in the stable `v0.30` surface)
+- finite-transform verification on nonperiodic translations (deferred to `v0.31.5` overlap-crop design)
+- weak-form derivatives or weak residuals on nonperiodic data
+- root-level one-call symmetry-discovery API (deferred to `v1.0` scope decision)
 
 ## Historical Detail
 

--- a/docs/planning/V0_30_SCOPE.md
+++ b/docs/planning/V0_30_SCOPE.md
@@ -1,0 +1,163 @@
+# V0.30 Scope - Nonperiodic Readiness and Low-Order Finite-Difference Derivative Diagnostics
+
+**Status:** IN_PROGRESS
+
+`v0.30` is the nonperiodic-readiness and low-order finite-difference derivative-diagnostics release.
+
+It loosens canonical ingestion to accept structured nonperiodic boundary conditions for scalar 1D fields, adds a finite-difference derivative backend limited to `u_t`, `u_x`, and `u_xx`, and lands cross-cutting hygiene infrastructure (ruff, mypy, coverage) under staged enforcement. It does not change the existing periodic spectral derivative path, does not promote any new PDE, does not add a symmetry-method registry, and does not unlock any external-dataset support claim.
+
+This file documents the frozen scope. The first executed slice is the design-only sub-release `v0.30a`, which adds documents, configs, and audit tests without modifying any runtime code or bumping the package version.
+
+Release conclusion (recorded by v0.30a, finalized by v0.30 proper):
+
+```text
+nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only
+```
+
+## Stable Intent
+
+v0.30 widens the canonical-ingestion surface from "periodic x only" to "periodic and structured nonperiodic" for scalar 1D fields, and adds a corresponding low-order finite-difference derivative backend. The existing periodic spectral path stays untouched. The release ships diagnostics, not new PDE-domain support claims.
+
+Three explicit user paths are unlocked:
+
+1. structured boundary metadata: `metadata["boundary_conditions"]["x"]` becomes a structured spec with `type`, optional per-face values, and explicit `specified` provenance
+2. finite-difference derivative diagnostics: `u_t`, `u_x`, `u_xx` on Dirichlet, Neumann, and `open_unknown` data
+3. residual preflight on manufactured nonperiodic Heat, Burgers, and advection-diffusion fields, with interior-vs-full-grid residual domain policy
+
+## Scope
+
+The v0.30 release scope is:
+
+- scalar 1D nonperiodic readiness for canonical `FieldBatch` inputs
+- low-order finite-difference derivative backend (implementation limited to u_t, u_x, u_xx — no higher orders on nonperiodic data in the stable `v0.30` surface)
+- design and implementation of structured `BoundaryConditionSpec`
+- cross-cutting hygiene preparation, audit-only in v0.30a and staged enforcement in v0.30 proper
+- release-gate consolidation proposal (consolidation lands in v0.30 proper, not v0.30a)
+
+The v0.30 deliverables, design-frozen in v0.30a and implemented in v0.30 proper:
+
+- structured `BoundaryConditionSpec` accepting legacy string inputs and normalizing them under a backwards-compatible loader
+- `compute_finite_difference_derivatives(field, *, max_spatial_order=2)` for `u_t`, `u_x`, `u_xx` only
+- `compute_derivatives(field, *, backend="auto", max_spatial_order=...)` dispatcher that records its selection explicitly in `DerivativeBatch.config`
+- residual interior-vs-full-grid policy reported on residual summaries
+- Heat, Burgers, and advection-diffusion residual preflight on manufactured nonperiodic scalar fields
+- readiness reports updated to surface boundary-condition under-specification as `needs_attention`
+- cross-cutting hygiene: `[tool.ruff]`, `[tool.mypy]` (initially strict on `src/pdelie/contracts.py`, `src/pdelie/derivatives/`, `src/pdelie/data/`, `src/pdelie/residuals/` only), `[tool.coverage]` in `pyproject.toml`; new audit-only CI jobs
+
+## Deferred Scope
+
+Explicit non-goals (the scope-freeze test will assert these phrases are present):
+
+- no PDEBench support claim
+- no The Well support claim
+- no file loaders or broad adapter framework
+- no KdV nonperiodic
+- no KS nonperiodic
+- no public KS runtime API
+- no weak nonperiodic
+- no public weak derivative backend
+- no high-order nonperiodic finite differences
+- no `u_xxx` or `u_xxxx` on nonperiodic data in the stable v0.30 surface
+- no finite-transform verification for nonperiodic translations
+- no symmetry arena
+- no symmetry-method registry
+- no root `pdelie.discover_symmetries`
+- no external symmetry-method ports
+- no new root pdelie exports
+- no neural or callable generator APIs
+- no train/test policy or leakage prevention
+- no PyPI or TestPyPI publication; package-index publishing remains deferred to `v1.0` or later
+
+The symmetry-method registry is the v0.30.1 deliverable, not v0.30. The PySINDy `PDELibrary` / `WeakPDELibrary` task-bridge work is v0.31. External-dataset readiness cookbooks (one scalar 1D PDEBench slice, optionally one scalar 1D The Well slice) are v0.32.
+
+## Boundary Condition Schema (Designed in v0.30a)
+
+The structured form is documented in `docs/design/BOUNDARY_CONDITION_SPEC.md`. Summary:
+
+```
+metadata["boundary_conditions"]["x"] = {
+    "type": "periodic" | "dirichlet" | "neumann" | "open_unknown",
+    "left": BoundaryFace | None,
+    "right": BoundaryFace | None,
+    "specified": bool,
+    "time_dependent": bool | None,
+    "notes": str | None,
+}
+```
+
+`BoundaryFace` carries `{"value": float | None, "time_dependent": bool, "source": "user_supplied" | "default" | "inferred_unspecified"}`.
+
+Legacy `0.1`-schema payloads that present `boundary_conditions["x"]` as a string normalize to the structured form under the v0.30 loader; the normalization is recorded in `preprocess_log` under operation `"schema_0_1_to_0_2_boundary_normalization"`. `FieldBatch.SCHEMA_VERSION` bumps `0.1` to `0.2`; `from_dict` accepts both versions. v0.30a does not bump the schema; v0.30 proper does.
+
+## Derivative Backend Policy (Designed in v0.30a)
+
+The full policy is documented in `docs/design/DERIVATIVE_BACKEND_POLICY.md`. Summary:
+
+- `spectral_fd` remains periodic-only; the check at `src/pdelie/derivatives/spectral_fd.py:32-33` is unchanged
+- `finite_difference` v1 supports `u_t`, `u_x`, `u_xx` on Dirichlet, Neumann, and `open_unknown` data
+- `u_xxx` and `u_xxxx` on nonperiodic data are not part of the stable v0.30 surface
+- `compute_derivatives(backend="auto")` dispatch is explicit: `DerivativeBatch.config` records `backend_selected_by_boundary_condition` and `backend_selection_reason`
+- residual domain policy on nonperiodic FD-derived residuals defaults to `interior_only`
+- finite-transform translation verification on nonperiodic data is deferred to v0.31.5 (overlap-crop design)
+
+## Hygiene Audit (Performed in v0.30a)
+
+The audit baseline is documented in `docs/design/V0_30_HYGIENE_AUDIT.md`. Headline findings:
+
+- no `[tool.ruff]`, `[tool.mypy]`, or `[tool.coverage]` in `pyproject.toml` today
+- CI runs only Python 3.11
+- `numpy>=1.24,<2` is the current upper-bound cap
+- 26 per-release-gate test files exist; consolidation is proposed via a parameterized test driven by a manifest file
+- optional-dependency lazy import pattern at `src/pdelie/discovery/pysindy_adapter.py:12-20` is the reference implementation; the audit confirms the policy must remain unchanged
+- strict JSON / `allow_nan=False` discipline confirmed; the audit confirms new outputs must follow it
+
+Staged enforcement (no implementation in v0.30a, designed only):
+
+1. Phase 0 (v0.30a): audit-only
+2. Phase 1 (v0.30 proper): ruff, mypy (strict on core modules, lenient elsewhere), coverage; non-blocking CI
+3. Phase 2 (v0.30.1 or v0.31): mypy strict across `src/pdelie/`; blocking CI
+4. Phase 3 (v0.32): Python 3.11 / 3.12 / 3.13 matrix; numpy 2.x side-job validation
+5. Phase 4 (v1.0): lift `numpy<2` cap once 2.x validation has soaked
+
+## Milestone Status
+
+- Milestone 0: scope freeze and design documents - COMPLETE (in v0.30a)
+- Milestone 1: structured `BoundaryConditionSpec` runtime - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+- Milestone 2: `compute_finite_difference_derivatives` and dispatcher - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+- Milestone 3: residual domain policy uptake in summaries - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+- Milestone 4: manufactured nonperiodic residual preflight tests - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+- Milestone 5: ruff/mypy/coverage Phase 1 in `pyproject.toml` and CI - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+- Milestone 6: release-gate consolidation - DESIGN COMPLETE in v0.30a, IMPLEMENTATION DEFERRED to v0.30
+
+## Release Gate (v0.30 proper, not v0.30a)
+
+`v0.30` is complete only if:
+
+- `FieldBatch.SCHEMA_VERSION` is `"0.2"` and `from_dict` accepts both `"0.1"` and `"0.2"` payloads
+- `compute_finite_difference_derivatives` is importable from `pdelie.derivatives` and supports `u_t`, `u_x`, `u_xx` on Dirichlet/Neumann/`open_unknown` data
+- `compute_derivatives(backend="auto")` is importable and records its selection explicitly
+- Heat, Burgers, and advection-diffusion residual evaluators accept nonperiodic structured BCs and route to the finite-difference backend by default
+- `summarize_residual_batch` and `summarize_field_batch_readiness` expose `residual_domain_policy` and `boundary_condition_warnings` respectively
+- `[tool.ruff]`, `[tool.mypy]`, `[tool.coverage]` are configured in `pyproject.toml`; non-blocking CI jobs run
+- The parameterized release-gate consolidation lands and the per-version `tests/test_v0_NN_release_gate.py` files (other than v0.30 itself) are removed
+- `tests/test_v0_30_release_gate.py` passes
+- the full test suite passes
+- package metadata is bumped to `0.30.0`
+- Git-tag-only; PyPI/TestPyPI remain deferred to `v1.0` or later
+
+## v0.30a Sub-Release Gate
+
+v0.30a is complete when:
+
+- this scope document is in place and the scope-freeze test passes
+- the three design documents in `docs/design/` are in place
+- `docs/planning/ROADMAP.md` records v0.30a
+- `docs/planning/PLAN.md` records v0.30a as IN_PROGRESS with the decision label
+- `docs/specs/API_STABILITY.md` contains a "Decision-only note for the frozen v0.30a" subsection
+- `configs/planning/v0_30_nonperiodic_readiness_scope.json` is present and strictly JSON-compatible (`allow_nan=False`)
+- `tests/test_v0_30_scope_freeze.py` and `tests/test_v0_30_hygiene_audit.py` pass
+- the full test suite still passes
+- no file under `src/pdelie/` is modified
+- no version bump in `pyproject.toml`
+- no new optional dependency added
+- no new CI job added

--- a/docs/planning/index.rst
+++ b/docs/planning/index.rst
@@ -12,4 +12,5 @@ Release planning records. Planning docs do not override the specs.
    V0_27_SCOPE
    V0_28_SCOPE
    V0_29_SCOPE
+   V0_30_SCOPE
    archive/index

--- a/docs/specs/API_STABILITY.md
+++ b/docs/specs/API_STABILITY.md
@@ -357,6 +357,57 @@ Decision-only note for the frozen `v0.29` workflow recipes and support matrix re
 - `v0.29` adds rendered tutorial notebooks for the two complete workflow recipes
 - this decision does not add `pdelie.reporting.summarize_workflow_readiness(...)`, new PDEs, file loaders, broad adapters, multidimensional or nonuniform stable support, public KS runtime APIs, train/test policy, neural/callable generators, operator-facing APIs, or root exports
 
+Decision-only note for the frozen `v0.30a` scope-freeze sub-release:
+
+- `v0.30a` adds no new runtime public API
+- `v0.30a` records the design decision `nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only`
+- `v0.30a` does not change any existing public surface, does not bump `pyproject.toml`, does not change CI, and does not declare any new optional dependency
+- `v0.30a` freezes the design of structured `BoundaryConditionSpec`, the `finite_difference` derivative backend, the `compute_derivatives(backend="auto")` dispatcher, and the residual interior-vs-full-grid domain policy; the documents are at `docs/planning/V0_30_SCOPE.md`, `docs/design/BOUNDARY_CONDITION_SPEC.md`, `docs/design/DERIVATIVE_BACKEND_POLICY.md`, and `docs/design/V0_30_HYGIENE_AUDIT.md`
+- the runtime implementation lands in `v0.30` proper, not in `v0.30a`
+- the `v0.30` release will bump `FieldBatch.SCHEMA_VERSION` from `"0.1"` to `"0.2"` to carry the structured `BoundaryConditionSpec`; `FieldBatch.from_dict` will accept both `"0.1"` and `"0.2"` payloads under a backwards-compatible loader so external tooling can prepare
+- `v0.30` will add `pdelie.derivatives.compute_finite_difference_derivatives` and `pdelie.derivatives.compute_derivatives` under their submodules; neither becomes a root `pdelie` export
+- `v0.30a` does not add a `SymmetryMethod` registry, a `pdelie.discover_symmetries` root API, any external symmetry-method port, any file loader, any PDEBench or The Well adapter, any KS runtime API, any weak nonperiodic surface, or any new PDE generator/evaluator
+- `v0.30a` records that `u_xxx` and `u_xxxx` on nonperiodic data remain deferred from the stable `v0.30` surface
+- `v0.30a` records that finite-transform verification for nonperiodic translations is deferred to the `v0.31.5` orbit/action scope decision
+
+Decision-only note for the frozen `v0.30b` BoundaryConditionSpec runtime and FieldBatch 0.2 migration sub-release:
+
+- `v0.30b` adds no new runtime public API and no new root `pdelie` export
+- `v0.30b` records the design decision `boundary_condition_spec_runtime_and_field_batch_0_2_migration`
+- `v0.30b` does not bump the package version (`pyproject.toml` stays at `0.29.0`); the version bump lands at v0.30 release close
+- `v0.30b` bumps `FieldBatch.SCHEMA_VERSION` from `"0.1"` to `"0.2"`; `FieldBatch.from_dict` accepts both `"0.1"` and `"0.2"` payloads under a backwards-compatible loader
+- legacy `metadata["boundary_conditions"]["x"]` string values (`"periodic"`, `"dirichlet"`, `"neumann"`, `"open"`, `"open_unknown"`) are normalized to the structured `BoundaryConditionSpec` form on load and recorded in `preprocess_log` under operation `"schema_0_1_to_0_2_boundary_normalization"`
+- the helpers live in the internal `src/pdelie/_boundary.py` module; they are not promoted as a public submodule API
+- `from_numpy` and `from_xarray` accept structured nonperiodic specs and the supported legacy nonperiodic strings; unsupported strings raise `ScopeValidationError`
+- downstream consumers (`spectral_fd`, `HeatResidualEvaluator`, `BurgersResidualEvaluator`, `KdVResidualEvaluator`, `ReactionDiffusionResidualEvaluator`, `AdvectionDiffusionResidualEvaluator`, `evaluate_weak_heat_residual`, `evaluate_weak_burgers_residual`, translation basis, `InvariantApplier`, finite-transform verification, candidate validation, formula generators, downstream discovery bridge) remain strict-periodic; they now route through the `is_x_periodic` helper rather than direct string compares
+- `v0.30b` does not add `compute_finite_difference_derivatives`, `compute_derivatives`, any nonperiodic residual support, any nonperiodic translation/verification path, or any new PDE; those land in v0.30c and later
+- `v0.30b` does not add a symmetry-method registry, an external method port, a file loader, a PDEBench/The Well adapter, a KS runtime API, a weak nonperiodic surface, or any new optional dependency
+
+Runtime public API for the frozen `v0.30c` low-order finite-difference derivative slice:
+
+- `pdelie.derivatives.compute_finite_difference_derivatives(field, *, max_spatial_order=2)` for `u_t`, `u_x`, and optionally `u_xx` on scalar 1D nonperiodic (`dirichlet`, `neumann`, `open_unknown`) uniform-grid `FieldBatch` data. The backend uses ``numpy.gradient`` with ``edge_order=2`` for both axes. ``max_spatial_order`` is restricted to ``{1, 2}``; higher orders raise ``ScopeValidationError`` (no `u_xxx`/`u_xxxx` on nonperiodic data in the stable surface).
+- the backend rejects periodic data with an explicit `ScopeValidationError`; periodic users must call `compute_spectral_fd_derivatives` or the dispatcher.
+- returned `DerivativeBatch.config` carries the v0.30c keys: `spatial_method = "finite_difference_centered"`, `temporal_method = "finite_difference"`, `stencil_edge_order = 2`, `boundary_handling ∈ {"dirichlet", "neumann", "open_unknown"}`, `spatial_max_order ∈ {1, 2}`, `backend_selected_by_boundary_condition` (default `False`), `backend_selection_reason` (default `None`), `recommended_residual_domain_policy = "interior_only"`, and `recommended_boundary_trim_width = 4`.
+- `pdelie.derivatives.compute_derivatives(field, *, backend="auto", max_spatial_order=2)` dispatches between `spectral_fd` for periodic data and `finite_difference` for any supported nonperiodic boundary type. When `backend="auto"`, the resulting `DerivativeBatch.config` sets `backend_selected_by_boundary_condition = True` and a non-null `backend_selection_reason` (`"periodic_x_uses_spectral_fd"` or `"nonperiodic_x_uses_finite_difference"`); the selection is always auditable from the artifact itself. Explicit `backend="spectral_fd"` on nonperiodic data and explicit `backend="finite_difference"` on periodic data both raise `ScopeValidationError`; the dispatcher never silently falls back.
+- both APIs are submodule-only (no root `pdelie` export) and do not change any existing residual evaluator behavior. Residual evaluator auto-dispatch is deferred.
+- `pdelie.contracts.ALLOWED_DERIVATIVE_BACKENDS` now includes the canonical `"finite_difference"` name; the legacy `"finite"` entry is retained.
+
+Runtime public API update for the frozen `v0.30c` boundary-aware reporting slice:
+
+- `pdelie.reporting.summarize_field_batch_readiness` now emits an additive `boundary_condition_warnings: list[str]` field with the v0.30c vocabulary: `"x_boundary_legacy_string_under_schema_0_2"`, `"x_boundary_open_unknown"`, `"x_boundary_dirichlet_unspecified"`, `"x_boundary_neumann_unspecified"`. The list is empty for periodic (legacy or structured) FieldBatches and for fully-specified structured nonperiodic FieldBatches. A non-empty list downgrades the report's `readiness_label` from `"ready"` to `"needs_attention"`; harder failures (non-finite values, missing required metadata keys, non-uniform x or time coordinates) still route to `"not_ready"`.
+- `pdelie.reporting.summarize_xarray_dataset_readiness` exposes the same `boundary_condition_warnings` field with the same vocabulary and the same readiness-label downgrade rule.
+- `pdelie.reporting.summarize_residual_batch` now records `residual_domain_policy: str` sourced from `ResidualBatch.diagnostics["residual_domain_policy"]` when present; defaults to `"not_configured"` so the field is always present and strict-JSON serializable. No existing residual evaluator output is mutated.
+- the readiness reports now treat a non-periodic boundary as a warning rather than a metadata failure; the `"x_boundary_not_periodic"` failure key has been replaced by the new warning vocabulary. Unsupported BC strings (e.g. `"insulating"`) continue to route to a metadata failure under `"x_boundary_unsupported"`.
+
+Decision-only note for the frozen `v0.30c` low-order finite-difference and boundary-aware reporting sub-release:
+
+- `v0.30c` adds no new runtime root `pdelie` export and no new optional dependency
+- `v0.30c` records the design decision `low_order_finite_difference_backend_and_boundary_aware_readiness`
+- `v0.30c` does not bump the package version (`pyproject.toml` stays at `0.29.0`); the version bump lands at v0.30 release close
+- residual evaluator auto-dispatch, residual interior-trim policy enforcement, and finite-transform verification on nonperiodic data are explicitly deferred to v0.30d / v0.31.5
+- `u_xxx` and `u_xxxx` on nonperiodic data remain unsupported; no experimental flag is exposed in v0.30c
+- the `finite_difference` backend uses only `numpy.gradient(edge_order=2)`; higher-order one-sided stencils, Fornberg-style families, and weak/Galerkin formulations remain deferred
+
 Runtime-level APIs are versioned public APIs, but they are not canonical objects.
 They are backend-specific and may change with a version bump.
 

--- a/src/pdelie/_boundary.py
+++ b/src/pdelie/_boundary.py
@@ -1,0 +1,311 @@
+"""Internal boundary-condition helpers.
+
+Implements the v0.30b runtime plumbing for the structured `BoundaryConditionSpec`
+designed in `docs/design/BOUNDARY_CONDITION_SPEC.md`.
+
+The helpers in this module are the single canonical entry point for reading and
+normalizing `metadata['boundary_conditions']['x']`. All consumers that need to
+know the boundary type must go through `get_x_boundary_type` or `is_x_periodic`
+rather than comparing the raw value directly. This keeps the legacy 0.1 string
+form and the 0.2 structured form interchangeable while the codebase migrates.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+ALLOWED_X_BOUNDARY_TYPES = frozenset({"periodic", "dirichlet", "neumann", "open_unknown"})
+ALLOWED_BOUNDARY_FACE_SOURCES = frozenset({"user_supplied", "default", "inferred_unspecified"})
+
+# Legacy 0.1 string inputs accepted by adapters and `FieldBatch.from_dict`.
+# Per the v0.30a design, `"open"` is renamed to `"open_unknown"` on normalization
+# so the canonical name reflects the PDELie convention "finite domain, BC unstated".
+_LEGACY_X_BOUNDARY_STRING_ALIASES: dict[str, str] = {
+    "periodic": "periodic",
+    "dirichlet": "dirichlet",
+    "neumann": "neumann",
+    "open": "open_unknown",
+    "open_unknown": "open_unknown",
+}
+
+# Migration provenance marker recorded in `preprocess_log` when a 0.1 payload
+# is normalized to the 0.2 structured form.
+LEGACY_BOUNDARY_NORMALIZATION_OPERATION = "schema_0_1_to_0_2_boundary_normalization"
+
+_BC_TYPES_WITH_FACES = frozenset({"dirichlet", "neumann"})
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryFace:
+    """One face (left or right) of a non-periodic boundary.
+
+    The library does not invent boundary values. A face whose `value` is `None`
+    or whose `source` is `"inferred_unspecified"` always counts as missing data
+    for the purpose of `BoundaryConditionSpec.specified`.
+    """
+
+    value: float | None
+    time_dependent: bool
+    source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "value": None if self.value is None else float(self.value),
+            "time_dependent": bool(self.time_dependent),
+            "source": str(self.source),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "BoundaryFace":
+        if not isinstance(value, Mapping):
+            raise SchemaValidationError("BoundaryFace must be a mapping.")
+        raw_value = value.get("value")
+        normalized_value = _validate_optional_finite_scalar(raw_value, name="BoundaryFace.value")
+        raw_time_dependent = value.get("time_dependent", False)
+        if not isinstance(raw_time_dependent, bool):
+            raise SchemaValidationError("BoundaryFace.time_dependent must be a bool.")
+        raw_source = value.get("source", "user_supplied")
+        if not isinstance(raw_source, str):
+            raise SchemaValidationError("BoundaryFace.source must be a string.")
+        if raw_source not in ALLOWED_BOUNDARY_FACE_SOURCES:
+            raise SchemaValidationError(
+                "BoundaryFace.source must be one of "
+                f"{sorted(ALLOWED_BOUNDARY_FACE_SOURCES)}; got {raw_source!r}."
+            )
+        return cls(value=normalized_value, time_dependent=bool(raw_time_dependent), source=raw_source)
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryConditionSpec:
+    """Structured representation of `metadata['boundary_conditions']['x']`.
+
+    For `type == 'periodic'` and `type == 'open_unknown'`, both `left` and
+    `right` must be `None`. For `type in {'dirichlet', 'neumann'}`, each face
+    may be `None` (one-sided constraint) or a `BoundaryFace`.
+
+    `specified` records whether the boundary is fully described. The library
+    never infers boundary values: a `BoundaryFace` whose `value` is `None` or
+    whose `source` is `"inferred_unspecified"` keeps the overall spec
+    unspecified.
+    """
+
+    type: str
+    left: BoundaryFace | None
+    right: BoundaryFace | None
+    specified: bool
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": str(self.type),
+            "left": None if self.left is None else self.left.to_dict(),
+            "right": None if self.right is None else self.right.to_dict(),
+            "specified": bool(self.specified),
+            "notes": None if self.notes is None else str(self.notes),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> "BoundaryConditionSpec":
+        if not isinstance(value, Mapping):
+            raise SchemaValidationError("BoundaryConditionSpec must be a mapping.")
+        raw_type = value.get("type")
+        if not isinstance(raw_type, str) or raw_type not in ALLOWED_X_BOUNDARY_TYPES:
+            raise ScopeValidationError(
+                "BoundaryConditionSpec.type must be one of "
+                f"{sorted(ALLOWED_X_BOUNDARY_TYPES)}; got {raw_type!r}."
+            )
+        bc_type = raw_type
+
+        raw_left = value.get("left")
+        raw_right = value.get("right")
+        left = None if raw_left is None else BoundaryFace.from_dict(raw_left)
+        right = None if raw_right is None else BoundaryFace.from_dict(raw_right)
+
+        if bc_type == "periodic":
+            if left is not None or right is not None:
+                raise SchemaValidationError(
+                    "Periodic boundary spec must have left=None and right=None."
+                )
+        elif bc_type == "open_unknown":
+            if left is not None or right is not None:
+                raise SchemaValidationError(
+                    "open_unknown boundary spec must have left=None and right=None."
+                )
+
+        if "specified" in value:
+            raw_specified = value["specified"]
+            if not isinstance(raw_specified, bool):
+                raise SchemaValidationError("BoundaryConditionSpec.specified must be a bool.")
+            specified = bool(raw_specified)
+        else:
+            specified = _infer_specified(bc_type, left, right)
+
+        raw_notes = value.get("notes")
+        if raw_notes is not None and not isinstance(raw_notes, str):
+            raise SchemaValidationError("BoundaryConditionSpec.notes must be a string or None.")
+        notes = None if raw_notes is None else str(raw_notes)
+
+        return cls(type=bc_type, left=left, right=right, specified=specified, notes=notes)
+
+
+def normalize_x_boundary_condition(value: object) -> dict[str, Any]:
+    """Normalize a `metadata['boundary_conditions']['x']` value to the canonical structured form.
+
+    Accepts:
+    - legacy 0.1 string: `"periodic"`, `"dirichlet"`, `"neumann"`, `"open"`, `"open_unknown"`
+    - structured dict matching `BoundaryConditionSpec.from_dict`
+
+    Returns the canonical structured dict (`BoundaryConditionSpec.to_dict()`).
+
+    Raises:
+    - `ScopeValidationError` for unsupported strings or unsupported `type` keys.
+    - `SchemaValidationError` for malformed dicts or non-string non-mapping values.
+    """
+    if isinstance(value, str):
+        canonical_type = _LEGACY_X_BOUNDARY_STRING_ALIASES.get(value)
+        if canonical_type is None:
+            raise ScopeValidationError(
+                f"Unsupported x boundary string {value!r}. "
+                "Supported legacy strings: "
+                f"{sorted(_LEGACY_X_BOUNDARY_STRING_ALIASES.keys())}; "
+                f"supported canonical types: {sorted(ALLOWED_X_BOUNDARY_TYPES)}."
+            )
+        if canonical_type == "periodic":
+            spec = BoundaryConditionSpec(
+                type="periodic", left=None, right=None, specified=True, notes=None
+            )
+        elif canonical_type == "open_unknown":
+            spec = BoundaryConditionSpec(
+                type="open_unknown",
+                left=None,
+                right=None,
+                specified=False,
+                notes="normalized from legacy 0.1 string",
+            )
+        else:
+            # dirichlet, neumann: library does not invent values
+            unspecified_face = BoundaryFace(
+                value=None, time_dependent=False, source="inferred_unspecified"
+            )
+            spec = BoundaryConditionSpec(
+                type=canonical_type,
+                left=unspecified_face,
+                right=unspecified_face,
+                specified=False,
+                notes="normalized from legacy 0.1 string",
+            )
+        return spec.to_dict()
+
+    if isinstance(value, Mapping):
+        return BoundaryConditionSpec.from_dict(value).to_dict()
+
+    raise SchemaValidationError(
+        "boundary_conditions['x'] must be a string or a mapping; got "
+        f"{type(value).__name__}."
+    )
+
+
+def get_x_boundary_type(metadata_or_field: object) -> str:
+    """Return the canonical x-boundary type from a `FieldBatch` or metadata dict.
+
+    Accepts both the legacy 0.1 string representation and the 0.2 structured form.
+    Returns one of: `'periodic'`, `'dirichlet'`, `'neumann'`, `'open_unknown'`.
+
+    Raises:
+    - `ScopeValidationError` if the value is a recognized format but the type is unsupported.
+    - `SchemaValidationError` if the input shape is malformed.
+    """
+    metadata = _resolve_metadata(metadata_or_field)
+    bcs = metadata.get("boundary_conditions")
+    if not isinstance(bcs, Mapping):
+        raise SchemaValidationError("metadata['boundary_conditions'] must be a mapping.")
+    x_bc = bcs.get("x")
+    if isinstance(x_bc, str):
+        canonical = _LEGACY_X_BOUNDARY_STRING_ALIASES.get(x_bc)
+        if canonical is None:
+            raise ScopeValidationError(
+                f"Unsupported x boundary string {x_bc!r}. "
+                f"Supported canonical types: {sorted(ALLOWED_X_BOUNDARY_TYPES)}."
+            )
+        return canonical
+    if isinstance(x_bc, Mapping):
+        raw_type = x_bc.get("type")
+        if raw_type not in ALLOWED_X_BOUNDARY_TYPES:
+            raise ScopeValidationError(
+                "BoundaryConditionSpec.type must be one of "
+                f"{sorted(ALLOWED_X_BOUNDARY_TYPES)}; got {raw_type!r}."
+            )
+        return str(raw_type)
+    raise SchemaValidationError(
+        "boundary_conditions['x'] must be a string or mapping; got "
+        f"{type(x_bc).__name__}."
+    )
+
+
+def is_x_periodic(metadata_or_field: object) -> bool:
+    """Return True iff the x boundary condition is periodic.
+
+    Errors (unsupported string, malformed dict, missing metadata) propagate to the caller.
+    """
+    return get_x_boundary_type(metadata_or_field) == "periodic"
+
+
+# --- private helpers --------------------------------------------------------
+
+
+def _validate_optional_finite_scalar(value: object, *, name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SchemaValidationError(f"{name} must be a finite scalar or None.")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise SchemaValidationError(f"{name} must be finite.")
+    return normalized
+
+
+def _infer_specified(
+    bc_type: str, left: BoundaryFace | None, right: BoundaryFace | None
+) -> bool:
+    if bc_type == "periodic":
+        return True
+    if bc_type == "open_unknown":
+        return False
+    if bc_type in _BC_TYPES_WITH_FACES:
+        faces = [face for face in (left, right) if face is not None]
+        if not faces:
+            return False
+        for face in faces:
+            if face.value is None or face.source == "inferred_unspecified":
+                return False
+        return True
+    return False
+
+
+def _resolve_metadata(metadata_or_field: object) -> Mapping[str, Any]:
+    if hasattr(metadata_or_field, "metadata"):
+        metadata = metadata_or_field.metadata
+        if not isinstance(metadata, Mapping):
+            raise SchemaValidationError("FieldBatch.metadata must be a mapping.")
+        return metadata
+    if isinstance(metadata_or_field, Mapping):
+        return metadata_or_field
+    raise SchemaValidationError("Expected FieldBatch or metadata mapping.")
+
+
+__all__ = [
+    "ALLOWED_BOUNDARY_FACE_SOURCES",
+    "ALLOWED_X_BOUNDARY_TYPES",
+    "BoundaryConditionSpec",
+    "BoundaryFace",
+    "LEGACY_BOUNDARY_NORMALIZATION_OPERATION",
+    "get_x_boundary_type",
+    "is_x_periodic",
+    "normalize_x_boundary_condition",
+]

--- a/src/pdelie/contracts.py
+++ b/src/pdelie/contracts.py
@@ -6,6 +6,10 @@ from typing import Any, ClassVar, Mapping
 
 import numpy as np
 
+from pdelie._boundary import (
+    LEGACY_BOUNDARY_NORMALIZATION_OPERATION,
+    normalize_x_boundary_condition,
+)
 from pdelie.errors import (
     SchemaValidationError,
     ScopeValidationError,
@@ -20,7 +24,9 @@ REQUIRED_METADATA_KEYS = (
     "grid_type",
     "parameter_tags",
 )
-ALLOWED_DERIVATIVE_BACKENDS = frozenset({"spectral_fd", "spectral", "finite", "weak"})
+ALLOWED_DERIVATIVE_BACKENDS = frozenset(
+    {"spectral_fd", "spectral", "finite", "finite_difference", "weak"}
+)
 ALLOWED_RESIDUAL_TYPES = frozenset({"analytic", "weak", "surrogate", "operator"})
 ALLOWED_CLASSIFICATIONS = frozenset({"exact", "approximate", "failed"})
 ALLOWED_DOMAIN_VALIDITIES = frozenset({"local", "global", "unknown"})
@@ -186,7 +192,7 @@ def _translation_generator_basis_spec() -> dict[str, Any]:
 
 @dataclass(slots=True)
 class FieldBatch:
-    schema_version: str = "0.1"
+    schema_version: str = "0.2"
     values: np.ndarray = None  # type: ignore[assignment]
     dims: tuple[str, ...] = ()
     coords: dict[str, np.ndarray] = None  # type: ignore[assignment]
@@ -195,7 +201,8 @@ class FieldBatch:
     preprocess_log: list[dict[str, Any]] = None  # type: ignore[assignment]
     mask: np.ndarray | None = None
 
-    SCHEMA_VERSION: ClassVar[str] = "0.1"
+    SCHEMA_VERSION: ClassVar[str] = "0.2"
+    LEGACY_SCHEMA_VERSIONS: ClassVar[frozenset[str]] = frozenset({"0.1"})
 
     def __post_init__(self) -> None:
         self.values = _to_numpy(self.values)
@@ -276,16 +283,89 @@ class FieldBatch:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "FieldBatch":
+        raw_schema_version = str(payload["schema_version"])
+        if (
+            raw_schema_version != cls.SCHEMA_VERSION
+            and raw_schema_version not in cls.LEGACY_SCHEMA_VERSIONS
+        ):
+            raise SchemaValidationError(
+                f"Unsupported FieldBatch schema_version {raw_schema_version!r}; "
+                f"supported: {cls.SCHEMA_VERSION!r} or one of "
+                f"{sorted(cls.LEGACY_SCHEMA_VERSIONS)}."
+            )
+
+        metadata = dict(payload["metadata"])
+        preprocess_log = [dict(item) for item in payload["preprocess_log"]]
+
+        if raw_schema_version != cls.SCHEMA_VERSION:
+            metadata, migration_entry = cls._migrate_legacy_metadata(
+                metadata, from_schema_version=raw_schema_version
+            )
+            if migration_entry is not None:
+                preprocess_log.append(migration_entry)
+
         return cls(
-            schema_version=str(payload["schema_version"]),
+            schema_version=cls.SCHEMA_VERSION,
             values=np.asarray(payload["values"], dtype=float),
             dims=tuple(payload["dims"]),
             coords={str(name): np.asarray(coord, dtype=float) for name, coord in payload["coords"].items()},
             var_names=[str(name) for name in payload["var_names"]],
-            metadata=dict(payload["metadata"]),
-            preprocess_log=[dict(item) for item in payload["preprocess_log"]],
+            metadata=metadata,
+            preprocess_log=preprocess_log,
             mask=None if payload.get("mask") is None else np.asarray(payload["mask"], dtype=bool),
         )
+
+    @classmethod
+    def _migrate_legacy_metadata(
+        cls,
+        metadata: dict[str, Any],
+        *,
+        from_schema_version: str,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        """Normalize a legacy `boundary_conditions['x']` string into the structured 0.2 form.
+
+        Returns the (possibly mutated) metadata dict and a single migration
+        provenance entry to append to `preprocess_log`, or `None` if no
+        normalization was needed.
+        """
+        migration_parameters: dict[str, Any] = {
+            "from_schema_version": from_schema_version,
+            "to_schema_version": cls.SCHEMA_VERSION,
+        }
+
+        bcs_raw = metadata.get("boundary_conditions")
+        if bcs_raw is None:
+            # Defensive: very old 0.1 payloads written before validate() enforced this key
+            # default to periodic for backwards compatibility.
+            metadata["boundary_conditions"] = {
+                "x": normalize_x_boundary_condition("periodic")
+            }
+            migration_parameters["default_x_boundary_string"] = "periodic"
+            migration_parameters["reason"] = (
+                "boundary_conditions missing in legacy payload; defaulted to periodic"
+            )
+            return metadata, {
+                "operation": LEGACY_BOUNDARY_NORMALIZATION_OPERATION,
+                "parameters": migration_parameters,
+            }
+
+        if not isinstance(bcs_raw, Mapping):
+            # Leave malformed input to downstream validate(); no migration entry.
+            return metadata, None
+
+        bcs_copy = dict(bcs_raw)
+        x_bc = bcs_copy.get("x")
+        if isinstance(x_bc, str):
+            bcs_copy["x"] = normalize_x_boundary_condition(x_bc)
+            metadata["boundary_conditions"] = bcs_copy
+            migration_parameters["legacy_x_boundary_string"] = x_bc
+            return metadata, {
+                "operation": LEGACY_BOUNDARY_NORMALIZATION_OPERATION,
+                "parameters": migration_parameters,
+            }
+
+        # Already structured (e.g. forward-compatible 0.1 payload writers): nothing to do.
+        return metadata, None
 
 
 @dataclass(slots=True)

--- a/src/pdelie/data/numpy_adapter.py
+++ b/src/pdelie/data/numpy_adapter.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
+from pdelie._boundary import get_x_boundary_type
 from pdelie.contracts import FieldBatch, REQUIRED_METADATA_KEYS, _is_uniform
 from pdelie.errors import SchemaValidationError, ScopeValidationError, ShapeValidationError
 
@@ -117,8 +118,11 @@ def _validate_metadata(value: object) -> dict[str, Any]:
         raise ScopeValidationError("from_numpy only supports uniform rectilinear grids.")
     if metadata["coordinate_system"] != "cartesian":
         raise ScopeValidationError("from_numpy only supports cartesian coordinates.")
-    if boundary_conditions["x"] != "periodic":
-        raise ScopeValidationError("from_numpy only supports periodic x boundary conditions.")
+    # Accept any supported boundary type (periodic, dirichlet, neumann, open_unknown).
+    # Unsupported strings or malformed structured specs are rejected by the helper.
+    # Derivative and residual support for non-periodic data is deferred to a later v0.30 milestone;
+    # the adapter constructs FieldBatch objects but downstream consumers still reject nonperiodic.
+    get_x_boundary_type({"boundary_conditions": boundary_conditions})
 
     return metadata
 

--- a/src/pdelie/data/xarray_adapter.py
+++ b/src/pdelie/data/xarray_adapter.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 
+from pdelie._boundary import get_x_boundary_type
 from pdelie.contracts import FieldBatch, REQUIRED_METADATA_KEYS, _is_uniform
 from pdelie.data.numpy_adapter import (
     _CANONICAL_DIMS,
@@ -111,8 +112,11 @@ def _validate_metadata(value: object) -> dict[str, Any]:
         raise ScopeValidationError("from_xarray only supports uniform rectilinear grids.")
     if metadata["coordinate_system"] != "cartesian":
         raise ScopeValidationError("from_xarray only supports cartesian coordinates.")
-    if boundary_conditions["x"] != "periodic":
-        raise ScopeValidationError("from_xarray only supports periodic x boundary conditions.")
+    # Accept any supported boundary type (periodic, dirichlet, neumann, open_unknown).
+    # Unsupported strings or malformed structured specs are rejected by the helper.
+    # Derivative and residual support for non-periodic data is deferred to a later v0.30 milestone;
+    # the adapter constructs FieldBatch objects but downstream consumers still reject nonperiodic.
+    get_x_boundary_type({"boundary_conditions": boundary_conditions})
 
     return metadata
 

--- a/src/pdelie/derivatives/__init__.py
+++ b/src/pdelie/derivatives/__init__.py
@@ -1,4 +1,80 @@
-from pdelie.derivatives.spectral_fd import compute_spectral_fd_derivatives
+from __future__ import annotations
 
-__all__ = ["compute_spectral_fd_derivatives"]
+from pdelie._boundary import is_x_periodic
+from pdelie.contracts import DerivativeBatch, FieldBatch
+from pdelie.derivatives.finite_difference import compute_finite_difference_derivatives
+from pdelie.derivatives.spectral_fd import compute_spectral_fd_derivatives
+from pdelie.errors import ScopeValidationError
+
+
+_ALLOWED_DERIVATIVE_BACKEND_NAMES = frozenset(
+    {"auto", "spectral_fd", "finite_difference"}
+)
+
+
+def compute_derivatives(
+    field: FieldBatch,
+    *,
+    backend: str = "auto",
+    max_spatial_order: int = 2,
+) -> DerivativeBatch:
+    """Backend-aware derivative dispatcher.
+
+    - ``backend="auto"``: choose ``spectral_fd`` for periodic data, ``finite_difference``
+      for any supported nonperiodic boundary type. The chosen backend always records
+      ``backend_selected_by_boundary_condition=True`` and a non-null
+      ``backend_selection_reason`` in ``DerivativeBatch.config`` so the selection is
+      auditable from the artifact itself.
+    - ``backend="spectral_fd"`` or ``backend="finite_difference"``: direct dispatch.
+      Mismatch between explicit backend and field BC raises ``ScopeValidationError``;
+      the dispatcher never silently falls back from one backend to the other.
+    - Unknown backend names raise ``ScopeValidationError``.
+
+    Both downstream backends require periodic / nonperiodic data respectively. The
+    dispatcher does not relax those requirements.
+    """
+    if not isinstance(backend, str) or backend not in _ALLOWED_DERIVATIVE_BACKEND_NAMES:
+        raise ScopeValidationError(
+            "compute_derivatives backend must be one of "
+            f"{sorted(_ALLOWED_DERIVATIVE_BACKEND_NAMES)}; got {backend!r}."
+        )
+
+    if backend == "auto":
+        if is_x_periodic(field):
+            selected_backend = "spectral_fd"
+            selection_reason = "periodic_x_uses_spectral_fd"
+        else:
+            selected_backend = "finite_difference"
+            selection_reason = "nonperiodic_x_uses_finite_difference"
+    else:
+        selected_backend = backend
+        selection_reason = None
+
+    if selected_backend == "spectral_fd":
+        derivatives = compute_spectral_fd_derivatives(
+            field, max_spatial_order=max_spatial_order
+        )
+    elif selected_backend == "finite_difference":
+        derivatives = compute_finite_difference_derivatives(
+            field, max_spatial_order=max_spatial_order
+        )
+    else:  # pragma: no cover — guarded by the allowed-set check above
+        raise ScopeValidationError(
+            f"compute_derivatives received an unsupported resolved backend: {selected_backend!r}."
+        )
+
+    if backend == "auto":
+        config = dict(derivatives.config)
+        config["backend_selected_by_boundary_condition"] = True
+        config["backend_selection_reason"] = selection_reason
+        derivatives.config = config
+
+    return derivatives
+
+
+__all__ = [
+    "compute_derivatives",
+    "compute_finite_difference_derivatives",
+    "compute_spectral_fd_derivatives",
+]
 

--- a/src/pdelie/derivatives/finite_difference.py
+++ b/src/pdelie/derivatives/finite_difference.py
@@ -1,0 +1,153 @@
+"""Nonperiodic low-order finite-difference derivative backend.
+
+v0.30c v1 surface: supports `u_t`, `u_x`, and `u_xx` only on scalar 1D
+nonperiodic uniform grids. Higher-order spatial derivatives on nonperiodic
+data are intentionally not part of the stable v0.30 surface — repeated
+``np.gradient`` propagates boundary error and quickly degrades by ``u_xxx``
+on typical 64-point grids. See `docs/design/DERIVATIVE_BACKEND_POLICY.md`.
+
+This backend never silently auto-routes periodic data. Periodic users must
+go through ``compute_spectral_fd_derivatives``; the
+``compute_derivatives(backend="auto")`` dispatcher in
+``pdelie.derivatives.__init__`` records which backend it chose and why.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from pdelie._boundary import get_x_boundary_type
+from pdelie.contracts import DerivativeBatch, FieldBatch
+from pdelie.errors import ScopeValidationError
+
+
+_SUPPORTED_X_BOUNDARY_TYPES = frozenset({"dirichlet", "neumann", "open_unknown"})
+_RECOMMENDED_RESIDUAL_DOMAIN_POLICY = "interior_only"
+_RECOMMENDED_BOUNDARY_TRIM_WIDTH = 4
+
+
+def _validate_max_spatial_order(max_spatial_order: object) -> int:
+    if isinstance(max_spatial_order, (bool, np.bool_)) or not isinstance(
+        max_spatial_order, (int, np.integer)
+    ):
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives max_spatial_order must be 1 or 2 in v0.30c."
+        )
+    normalized = int(max_spatial_order)
+    if normalized not in {1, 2}:
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives max_spatial_order must be 1 or 2 in v0.30c. "
+            "Higher orders on nonperiodic data are deferred."
+        )
+    return normalized
+
+
+def compute_finite_difference_derivatives(
+    field: FieldBatch,
+    *,
+    max_spatial_order: int = 2,
+) -> DerivativeBatch:
+    """Compute `u_t`, `u_x`, and (optionally) `u_xx` on a scalar 1D nonperiodic field.
+
+    Uses ``numpy.gradient`` with ``edge_order=2`` for both axes. Reject periodic data —
+    use ``compute_spectral_fd_derivatives`` for that path.
+
+    Field requirements:
+    - dims ``("batch", "time", "x", "var")``
+    - single scalar variable
+    - uniform x and uniform time, each with at least 3 points (edge_order=2 needs N>=3)
+    - boundary type ``dirichlet``, ``neumann``, or ``open_unknown``
+    """
+    normalized_max_spatial_order = _validate_max_spatial_order(max_spatial_order)
+    field.validate()
+
+    if field.dims != ("batch", "time", "x", "var"):
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives only supports dims ('batch', 'time', 'x', 'var') in v0.30c."
+        )
+    if len(field.var_names) != 1:
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives only supports a single scalar variable in v0.30c."
+        )
+
+    boundary_type = get_x_boundary_type(field)
+    if boundary_type == "periodic":
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives rejects periodic data. "
+            "Use compute_spectral_fd_derivatives or compute_derivatives(backend='auto') instead."
+        )
+    if boundary_type not in _SUPPORTED_X_BOUNDARY_TYPES:
+        raise ScopeValidationError(
+            f"compute_finite_difference_derivatives requires one of {sorted(_SUPPORTED_X_BOUNDARY_TYPES)}; "
+            f"got {boundary_type!r}."
+        )
+
+    x = field.coords["x"]
+    t = field.coords["time"]
+    if x.size < 3:
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives requires at least 3 x-points for edge_order=2."
+        )
+    if t.size < 3:
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives requires at least 3 time points for edge_order=2."
+        )
+
+    dx = float(x[1] - x[0])
+    dt = float(t[1] - t[0])
+    if not np.allclose(np.diff(x), dx, atol=1e-12, rtol=0.0):
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives requires a uniform x grid."
+        )
+    if not np.allclose(np.diff(t), dt, atol=1e-12, rtol=0.0):
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives requires a uniform time grid."
+        )
+    if dx <= 0.0 or dt <= 0.0:
+        raise ScopeValidationError(
+            "compute_finite_difference_derivatives requires strictly increasing x and time coordinates."
+        )
+
+    x_axis = field.dims.index("x")
+    t_axis = field.dims.index("time")
+    values = np.asarray(field.values, dtype=float)
+
+    u_t = np.gradient(values, dt, axis=t_axis, edge_order=2)
+    u_x = np.gradient(values, dx, axis=x_axis, edge_order=2)
+
+    derivative_arrays: dict[str, np.ndarray] = {
+        "u_t": np.asarray(u_t, dtype=float),
+        "u_x": np.asarray(u_x, dtype=float),
+    }
+    if normalized_max_spatial_order >= 2:
+        u_xx = np.gradient(u_x, dx, axis=x_axis, edge_order=2)
+        derivative_arrays["u_xx"] = np.asarray(u_xx, dtype=float)
+
+    config: dict[str, object] = {
+        "spatial_method": "finite_difference_centered",
+        "temporal_method": "finite_difference",
+        "stencil_edge_order": 2,
+        "spatial_max_order": int(normalized_max_spatial_order),
+        "boundary_handling": str(boundary_type),
+        "backend_selected_by_boundary_condition": False,
+        "backend_selection_reason": None,
+        "recommended_residual_domain_policy": _RECOMMENDED_RESIDUAL_DOMAIN_POLICY,
+        "recommended_boundary_trim_width": int(_RECOMMENDED_BOUNDARY_TRIM_WIDTH),
+    }
+
+    derivatives = DerivativeBatch(
+        derivatives=derivative_arrays,
+        backend="finite_difference",
+        config=config,
+        boundary_assumptions=f"{boundary_type} in x; finite differences in time",
+        diagnostics={
+            "dx": float(dx),
+            "dt": float(dt),
+            "x_points": int(x.size),
+            "time_points": int(t.size),
+        },
+    )
+    derivatives.validate_against(field)
+    return derivatives
+
+
+__all__ = ["compute_finite_difference_derivatives"]

--- a/src/pdelie/derivatives/spectral_fd.py
+++ b/src/pdelie/derivatives/spectral_fd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import DerivativeBatch, FieldBatch
 from pdelie.errors import ScopeValidationError
 
@@ -29,7 +30,7 @@ def compute_spectral_fd_derivatives(field: FieldBatch, *, max_spatial_order: int
         raise ScopeValidationError("spectral_fd only supports dims ('batch', 'time', 'x', 'var') in V0.1.")
     if len(field.var_names) != 1:
         raise ScopeValidationError("spectral_fd only supports a single variable in V0.1.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("spectral_fd requires periodic boundary conditions in x.")
 
     x = field.coords["x"]

--- a/src/pdelie/discovery/pysindy_bridge.py
+++ b/src/pdelie/discovery/pysindy_bridge.py
@@ -11,6 +11,7 @@ import importlib
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch
 from pdelie.errors import ScopeValidationError
 
@@ -24,7 +25,7 @@ def _validate_supported_field(field: FieldBatch) -> None:
         raise ScopeValidationError(
             "to_pysindy_trajectories only supports a single scalar variable in V0.3 Milestone 2."
         )
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("to_pysindy_trajectories requires periodic boundary conditions in x.")
 
 

--- a/src/pdelie/discovery/translation_canonical.py
+++ b/src/pdelie/discovery/translation_canonical.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch, GeneratorFamily, InvariantMapSpec
 from pdelie.discovery.pysindy_bridge import to_pysindy_trajectories
 from pdelie.errors import SchemaValidationError, ScopeValidationError
@@ -39,7 +40,7 @@ def _validate_supported_field(field: FieldBatch) -> None:
         raise ScopeValidationError(
             "build_translation_canonical_discovery_inputs only supports a single scalar variable in V0.6 Milestone 3."
         )
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError(
             "build_translation_canonical_discovery_inputs requires periodic boundary conditions in x."
         )

--- a/src/pdelie/invariants/apply.py
+++ b/src/pdelie/invariants/apply.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch, InvariantMapSpec
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 
@@ -13,7 +14,7 @@ def _validate_supported_field(field: FieldBatch) -> None:
         raise ScopeValidationError("InvariantApplier only supports dims ('batch', 'time', 'x', 'var') in V0.3 Milestone 1.")
     if len(field.var_names) != 1:
         raise ScopeValidationError("InvariantApplier only supports a single scalar variable in V0.3 Milestone 1.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("InvariantApplier requires periodic boundary conditions in x.")
 
 

--- a/src/pdelie/invariants/diagnostics.py
+++ b/src/pdelie/invariants/diagnostics.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import (
     FieldBatch,
     GeneratorFamily,
@@ -292,7 +293,7 @@ def _validate_consistency_field(
         raise ScopeValidationError(f"{api_name} requires dims ('batch', 'time', 'x', 'var').")
     if len(field.var_names) != 1:
         raise ScopeValidationError(f"{api_name} requires a scalar field.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError(f"{api_name} requires periodic x boundary conditions.")
     _, dx, domain_length, _ = _normalize_periodic_grid(field.coords["x"], domain_length=None)
     return dx, domain_length

--- a/src/pdelie/reporting/summaries.py
+++ b/src/pdelie/reporting/summaries.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 
+from pdelie._boundary import get_x_boundary_type, is_x_periodic
 from pdelie.contracts import (
     REQUIRED_METADATA_KEYS,
     DerivativeBatch,
@@ -38,6 +39,62 @@ _FIT_EVIDENCE_LABELS = frozenset(
 _CONFIDENCE_LABELS = frozenset({"strong", "qualified", "failed", "insufficient_evidence"})
 _CONFIDENCE_COMPONENT_STATUSES = frozenset({"passed", "warning", "failed", "not_configured", "unavailable"})
 _READINESS_LABELS = frozenset({"ready", "needs_attention", "not_ready"})
+_BOUNDARY_CONDITION_WARNING_KEYS = frozenset(
+    {
+        "x_boundary_legacy_string_under_schema_0_2",
+        "x_boundary_open_unknown",
+        "x_boundary_dirichlet_unspecified",
+        "x_boundary_neumann_unspecified",
+    }
+)
+
+
+def _x_boundary_warnings(metadata: object) -> list[str]:
+    """Return the v0.30c boundary_condition_warnings list for a FieldBatch/Dataset metadata.
+
+    Warnings, not failures: nonperiodic boundaries are accepted but signal that
+    downstream derivative and residual support is still strict-periodic.
+
+    Empty for periodic (legacy string or structured). Empty for malformed/missing
+    boundary metadata (those cases are reported separately by the metadata
+    failures list).
+    """
+    if not isinstance(metadata, Mapping):
+        return []
+    bcs = metadata.get("boundary_conditions")
+    if not isinstance(bcs, Mapping):
+        return []
+    x_bc = bcs.get("x")
+    try:
+        canonical = get_x_boundary_type({"boundary_conditions": bcs})
+    except (ScopeValidationError, SchemaValidationError):
+        return []
+
+    warnings: list[str] = []
+    if isinstance(x_bc, str):
+        # Legacy 0.1 string form embedded in a 0.2 FieldBatch; recommend structured form
+        # for any nonperiodic type (the structured form is the only way to record
+        # `specified=True` for dirichlet/neumann).
+        if canonical != "periodic":
+            warnings.append("x_boundary_legacy_string_under_schema_0_2")
+            if canonical == "open_unknown":
+                warnings.append("x_boundary_open_unknown")
+            elif canonical in {"dirichlet", "neumann"}:
+                warnings.append(f"x_boundary_{canonical}_unspecified")
+        return warnings
+
+    # Structured dict form
+    if canonical == "periodic":
+        return warnings
+    if canonical == "open_unknown":
+        warnings.append("x_boundary_open_unknown")
+        return warnings
+    if canonical in {"dirichlet", "neumann"}:
+        specified = x_bc.get("specified") if isinstance(x_bc, Mapping) else None
+        if specified is not True:
+            warnings.append(f"x_boundary_{canonical}_unspecified")
+        return warnings
+    return warnings  # pragma: no cover — guarded by get_x_boundary_type allowlist
 _SPLIT_LEAKAGE_RISK_LABELS = frozenset(
     {
         "no_detected_overlap",
@@ -762,8 +819,11 @@ def _readiness_metadata_status(
         failures.append("missing_required_metadata")
     if not isinstance(boundary_conditions, Mapping):
         failures.append("boundary_conditions_not_mapping")
-    elif boundary_conditions.get("x") != "periodic":
-        failures.append("x_boundary_not_periodic")
+    else:
+        try:
+            get_x_boundary_type({"boundary_conditions": boundary_conditions})
+        except (ScopeValidationError, SchemaValidationError):
+            failures.append("x_boundary_unsupported")
     if metadata.get("grid_type") != "rectilinear":
         failures.append("grid_type_not_rectilinear")
     if metadata.get("grid_regularity") != "uniform":
@@ -860,6 +920,10 @@ def summarize_field_batch_readiness(
     if label not in _READINESS_LABELS:
         raise AssertionError(f"unsupported readiness label: {label}")
 
+    boundary_condition_warnings = _x_boundary_warnings(field.metadata)
+    if boundary_condition_warnings and label == "ready":
+        label = "needs_attention"
+
     return _summary_payload(
         "field_batch_readiness",
         readiness_label=label,
@@ -871,6 +935,7 @@ def summarize_field_batch_readiness(
         metadata_diagnostics=metadata_diagnostics,
         metadata_suggestions=metadata_suggestions,
         residual_preflight=residual_preflight,
+        boundary_condition_warnings=boundary_condition_warnings,
         stable_scope={
             "dims": ["batch", "time", "x", "var"],
             "scalar_1d_periodic": True,
@@ -1055,8 +1120,11 @@ def _dataset_metadata_status(
         failures.append("missing_required_metadata")
     if not isinstance(boundary_conditions, Mapping):
         failures.append("boundary_conditions_not_mapping")
-    elif boundary_conditions.get("x") != "periodic":
-        failures.append("x_boundary_not_periodic")
+    else:
+        try:
+            get_x_boundary_type({"boundary_conditions": boundary_conditions})
+        except (ScopeValidationError, SchemaValidationError):
+            failures.append("x_boundary_unsupported")
     if normalized_metadata.get("grid_type") != "rectilinear":
         failures.append("grid_type_not_rectilinear")
     if normalized_metadata.get("grid_regularity") != "uniform":
@@ -1212,6 +1280,9 @@ def summarize_xarray_dataset_readiness(
         "conversion_preflight": conversion_status,
     }
     label = _readiness_label(component_statuses)
+    boundary_condition_warnings = _x_boundary_warnings(metadata)
+    if boundary_condition_warnings and label == "ready":
+        label = "needs_attention"
     payload = {
         "summary_schema_version": _SUMMARY_SCHEMA_VERSION,
         "summary_type": "xarray_dataset_readiness",
@@ -1230,6 +1301,7 @@ def summarize_xarray_dataset_readiness(
         "metadata_diagnostics": metadata_diagnostics,
         "metadata_suggestions": metadata_suggestions,
         "conversion_preflight": conversion_preflight,
+        "boundary_condition_warnings": boundary_condition_warnings,
         "stable_scope": {
             "dataset_input": True,
             "scalar_1d_periodic": True,
@@ -1245,6 +1317,16 @@ def summarize_residual_batch(residual: ResidualBatch) -> dict[str, Any]:
         raise SchemaValidationError("summarize_residual_batch requires a ResidualBatch.")
 
     residual_values = _require_finite(residual.residual, name="ResidualBatch.residual")
+
+    # v0.30c additive: surface a residual_domain_policy field if the evaluator (or any
+    # caller-supplied diagnostics) records one. Default is "not_configured" so the
+    # field is always present and strict-JSON serializable.
+    diagnostics = residual.diagnostics if isinstance(residual.diagnostics, Mapping) else {}
+    raw_policy = diagnostics.get("residual_domain_policy")
+    residual_domain_policy = (
+        str(raw_policy) if isinstance(raw_policy, str) and raw_policy else "not_configured"
+    )
+
     return _summary_payload(
         "residual_batch",
         residual_shape=list(residual_values.shape),
@@ -1252,6 +1334,7 @@ def summarize_residual_batch(residual: ResidualBatch) -> dict[str, Any]:
         normalization=residual.normalization,
         max_abs_residual=float(np.max(np.abs(residual_values))),
         rms_residual=float(np.sqrt(np.mean(np.square(residual_values)))),
+        residual_domain_policy=residual_domain_policy,
         diagnostics=residual.diagnostics,
     )
 

--- a/src/pdelie/residuals/advection_diffusion_1d.py
+++ b/src/pdelie/residuals/advection_diffusion_1d.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import DerivativeBatch, FieldBatch, ResidualBatch
 from pdelie.data.advection_diffusion_1d import DEFAULT_ADVECTION_DIFFUSION_EQUATION
 from pdelie.derivatives import compute_spectral_fd_derivatives
@@ -48,8 +49,7 @@ def _validate_advection_diffusion_field(field: FieldBatch) -> Mapping[str, objec
     if not np.all(np.isfinite(field.values)):
         raise ScopeValidationError("AdvectionDiffusionResidualEvaluator requires finite field values.")
 
-    boundary_conditions = field.metadata.get("boundary_conditions")
-    if not isinstance(boundary_conditions, Mapping) or boundary_conditions.get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("AdvectionDiffusionResidualEvaluator requires periodic boundary conditions in x.")
 
     parameter_tags = field.metadata.get("parameter_tags")

--- a/src/pdelie/residuals/kdv_1d.py
+++ b/src/pdelie/residuals/kdv_1d.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import DerivativeBatch, FieldBatch, ResidualBatch
 from pdelie.derivatives import compute_spectral_fd_derivatives
 from pdelie.errors import SchemaValidationError, ScopeValidationError
@@ -26,8 +27,7 @@ def _validate_kdv_field(field: FieldBatch) -> None:
     if not np.all(np.isfinite(field.values)):
         raise ScopeValidationError("KdVResidualEvaluator requires finite field values.")
 
-    boundary_conditions = field.metadata.get("boundary_conditions")
-    if not isinstance(boundary_conditions, Mapping) or boundary_conditions.get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("KdVResidualEvaluator requires periodic boundary conditions in x.")
 
     parameter_tags = field.metadata.get("parameter_tags")

--- a/src/pdelie/residuals/reaction_diffusion_1d.py
+++ b/src/pdelie/residuals/reaction_diffusion_1d.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import DerivativeBatch, FieldBatch, ResidualBatch
 from pdelie.data.reaction_diffusion_1d import DEFAULT_REACTION_DIFFUSION_EQUATION
 from pdelie.derivatives import compute_spectral_fd_derivatives
@@ -41,8 +42,7 @@ def _validate_reaction_diffusion_field(field: FieldBatch) -> Mapping[str, object
     if not np.all(np.isfinite(field.values)):
         raise ScopeValidationError("ReactionDiffusionResidualEvaluator requires finite field values.")
 
-    boundary_conditions = field.metadata.get("boundary_conditions")
-    if not isinstance(boundary_conditions, Mapping) or boundary_conditions.get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("ReactionDiffusionResidualEvaluator requires periodic boundary conditions in x.")
 
     parameter_tags = field.metadata.get("parameter_tags")

--- a/src/pdelie/residuals/weak_1d.py
+++ b/src/pdelie/residuals/weak_1d.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 
@@ -102,8 +103,7 @@ def _validate_supported_field(field: FieldBatch, *, function_name: str) -> tuple
     dt = _validate_strict_uniform_increasing_coordinate(time, name="time", function_name=function_name)
     dx = _validate_strict_uniform_increasing_coordinate(x, name="x", function_name=function_name)
 
-    boundary_conditions = field.metadata.get("boundary_conditions")
-    if not isinstance(boundary_conditions, Mapping) or boundary_conditions.get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError(f"{function_name} requires periodic boundary conditions in x.")
     return dt, dx
 

--- a/src/pdelie/symmetry/candidate_validation.py
+++ b/src/pdelie/symmetry/candidate_validation.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch, GeneratorFamily, InvariantMapSpec
 from pdelie.errors import PDELieValidationError, SchemaValidationError, ScopeValidationError
 from pdelie.invariants import InvariantApplier
@@ -67,7 +68,7 @@ def _validate_field(field: FieldBatch) -> None:
         raise ScopeValidationError("validate_symmetry_candidate requires dims ('batch', 'time', 'x', 'var').")
     if len(field.var_names) != 1:
         raise ScopeValidationError("validate_symmetry_candidate requires a scalar field.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("validate_symmetry_candidate requires periodic x boundary conditions.")
 
 

--- a/src/pdelie/symmetry/formula.py
+++ b/src/pdelie/symmetry/formula.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch, InvariantMapSpec
 from pdelie.errors import SchemaValidationError, ScopeValidationError
 
@@ -220,7 +221,7 @@ def _field_variables(field: FieldBatch) -> dict[str, np.ndarray]:
         raise ScopeValidationError("FormulaGeneratorFamily diagnostics require dims ('batch', 'time', 'x', 'var').")
     if len(field.var_names) != 1 or field.values.shape[-1] != 1:
         raise ScopeValidationError("FormulaGeneratorFamily diagnostics require a scalar field.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("FormulaGeneratorFamily diagnostics require periodic x boundary conditions.")
     if not np.all(np.isfinite(field.values)):
         raise ScopeValidationError("FormulaGeneratorFamily diagnostics require finite field values.")

--- a/src/pdelie/symmetry/parameterization/polynomial_translation.py
+++ b/src/pdelie/symmetry/parameterization/polynomial_translation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch
 from pdelie.errors import ScopeValidationError, ShapeValidationError
 
@@ -31,7 +32,7 @@ def build_translation_basis(field: FieldBatch) -> dict[str, np.ndarray]:
         raise ScopeValidationError("The stable translation basis only supports dims ('batch', 'time', 'x', 'var').")
     if len(field.var_names) != 1:
         raise ScopeValidationError("The stable translation basis only supports a single scalar variable.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("The stable translation basis requires periodic boundary conditions in x.")
 
     ones = np.ones_like(field.values)
@@ -79,7 +80,7 @@ def apply_pointwise_translation(field: FieldBatch, xi: np.ndarray, epsilon: floa
     xi = np.asarray(xi, dtype=float)
     if xi.shape != field.values.shape:
         raise ScopeValidationError("Pointwise translation xi must match the FieldBatch shape.")
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("Pointwise translation requires periodic boundary conditions in x.")
 
     x = field.coords["x"]

--- a/src/pdelie/verification/finite_transform.py
+++ b/src/pdelie/verification/finite_transform.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from pdelie._boundary import is_x_periodic
 from pdelie.contracts import FieldBatch, GeneratorFamily, VerificationReport
 from pdelie.errors import ScopeValidationError
 from pdelie.residuals.base import ResidualEvaluator
@@ -19,7 +20,7 @@ DEFAULT_RELATIVE_L2_NORM = "relative_l2"
 
 
 def _apply_uniform_translation(field: FieldBatch, shift: float) -> FieldBatch:
-    if field.metadata["boundary_conditions"].get("x") != "periodic":
+    if not is_x_periodic(field):
         raise ScopeValidationError("Uniform translation requires periodic boundary conditions in x.")
     x = field.coords["x"]
     dx = float(x[1] - x[0])

--- a/tests/test_boundary_condition_internal_usage.py
+++ b/tests/test_boundary_condition_internal_usage.py
@@ -1,0 +1,250 @@
+"""Tests for v0.30b internal boundary-condition usage policy.
+
+These tests verify three properties:
+
+1. Downstream periodic-only consumers (spectral_fd, translation basis,
+   weak_1d, finite-transform verification, etc.) still reject nonperiodic
+   inputs — preserving v0.29 behavior.
+
+2. The ingestion adapters (`from_numpy`, `from_xarray`) now accept structured
+   nonperiodic specs and supported legacy nonperiodic strings, but downstream
+   consumers continue to reject the resulting FieldBatch when they need
+   periodic data.
+
+3. No source file under `src/pdelie/` reintroduces a direct
+   `metadata["boundary_conditions"]["x"] == "periodic"` comparison outside the
+   `_boundary` helper module. New consumers must go through `is_x_periodic`
+   or `get_x_boundary_type`.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import pdelie
+from pdelie._boundary import normalize_x_boundary_condition
+from pdelie.data import from_numpy, generate_heat_1d_field_batch
+from pdelie.data.numpy_adapter import from_numpy as from_numpy_module_level
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import ScopeValidationError
+from pdelie.residuals import HeatResidualEvaluator, evaluate_weak_heat_residual
+from pdelie.symmetry.parameterization.polynomial_translation import build_translation_basis
+from pdelie.verification import verify_translation_generator
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src" / "pdelie"
+
+
+def _periodic_metadata(*, nu: float = 0.1) -> dict:
+    return {
+        "boundary_conditions": {"x": "periodic"},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {"nu": nu},
+    }
+
+
+def _nonperiodic_metadata(*, x_boundary: str | dict = "dirichlet", nu: float = 0.1) -> dict:
+    return {
+        "boundary_conditions": {"x": x_boundary},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {"nu": nu},
+    }
+
+
+def _make_nonperiodic_field(x_boundary: str | dict = "dirichlet"):
+    values = np.zeros((1, 4, 16), dtype=float)
+    t = np.linspace(0.0, 0.2, 4, dtype=float)
+    x = np.linspace(0.0, 1.0, 16, endpoint=False, dtype=float)
+    return from_numpy(
+        values,
+        dims=("batch", "time", "x"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(x_boundary=x_boundary),
+    )
+
+
+# --- Consumers still reject nonperiodic ---------------------------------
+
+
+def test_spectral_fd_still_rejects_nonperiodic() -> None:
+    field = _make_nonperiodic_field("dirichlet")
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        compute_spectral_fd_derivatives(field)
+
+
+def test_polynomial_translation_basis_still_rejects_nonperiodic() -> None:
+    field = _make_nonperiodic_field("dirichlet")
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        build_translation_basis(field)
+
+
+def test_weak_heat_residual_still_rejects_nonperiodic() -> None:
+    # Use a larger field so weak_1d's minimum-window constraints would have been satisfiable.
+    values = np.zeros((1, 8, 16), dtype=float)
+    t = np.linspace(0.0, 0.7, 8, dtype=float)
+    x = np.linspace(0.0, 1.0, 16, endpoint=False, dtype=float)
+    field = from_numpy(
+        values,
+        dims=("batch", "time", "x"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(x_boundary="dirichlet"),
+    )
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        evaluate_weak_heat_residual(field)
+
+
+def test_heat_residual_evaluator_still_rejects_nonperiodic_derivative_path() -> None:
+    """HeatResidualEvaluator computes derivatives via spectral_fd by default;
+    spectral_fd's periodic check propagates."""
+    field = _make_nonperiodic_field("dirichlet")
+    evaluator = HeatResidualEvaluator(diffusivity=0.1)
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        evaluator.evaluate(field)
+
+
+def test_finite_transform_verification_still_rejects_nonperiodic() -> None:
+    # Build a periodic generator on a periodic field
+    periodic = generate_heat_1d_field_batch(batch_size=3, num_times=5, num_points=16, seed=0)
+    from pdelie.symmetry import fit_translation_generator
+
+    generator = fit_translation_generator(periodic, HeatResidualEvaluator())
+    # Make the heldout-target field large enough to pass the size precheck so the
+    # BC rejection is what surfaces.
+    values = np.zeros((3, 4, 16), dtype=float)
+    t = np.linspace(0.0, 0.2, 4, dtype=float)
+    x = np.linspace(0.0, 1.0, 16, endpoint=False, dtype=float)
+    nonperiodic = from_numpy(
+        values,
+        dims=("batch", "time", "x"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(x_boundary="dirichlet"),
+    )
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        verify_translation_generator(nonperiodic, generator, HeatResidualEvaluator())
+
+
+# --- Adapters accept structured nonperiodic --------------------------------
+
+
+def test_from_numpy_accepts_structured_dirichlet_spec() -> None:
+    structured = normalize_x_boundary_condition({
+        "type": "dirichlet",
+        "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"},
+        "right": {"value": 1.0, "time_dependent": False, "source": "user_supplied"},
+    })
+    field = _make_nonperiodic_field(x_boundary=structured)
+    bc = field.metadata["boundary_conditions"]["x"]
+    assert bc["type"] == "dirichlet"
+    assert bc["specified"] is True
+
+
+def test_from_numpy_accepts_legacy_dirichlet_string() -> None:
+    field = _make_nonperiodic_field(x_boundary="dirichlet")
+    # The legacy string is preserved in metadata (not auto-normalized) for adapter outputs.
+    assert field.metadata["boundary_conditions"]["x"] == "dirichlet"
+
+
+def test_from_numpy_accepts_open_unknown() -> None:
+    field = _make_nonperiodic_field(x_boundary="open_unknown")
+    assert field.metadata["boundary_conditions"]["x"] == "open_unknown"
+
+
+def test_from_numpy_rejects_unsupported_string() -> None:
+    values = np.zeros((1, 4, 16), dtype=float)
+    t = np.linspace(0.0, 0.2, 4, dtype=float)
+    x = np.linspace(0.0, 1.0, 16, endpoint=False, dtype=float)
+    with pytest.raises(ScopeValidationError, match="Unsupported x boundary string"):
+        from_numpy(
+            values,
+            dims=("batch", "time", "x"),
+            coords={"time": t, "x": x},
+            var_name="u",
+            metadata=_nonperiodic_metadata(x_boundary="insulating"),
+        )
+
+
+# --- Static guard: no new direct periodic compares -----------------------
+
+
+_ALLOWED_DIRECT_PERIODIC_COMPARE_FILES: frozenset[str] = frozenset({
+    # _boundary itself is the central helper; it canonically encodes "periodic".
+    str(_SRC_ROOT / "_boundary.py"),
+    # PDE data generators set "boundary_conditions": {"x": "periodic"} on output
+    # (this is assignment, not comparison, but the regex below is liberal — the
+    # assignment form is still allowed).
+    str(_SRC_ROOT / "data" / "heat_1d.py"),
+    str(_SRC_ROOT / "data" / "burgers_1d.py"),
+    str(_SRC_ROOT / "data" / "kdv_1d.py"),
+    str(_SRC_ROOT / "data" / "reaction_diffusion_1d.py"),
+    str(_SRC_ROOT / "data" / "advection_diffusion_1d.py"),
+    # v0.30c: reporting/summaries.py now goes through get_x_boundary_type for
+    # the readiness checks; the only "periodic" literal there is the
+    # metadata_suggestions output dict and the boundary-warnings vocabulary,
+    # neither of which is a direct compare. No allowlist entry needed.
+})
+
+
+_DIRECT_COMPARE_PATTERN = re.compile(
+    r'boundary_conditions[^=]*\.\s*get\s*\(\s*["\']x["\']\s*\)\s*!=\s*["\']periodic["\']'
+    r'|boundary_conditions\s*\[\s*["\']x["\']\s*\]\s*(==|!=)\s*["\']periodic["\']'
+)
+
+
+def test_no_new_direct_periodic_compares_outside_boundary_helper() -> None:
+    """Any direct `metadata['boundary_conditions']['x'] != 'periodic'` style check
+    must be replaced by `is_x_periodic`/`get_x_boundary_type` from `pdelie._boundary`."""
+    violations: list[str] = []
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if _DIRECT_COMPARE_PATTERN.search(text):
+            if str(path) not in _ALLOWED_DIRECT_PERIODIC_COMPARE_FILES:
+                violations.append(str(path.relative_to(_REPO_ROOT)))
+    assert violations == [], (
+        "v0.30b policy: new sites must use is_x_periodic() / get_x_boundary_type() "
+        "from pdelie._boundary. Direct compares found in: " + ", ".join(violations)
+    )
+
+
+def test_boundary_helper_module_is_imported_by_all_runtime_consumers() -> None:
+    """Each module that previously did direct `!= 'periodic'` checks now imports
+    from pdelie._boundary to demonstrate the migration."""
+    must_import_helper = [
+        _SRC_ROOT / "derivatives" / "spectral_fd.py",
+        _SRC_ROOT / "derivatives" / "finite_difference.py",  # v0.30c
+        _SRC_ROOT / "derivatives" / "__init__.py",  # v0.30c dispatcher
+        _SRC_ROOT / "residuals" / "weak_1d.py",
+        _SRC_ROOT / "residuals" / "kdv_1d.py",
+        _SRC_ROOT / "residuals" / "reaction_diffusion_1d.py",
+        _SRC_ROOT / "residuals" / "advection_diffusion_1d.py",
+        _SRC_ROOT / "discovery" / "translation_canonical.py",
+        _SRC_ROOT / "discovery" / "pysindy_bridge.py",
+        _SRC_ROOT / "invariants" / "diagnostics.py",
+        _SRC_ROOT / "invariants" / "apply.py",
+        _SRC_ROOT / "symmetry" / "formula.py",
+        _SRC_ROOT / "symmetry" / "candidate_validation.py",
+        _SRC_ROOT / "symmetry" / "parameterization" / "polynomial_translation.py",
+        _SRC_ROOT / "verification" / "finite_transform.py",
+        _SRC_ROOT / "data" / "numpy_adapter.py",
+        _SRC_ROOT / "data" / "xarray_adapter.py",
+        _SRC_ROOT / "reporting" / "summaries.py",  # v0.30c
+    ]
+    missing = []
+    for path in must_import_helper:
+        text = path.read_text(encoding="utf-8")
+        if "from pdelie._boundary import" not in text:
+            missing.append(str(path.relative_to(_REPO_ROOT)))
+    assert missing == [], (
+        "v0.30b consumers must import the boundary helper. Missing in: "
+        + ", ".join(missing)
+    )

--- a/tests/test_boundary_condition_spec.py
+++ b/tests/test_boundary_condition_spec.py
@@ -1,0 +1,246 @@
+"""Tests for the v0.30b BoundaryConditionSpec helpers."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pdelie._boundary import (
+    ALLOWED_BOUNDARY_FACE_SOURCES,
+    ALLOWED_X_BOUNDARY_TYPES,
+    BoundaryConditionSpec,
+    BoundaryFace,
+    get_x_boundary_type,
+    is_x_periodic,
+    normalize_x_boundary_condition,
+)
+from pdelie.errors import SchemaValidationError, ScopeValidationError
+
+
+# --- normalize_x_boundary_condition --------------------------------------
+
+
+def test_normalize_legacy_periodic_string_yields_structured_periodic() -> None:
+    result = normalize_x_boundary_condition("periodic")
+    assert result["type"] == "periodic"
+    assert result["left"] is None
+    assert result["right"] is None
+    assert result["specified"] is True
+
+
+def test_normalize_legacy_open_string_renames_to_open_unknown() -> None:
+    result = normalize_x_boundary_condition("open")
+    assert result["type"] == "open_unknown"
+    assert result["left"] is None
+    assert result["right"] is None
+    assert result["specified"] is False
+    assert "normalized from legacy 0.1 string" in result["notes"]
+
+
+def test_normalize_legacy_open_unknown_string_yields_open_unknown() -> None:
+    result = normalize_x_boundary_condition("open_unknown")
+    assert result["type"] == "open_unknown"
+    assert result["specified"] is False
+
+
+def test_normalize_legacy_dirichlet_string_marks_specified_false() -> None:
+    """The library never invents boundary values: legacy "dirichlet" → specified=False."""
+    result = normalize_x_boundary_condition("dirichlet")
+    assert result["type"] == "dirichlet"
+    assert result["specified"] is False
+    for face in (result["left"], result["right"]):
+        assert face["value"] is None
+        assert face["source"] == "inferred_unspecified"
+
+
+def test_normalize_legacy_neumann_string_marks_specified_false() -> None:
+    result = normalize_x_boundary_condition("neumann")
+    assert result["type"] == "neumann"
+    assert result["specified"] is False
+
+
+def test_normalize_rejects_unsupported_legacy_string() -> None:
+    with pytest.raises(ScopeValidationError, match="Unsupported x boundary string"):
+        normalize_x_boundary_condition("insulating")
+
+
+def test_normalize_rejects_non_string_non_mapping() -> None:
+    for bad_value in (42, 3.14, True, None, ["periodic"]):
+        with pytest.raises(SchemaValidationError):
+            normalize_x_boundary_condition(bad_value)
+
+
+def test_normalize_structured_periodic_round_trips() -> None:
+    structured = {
+        "type": "periodic",
+        "left": None,
+        "right": None,
+        "specified": True,
+        "notes": None,
+    }
+    result = normalize_x_boundary_condition(structured)
+    assert result["type"] == "periodic"
+    assert result["specified"] is True
+
+
+def test_normalize_structured_dirichlet_with_user_values_marks_specified_true() -> None:
+    structured = {
+        "type": "dirichlet",
+        "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"},
+        "right": {"value": 1.0, "time_dependent": False, "source": "user_supplied"},
+    }
+    result = normalize_x_boundary_condition(structured)
+    assert result["type"] == "dirichlet"
+    assert result["specified"] is True
+    assert result["left"]["value"] == 0.0
+    assert result["right"]["value"] == 1.0
+
+
+def test_normalize_structured_dirichlet_without_values_marks_specified_false() -> None:
+    structured = {
+        "type": "dirichlet",
+        "left": {"value": None, "time_dependent": False, "source": "inferred_unspecified"},
+        "right": {"value": None, "time_dependent": False, "source": "inferred_unspecified"},
+    }
+    result = normalize_x_boundary_condition(structured)
+    assert result["specified"] is False
+
+
+def test_normalize_structured_periodic_rejects_left_or_right_face() -> None:
+    bad = {"type": "periodic", "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"}, "right": None}
+    with pytest.raises(SchemaValidationError, match="Periodic boundary spec"):
+        normalize_x_boundary_condition(bad)
+
+
+def test_normalize_structured_open_unknown_rejects_faces() -> None:
+    bad = {
+        "type": "open_unknown",
+        "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"},
+        "right": None,
+    }
+    with pytest.raises(SchemaValidationError, match="open_unknown"):
+        normalize_x_boundary_condition(bad)
+
+
+def test_normalize_rejects_unsupported_type_key() -> None:
+    with pytest.raises(ScopeValidationError, match="BoundaryConditionSpec.type"):
+        normalize_x_boundary_condition({"type": "robin"})
+
+
+# --- BoundaryFace dataclass ----------------------------------------------
+
+
+def test_boundary_face_to_dict_and_from_dict_round_trip() -> None:
+    face = BoundaryFace(value=2.5, time_dependent=False, source="user_supplied")
+    payload = face.to_dict()
+    assert payload == {"value": 2.5, "time_dependent": False, "source": "user_supplied"}
+    rebuilt = BoundaryFace.from_dict(payload)
+    assert rebuilt == face
+
+
+def test_boundary_face_accepts_none_value() -> None:
+    face = BoundaryFace(value=None, time_dependent=False, source="inferred_unspecified")
+    payload = face.to_dict()
+    assert payload["value"] is None
+    rebuilt = BoundaryFace.from_dict(payload)
+    assert rebuilt.value is None
+
+
+def test_boundary_face_rejects_non_finite_value() -> None:
+    with pytest.raises(SchemaValidationError, match="finite"):
+        BoundaryFace.from_dict({"value": float("inf"), "time_dependent": False, "source": "user_supplied"})
+
+
+def test_boundary_face_rejects_unknown_source() -> None:
+    with pytest.raises(SchemaValidationError, match="BoundaryFace.source"):
+        BoundaryFace.from_dict({"value": 0.0, "time_dependent": False, "source": "guessed"})
+
+
+# --- BoundaryConditionSpec dataclass --------------------------------------
+
+
+def test_boundary_condition_spec_to_dict_and_from_dict_round_trip() -> None:
+    face = BoundaryFace(value=0.0, time_dependent=False, source="user_supplied")
+    spec = BoundaryConditionSpec(
+        type="dirichlet", left=face, right=face, specified=True, notes="test"
+    )
+    payload = spec.to_dict()
+    rebuilt = BoundaryConditionSpec.from_dict(payload)
+    assert rebuilt == spec
+
+
+# --- get_x_boundary_type / is_x_periodic ----------------------------------
+
+
+def test_get_x_boundary_type_accepts_legacy_string_and_returns_canonical() -> None:
+    for legacy, canonical in (
+        ("periodic", "periodic"),
+        ("dirichlet", "dirichlet"),
+        ("neumann", "neumann"),
+        ("open", "open_unknown"),
+        ("open_unknown", "open_unknown"),
+    ):
+        metadata = {"boundary_conditions": {"x": legacy}}
+        assert get_x_boundary_type(metadata) == canonical
+
+
+def test_get_x_boundary_type_accepts_structured_dict() -> None:
+    metadata = {"boundary_conditions": {"x": {"type": "dirichlet", "specified": False}}}
+    assert get_x_boundary_type(metadata) == "dirichlet"
+
+
+def test_get_x_boundary_type_accepts_field_like_object_with_metadata_attr() -> None:
+    class _Stub:
+        metadata = {"boundary_conditions": {"x": "periodic"}}
+
+    assert get_x_boundary_type(_Stub()) == "periodic"
+
+
+def test_get_x_boundary_type_rejects_unsupported_string() -> None:
+    metadata = {"boundary_conditions": {"x": "robin"}}
+    with pytest.raises(ScopeValidationError, match="Unsupported x boundary string"):
+        get_x_boundary_type(metadata)
+
+
+def test_get_x_boundary_type_rejects_unsupported_structured_type() -> None:
+    metadata = {"boundary_conditions": {"x": {"type": "robin"}}}
+    with pytest.raises(ScopeValidationError, match="BoundaryConditionSpec.type"):
+        get_x_boundary_type(metadata)
+
+
+def test_get_x_boundary_type_rejects_malformed_metadata() -> None:
+    with pytest.raises(SchemaValidationError):
+        get_x_boundary_type({"boundary_conditions": "periodic"})
+    with pytest.raises(SchemaValidationError):
+        get_x_boundary_type({"boundary_conditions": {"x": 42}})
+
+
+def test_is_x_periodic_returns_true_for_legacy_and_structured_periodic() -> None:
+    assert is_x_periodic({"boundary_conditions": {"x": "periodic"}}) is True
+    assert is_x_periodic({"boundary_conditions": {"x": {"type": "periodic", "left": None, "right": None, "specified": True}}}) is True
+
+
+def test_is_x_periodic_returns_false_for_supported_nonperiodic() -> None:
+    for non_periodic in ("dirichlet", "neumann", "open", "open_unknown"):
+        assert is_x_periodic({"boundary_conditions": {"x": non_periodic}}) is False
+
+
+# --- strict JSON ---------------------------------------------------------
+
+
+def test_normalize_output_is_strict_json_compatible() -> None:
+    for x_bc in ("periodic", "dirichlet", "neumann", "open_unknown"):
+        result = normalize_x_boundary_condition(x_bc)
+        # Strict round-trip with allow_nan=False is the project's reporting discipline.
+        assert json.loads(json.dumps(result, allow_nan=False)) == result
+
+
+def test_allowed_constants_are_frozen_and_match_documented_set() -> None:
+    assert isinstance(ALLOWED_X_BOUNDARY_TYPES, frozenset)
+    assert ALLOWED_X_BOUNDARY_TYPES == frozenset(
+        {"periodic", "dirichlet", "neumann", "open_unknown"}
+    )
+    assert isinstance(ALLOWED_BOUNDARY_FACE_SOURCES, frozenset)
+    assert ALLOWED_BOUNDARY_FACE_SOURCES == frozenset(
+        {"user_supplied", "default", "inferred_unspecified"}
+    )

--- a/tests/test_boundary_readiness_reporting.py
+++ b/tests/test_boundary_readiness_reporting.py
@@ -1,0 +1,191 @@
+"""Tests for v0.30c boundary-aware readiness and reporting."""
+from __future__ import annotations
+
+import json
+import copy
+
+import numpy as np
+import pytest
+
+from pdelie._boundary import normalize_x_boundary_condition
+from pdelie.data import from_numpy, generate_heat_1d_field_batch
+from pdelie.errors import ScopeValidationError
+from pdelie.reporting import (
+    summarize_field_batch_readiness,
+    summarize_residual_batch,
+)
+from pdelie.residuals import HeatResidualEvaluator
+
+
+def _nonperiodic_metadata(*, x_boundary):
+    return {
+        "boundary_conditions": {"x": x_boundary},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {},
+    }
+
+
+def _nonperiodic_field(x_boundary):
+    n_t, n_x = 9, 16
+    t = np.linspace(0.0, 1.0, n_t, dtype=float)
+    x = np.linspace(0.0, 1.0, n_x, dtype=float)
+    values = np.zeros((1, n_t, n_x, 1), dtype=float)
+    return from_numpy(
+        values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(x_boundary=x_boundary),
+    )
+
+
+# --- summarize_field_batch_readiness boundary_condition_warnings ------------
+
+
+def test_periodic_legacy_string_has_no_boundary_warnings() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=0)
+    summary = summarize_field_batch_readiness(field)
+    assert summary["boundary_condition_warnings"] == []
+    assert summary["readiness_label"] == "ready"
+
+
+def test_periodic_structured_has_no_boundary_warnings() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=1)
+    field = copy.copy(field)
+    field.metadata = copy.deepcopy(field.metadata)
+    field.metadata["boundary_conditions"] = {"x": normalize_x_boundary_condition("periodic")}
+    summary = summarize_field_batch_readiness(field)
+    assert summary["boundary_condition_warnings"] == []
+
+
+def test_legacy_dirichlet_string_emits_legacy_and_unspecified_warnings() -> None:
+    field = _nonperiodic_field("dirichlet")
+    summary = summarize_field_batch_readiness(field)
+    warnings = summary["boundary_condition_warnings"]
+    assert "x_boundary_legacy_string_under_schema_0_2" in warnings
+    assert "x_boundary_dirichlet_unspecified" in warnings
+    assert summary["readiness_label"] == "needs_attention"
+
+
+def test_legacy_neumann_string_emits_neumann_unspecified_warning() -> None:
+    field = _nonperiodic_field("neumann")
+    summary = summarize_field_batch_readiness(field)
+    assert "x_boundary_neumann_unspecified" in summary["boundary_condition_warnings"]
+
+
+def test_legacy_open_unknown_string_emits_open_unknown_warning() -> None:
+    field = _nonperiodic_field("open_unknown")
+    summary = summarize_field_batch_readiness(field)
+    assert "x_boundary_open_unknown" in summary["boundary_condition_warnings"]
+    assert summary["readiness_label"] == "needs_attention"
+
+
+def test_structured_dirichlet_unspecified_emits_unspecified_warning() -> None:
+    spec = normalize_x_boundary_condition("dirichlet")
+    field = _nonperiodic_field(spec)
+    summary = summarize_field_batch_readiness(field)
+    warnings = summary["boundary_condition_warnings"]
+    assert "x_boundary_dirichlet_unspecified" in warnings
+    # No legacy-string warning when the BC is structured.
+    assert "x_boundary_legacy_string_under_schema_0_2" not in warnings
+
+
+def test_structured_dirichlet_with_user_values_has_no_unspecified_warning() -> None:
+    spec = normalize_x_boundary_condition({
+        "type": "dirichlet",
+        "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"},
+        "right": {"value": 1.0, "time_dependent": False, "source": "user_supplied"},
+    })
+    field = _nonperiodic_field(spec)
+    summary = summarize_field_batch_readiness(field)
+    warnings = summary["boundary_condition_warnings"]
+    # Specified=True ⇒ no "_unspecified" warning, and no legacy-string warning.
+    assert "x_boundary_dirichlet_unspecified" not in warnings
+    assert "x_boundary_legacy_string_under_schema_0_2" not in warnings
+    # Readiness is at most "needs_attention" — but for fully-specified dirichlet there's no warning at all,
+    # so the label stays "ready" (the warning system only downgrades when warnings exist).
+    # Other failures could still downgrade the field; the assertion below holds only for this minimal field.
+    assert summary["boundary_condition_warnings"] == []
+
+
+def test_structured_open_unknown_emits_open_warning() -> None:
+    spec = normalize_x_boundary_condition("open_unknown")
+    field = _nonperiodic_field(spec)
+    summary = summarize_field_batch_readiness(field)
+    assert "x_boundary_open_unknown" in summary["boundary_condition_warnings"]
+
+
+# --- readiness label downgrade ---------------------------------------------
+
+
+def test_nonperiodic_downgrades_ready_to_needs_attention() -> None:
+    field = _nonperiodic_field("dirichlet")
+    summary = summarize_field_batch_readiness(field)
+    assert summary["readiness_label"] == "needs_attention"
+    # Metadata itself is now considered "passed" — nonperiodic is not a failure.
+    assert summary["component_statuses"]["metadata"]["status"] == "passed"
+
+
+def test_other_failures_still_route_to_not_ready_regardless_of_boundary() -> None:
+    """A non-finite value remains a hard failure; the boundary warning does not soften it."""
+    field = _nonperiodic_field("dirichlet")
+    field.values[0, 0, 0, 0] = np.nan
+    summary = summarize_field_batch_readiness(field)
+    assert summary["readiness_label"] == "not_ready"
+
+
+# --- strict JSON ------------------------------------------------------------
+
+
+def test_field_batch_readiness_summary_is_strict_json_compatible() -> None:
+    field = _nonperiodic_field("dirichlet")
+    summary = summarize_field_batch_readiness(field)
+    assert json.loads(json.dumps(summary, allow_nan=False)) == summary
+
+
+# --- summarize_residual_batch.residual_domain_policy -----------------------
+
+
+def test_residual_batch_summary_records_not_configured_when_policy_absent() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=2)
+    residual = HeatResidualEvaluator().evaluate(field)
+    summary = summarize_residual_batch(residual)
+    assert summary["residual_domain_policy"] == "not_configured"
+
+
+def test_residual_batch_summary_passes_through_supplied_policy() -> None:
+    """A caller (or a future v0.30+ residual evaluator) can record the policy in
+    `residual.diagnostics`; the summary surfaces it verbatim."""
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=3)
+    residual = HeatResidualEvaluator().evaluate(field)
+    residual.diagnostics["residual_domain_policy"] = "interior_only"
+    summary = summarize_residual_batch(residual)
+    assert summary["residual_domain_policy"] == "interior_only"
+
+
+def test_residual_batch_summary_remains_strict_json_compatible() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=4)
+    residual = HeatResidualEvaluator().evaluate(field)
+    summary = summarize_residual_batch(residual)
+    assert json.loads(json.dumps(summary, allow_nan=False)) == summary
+
+
+# --- malformed metadata still routes to failure -----------------------------
+
+
+def test_unsupported_boundary_string_routes_to_metadata_failure() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=9, num_points=16, seed=5)
+    field = copy.copy(field)
+    field.metadata = copy.deepcopy(field.metadata)
+    field.metadata["boundary_conditions"] = {"x": "insulating"}
+    summary = summarize_field_batch_readiness(field)
+    # Unsupported BC strings are reported as a hard failure, not as a soft warning.
+    assert summary["readiness_label"] in {"needs_attention", "not_ready"}
+    failures = summary["metadata_diagnostics"].get("missing_keys", [])
+    component_failures = summary["component_statuses"]["metadata"]
+    # Either a metadata failure or an x_boundary_unsupported entry should appear.
+    if component_failures["status"] == "failed":
+        details = component_failures.get("details", {})
+        assert "x_boundary_unsupported" in details.get("failures", []) or failures

--- a/tests/test_data_numpy_adapter.py
+++ b/tests/test_data_numpy_adapter.py
@@ -270,14 +270,32 @@ def test_from_numpy_rejects_missing_or_invalid_metadata(
         )
 
 
-def test_from_numpy_rejects_non_periodic_x_boundary_condition() -> None:
-    with pytest.raises(ScopeValidationError, match="periodic x boundary conditions"):
+def test_from_numpy_accepts_supported_non_periodic_x_boundary_conditions() -> None:
+    """v0.30b: from_numpy accepts dirichlet/neumann/open_unknown structured BC inputs.
+
+    Derivative/residual support for nonperiodic data lands in later v0.30 milestones;
+    downstream consumers (spectral_fd, residuals, weak_1d) still reject nonperiodic.
+    """
+    for x_boundary in ("dirichlet", "neumann", "open_unknown"):
+        field = from_numpy(
+            np.zeros((4, 8), dtype=float),
+            dims=("time", "x"),
+            coords={"time": _time(), "x": _x()},
+            var_name="u",
+            metadata=_metadata(x_boundary=x_boundary),
+        )
+        # The legacy string is preserved in metadata; consumers use the is_x_periodic helper.
+        assert field.metadata["boundary_conditions"]["x"] == x_boundary
+
+
+def test_from_numpy_rejects_unsupported_x_boundary_string() -> None:
+    with pytest.raises(ScopeValidationError, match="Unsupported x boundary string"):
         from_numpy(
             np.zeros((4, 8), dtype=float),
             dims=("time", "x"),
             coords={"time": _time(), "x": _x()},
             var_name="u",
-            metadata=_metadata(x_boundary="dirichlet"),
+            metadata=_metadata(x_boundary="insulating"),
         )
 
 

--- a/tests/test_data_xarray_adapter.py
+++ b/tests/test_data_xarray_adapter.py
@@ -350,11 +350,31 @@ def test_from_xarray_rejects_missing_or_invalid_metadata(
         from_xarray(data_array, metadata=metadata)
 
 
-def test_from_xarray_rejects_non_periodic_x_boundary_condition() -> None:
-    data_array = xr.DataArray(np.zeros((4, 8), dtype=float), dims=("time", "x"), coords={"time": _time(), "x": _x()}, name="u")
+def test_from_xarray_accepts_supported_non_periodic_x_boundary_conditions() -> None:
+    """v0.30b: from_xarray accepts dirichlet/neumann/open_unknown BC inputs.
 
-    with pytest.raises(ScopeValidationError, match="periodic x boundary conditions"):
-        from_xarray(data_array, metadata=_metadata(x_boundary="dirichlet"))
+    Downstream consumers still reject nonperiodic; v0.30b only loosens ingestion.
+    """
+    data_array = xr.DataArray(
+        np.zeros((4, 8), dtype=float),
+        dims=("time", "x"),
+        coords={"time": _time(), "x": _x()},
+        name="u",
+    )
+    for x_boundary in ("dirichlet", "neumann", "open_unknown"):
+        field = from_xarray(data_array, metadata=_metadata(x_boundary=x_boundary))
+        assert field.metadata["boundary_conditions"]["x"] == x_boundary
+
+
+def test_from_xarray_rejects_unsupported_x_boundary_string() -> None:
+    data_array = xr.DataArray(
+        np.zeros((4, 8), dtype=float),
+        dims=("time", "x"),
+        coords={"time": _time(), "x": _x()},
+        name="u",
+    )
+    with pytest.raises(ScopeValidationError, match="Unsupported x boundary string"):
+        from_xarray(data_array, metadata=_metadata(x_boundary="insulating"))
 
 
 def test_from_xarray_ignores_attrs_for_metadata() -> None:

--- a/tests/test_derivative_dispatcher.py
+++ b/tests/test_derivative_dispatcher.py
@@ -1,0 +1,145 @@
+"""Tests for the v0.30c `compute_derivatives` backend dispatcher."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pdelie.data import from_numpy, generate_heat_1d_field_batch
+from pdelie.derivatives import compute_derivatives
+from pdelie.errors import ScopeValidationError
+
+
+def _nonperiodic_metadata(*, x_boundary: str = "dirichlet") -> dict:
+    return {
+        "boundary_conditions": {"x": x_boundary},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {},
+    }
+
+
+def _nonperiodic_field(*, x_boundary: str = "dirichlet"):
+    n_t, n_x = 9, 16
+    t = np.linspace(0.0, 1.0, n_t, dtype=float)
+    x = np.linspace(0.0, 1.0, n_x, dtype=float)
+    values = np.zeros((1, n_t, n_x, 1), dtype=float)
+    return from_numpy(
+        values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(x_boundary=x_boundary),
+    )
+
+
+# --- backend="auto" path -----------------------------------------------------
+
+
+def test_auto_on_periodic_routes_to_spectral_fd_and_records_reason() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=0)
+    d = compute_derivatives(field, backend="auto", max_spatial_order=2)
+    assert d.backend == "spectral_fd"
+    assert d.config["backend_selected_by_boundary_condition"] is True
+    assert d.config["backend_selection_reason"] == "periodic_x_uses_spectral_fd"
+
+
+def test_auto_on_dirichlet_routes_to_finite_difference_and_records_reason() -> None:
+    field = _nonperiodic_field(x_boundary="dirichlet")
+    d = compute_derivatives(field, backend="auto", max_spatial_order=2)
+    assert d.backend == "finite_difference"
+    assert d.config["backend_selected_by_boundary_condition"] is True
+    assert d.config["backend_selection_reason"] == "nonperiodic_x_uses_finite_difference"
+
+
+def test_auto_on_neumann_routes_to_finite_difference() -> None:
+    field = _nonperiodic_field(x_boundary="neumann")
+    d = compute_derivatives(field, backend="auto")
+    assert d.backend == "finite_difference"
+    assert d.config["backend_selection_reason"] == "nonperiodic_x_uses_finite_difference"
+
+
+def test_auto_on_open_unknown_routes_to_finite_difference() -> None:
+    field = _nonperiodic_field(x_boundary="open_unknown")
+    d = compute_derivatives(field, backend="auto")
+    assert d.backend == "finite_difference"
+    assert d.config["backend_selection_reason"] == "nonperiodic_x_uses_finite_difference"
+
+
+# --- explicit backend path --------------------------------------------------
+
+
+def test_explicit_finite_difference_on_nonperiodic_works() -> None:
+    field = _nonperiodic_field()
+    d = compute_derivatives(field, backend="finite_difference")
+    assert d.backend == "finite_difference"
+    # Explicit backend selection: dispatcher does NOT mark backend_selected_by_boundary_condition.
+    assert d.config["backend_selected_by_boundary_condition"] is False
+    assert d.config["backend_selection_reason"] is None
+
+
+def test_explicit_spectral_fd_on_periodic_works() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=1)
+    d = compute_derivatives(field, backend="spectral_fd")
+    assert d.backend == "spectral_fd"
+
+
+def test_explicit_spectral_fd_on_nonperiodic_raises_and_does_not_fall_back() -> None:
+    field = _nonperiodic_field()
+    with pytest.raises(ScopeValidationError, match="periodic"):
+        compute_derivatives(field, backend="spectral_fd")
+
+
+def test_explicit_finite_difference_on_periodic_raises_and_does_not_fall_back() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=2)
+    with pytest.raises(ScopeValidationError, match="rejects periodic"):
+        compute_derivatives(field, backend="finite_difference")
+
+
+# --- bad backend names ------------------------------------------------------
+
+
+def test_unknown_backend_raises() -> None:
+    field = _nonperiodic_field()
+    with pytest.raises(ScopeValidationError, match="backend must be one of"):
+        compute_derivatives(field, backend="weak")
+    with pytest.raises(ScopeValidationError, match="backend must be one of"):
+        compute_derivatives(field, backend="nonsense")
+
+
+def test_non_string_backend_raises() -> None:
+    field = _nonperiodic_field()
+    with pytest.raises(ScopeValidationError, match="backend must be one of"):
+        compute_derivatives(field, backend=42)  # type: ignore[arg-type]
+
+
+# --- order propagation ------------------------------------------------------
+
+
+def test_max_spatial_order_propagates_to_finite_difference() -> None:
+    field = _nonperiodic_field()
+    d1 = compute_derivatives(field, backend="auto", max_spatial_order=1)
+    assert set(d1.derivatives.keys()) == {"u_t", "u_x"}
+    d2 = compute_derivatives(field, backend="auto", max_spatial_order=2)
+    assert set(d2.derivatives.keys()) == {"u_t", "u_x", "u_xx"}
+
+
+def test_finite_difference_high_order_rejected_via_dispatcher() -> None:
+    field = _nonperiodic_field()
+    with pytest.raises(ScopeValidationError, match="max_spatial_order"):
+        compute_derivatives(field, backend="auto", max_spatial_order=3)
+
+
+# --- auto selection annotation does not lie on explicit calls ---------------
+
+
+def test_auto_annotation_only_set_when_backend_is_auto() -> None:
+    """The `backend_selected_by_boundary_condition` flag must mean "auto did it",
+    not "any periodic check happened". Explicit calls must not claim auto."""
+    periodic = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=3)
+    d = compute_derivatives(periodic, backend="spectral_fd")
+    assert d.config.get("backend_selected_by_boundary_condition", False) is False
+
+    nonperiodic = _nonperiodic_field()
+    d2 = compute_derivatives(nonperiodic, backend="finite_difference")
+    assert d2.config["backend_selected_by_boundary_condition"] is False

--- a/tests/test_field_batch_schema_0_2_migration.py
+++ b/tests/test_field_batch_schema_0_2_migration.py
@@ -1,0 +1,174 @@
+"""Tests for v0.30b FieldBatch schema 0.1 -> 0.2 migration."""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import pdelie
+from pdelie import FieldBatch
+from pdelie._boundary import LEGACY_BOUNDARY_NORMALIZATION_OPERATION
+from pdelie.data import generate_heat_1d_field_batch
+from pdelie.derivatives import compute_spectral_fd_derivatives
+from pdelie.errors import SchemaValidationError
+
+
+def _legacy_payload(
+    *,
+    schema_version: str = "0.1",
+    x_boundary: str | dict | None = "periodic",
+    include_boundary_conditions: bool = True,
+) -> dict:
+    metadata = {
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {"nu": 0.1},
+    }
+    if include_boundary_conditions:
+        metadata["boundary_conditions"] = {"x": x_boundary}
+    x = np.linspace(0.0, 2.0 * np.pi, 8, endpoint=False, dtype=float)
+    t = np.linspace(0.0, 0.2, 4, dtype=float)
+    return {
+        "schema_version": schema_version,
+        "values": np.zeros((2, 4, 8, 1), dtype=float).tolist(),
+        "dims": ["batch", "time", "x", "var"],
+        "coords": {"time": t.tolist(), "x": x.tolist()},
+        "var_names": ["u"],
+        "metadata": metadata,
+        "preprocess_log": [],
+        "mask": None,
+    }
+
+
+# --- FieldBatch SCHEMA_VERSION is now 0.2 -------------------------------
+
+
+def test_field_batch_class_var_schema_version_is_0_2() -> None:
+    assert FieldBatch.SCHEMA_VERSION == "0.2"
+    # Legacy 0.1 is still accepted by from_dict
+    assert "0.1" in FieldBatch.LEGACY_SCHEMA_VERSIONS
+
+
+def test_new_field_batch_default_schema_version_is_0_2() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=8, seed=0)
+    assert field.schema_version == "0.2"
+
+
+# --- Legacy 0.1 payloads load and validate ------------------------------
+
+
+def test_from_dict_accepts_legacy_0_1_payload_with_periodic_string() -> None:
+    payload = _legacy_payload(schema_version="0.1", x_boundary="periodic")
+    field = FieldBatch.from_dict(payload)
+    assert field.schema_version == "0.2"
+    # Legacy periodic string is normalized to the structured form on load.
+    bc = field.metadata["boundary_conditions"]["x"]
+    assert isinstance(bc, dict)
+    assert bc["type"] == "periodic"
+    assert bc["specified"] is True
+    # Migration provenance recorded.
+    operations = [entry["operation"] for entry in field.preprocess_log]
+    assert LEGACY_BOUNDARY_NORMALIZATION_OPERATION in operations
+
+
+def test_from_dict_accepts_legacy_0_1_payload_with_dirichlet_string() -> None:
+    payload = _legacy_payload(schema_version="0.1", x_boundary="dirichlet")
+    field = FieldBatch.from_dict(payload)
+    bc = field.metadata["boundary_conditions"]["x"]
+    assert bc["type"] == "dirichlet"
+    # Library does not invent values: specified=False after legacy-string migration.
+    assert bc["specified"] is False
+    assert bc["left"]["value"] is None
+    assert bc["right"]["value"] is None
+    operations = [entry["operation"] for entry in field.preprocess_log]
+    assert LEGACY_BOUNDARY_NORMALIZATION_OPERATION in operations
+
+
+def test_from_dict_accepts_legacy_0_1_payload_with_missing_boundary_conditions() -> None:
+    payload = _legacy_payload(schema_version="0.1", include_boundary_conditions=False)
+    field = FieldBatch.from_dict(payload)
+    bc = field.metadata["boundary_conditions"]["x"]
+    assert bc["type"] == "periodic"
+    assert bc["specified"] is True
+    operations = [entry["operation"] for entry in field.preprocess_log]
+    assert LEGACY_BOUNDARY_NORMALIZATION_OPERATION in operations
+    migration_entries = [
+        entry for entry in field.preprocess_log
+        if entry["operation"] == LEGACY_BOUNDARY_NORMALIZATION_OPERATION
+    ]
+    assert migration_entries[0]["parameters"]["default_x_boundary_string"] == "periodic"
+
+
+def test_from_dict_rejects_unsupported_schema_version() -> None:
+    payload = _legacy_payload(schema_version="9.9")
+    with pytest.raises(SchemaValidationError, match="schema_version"):
+        FieldBatch.from_dict(payload)
+
+
+def test_from_dict_does_not_record_migration_for_already_0_2_payload() -> None:
+    # Construct a 0.2 payload directly.
+    field0 = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=8, seed=0)
+    payload = field0.to_dict()
+    assert payload["schema_version"] == "0.2"
+    field1 = FieldBatch.from_dict(payload)
+    operations = [entry["operation"] for entry in field1.preprocess_log]
+    assert LEGACY_BOUNDARY_NORMALIZATION_OPERATION not in operations
+
+
+# --- 0.2 round-trip preserves behavior ----------------------------------
+
+
+def test_new_0_2_field_round_trip_preserves_values_and_metadata() -> None:
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=8, seed=1)
+    payload = field.to_dict()
+    # Strict JSON: no NaN.
+    json.dumps(payload, allow_nan=False)
+    round_tripped = FieldBatch.from_dict(payload)
+    np.testing.assert_allclose(round_tripped.values, field.values)
+    assert round_tripped.schema_version == "0.2"
+
+
+def test_generated_periodic_fields_still_pass_consumers() -> None:
+    """Regression: generators still emit legacy "periodic" strings (no breakage)."""
+    field = generate_heat_1d_field_batch(batch_size=1, num_times=5, num_points=16, seed=2)
+    # Generators emit the legacy form for backwards compat. The consumers
+    # use is_x_periodic which accepts both forms transparently.
+    assert field.metadata["boundary_conditions"]["x"] == "periodic"
+    derivatives = compute_spectral_fd_derivatives(field)
+    assert "u_x" in derivatives.derivatives
+
+
+def test_legacy_0_1_payload_with_structured_bc_passes_through_unchanged() -> None:
+    """A 0.1 payload whose BC is already structured needs no normalization entry."""
+    structured = {
+        "type": "periodic",
+        "left": None,
+        "right": None,
+        "specified": True,
+        "notes": None,
+    }
+    payload = _legacy_payload(schema_version="0.1", x_boundary=structured)
+    field = FieldBatch.from_dict(payload)
+    assert field.metadata["boundary_conditions"]["x"]["type"] == "periodic"
+    operations = [entry["operation"] for entry in field.preprocess_log]
+    # No migration entry is recorded because no normalization was needed.
+    assert LEGACY_BOUNDARY_NORMALIZATION_OPERATION not in operations
+
+
+# --- Schema migration metadata ------------------------------------------
+
+
+def test_migration_entry_records_from_and_to_schema_versions() -> None:
+    payload = _legacy_payload(schema_version="0.1", x_boundary="dirichlet")
+    field = FieldBatch.from_dict(payload)
+    entries = [
+        entry for entry in field.preprocess_log
+        if entry["operation"] == LEGACY_BOUNDARY_NORMALIZATION_OPERATION
+    ]
+    assert len(entries) == 1
+    params = entries[0]["parameters"]
+    assert params["from_schema_version"] == "0.1"
+    assert params["to_schema_version"] == "0.2"
+    assert params["legacy_x_boundary_string"] == "dirichlet"

--- a/tests/test_finite_difference_backend.py
+++ b/tests/test_finite_difference_backend.py
@@ -1,0 +1,246 @@
+"""Tests for the v0.30c finite_difference derivative backend.
+
+Manufactured analytic field tests use closed-form derivatives, not `np.gradient`
+itself — testing the backend against itself would be meaningless. See
+`docs/design/DERIVATIVE_BACKEND_POLICY.md`.
+"""
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+
+from pdelie._boundary import normalize_x_boundary_condition
+from pdelie.contracts import ALLOWED_DERIVATIVE_BACKENDS, DerivativeBatch
+from pdelie.data import from_numpy
+from pdelie.derivatives import compute_finite_difference_derivatives
+from pdelie.errors import ScopeValidationError
+
+
+def _nonperiodic_metadata(*, x_boundary: str | dict = "dirichlet") -> dict:
+    return {
+        "boundary_conditions": {"x": x_boundary},
+        "coordinate_system": "cartesian",
+        "grid_regularity": "uniform",
+        "grid_type": "rectilinear",
+        "parameter_tags": {},
+    }
+
+
+def _polynomial_field(
+    *,
+    n_t: int = 17,
+    n_x: int = 33,
+    t_max: float = 1.0,
+    x_max: float = 2.0,
+    x_boundary: str | dict = "dirichlet",
+):
+    """u(t, x) = t^2 + x^2 + t * x on a uniform nonperiodic grid."""
+    t = np.linspace(0.0, t_max, n_t, dtype=float)
+    x = np.linspace(0.0, x_max, n_x, dtype=float)
+    T, X = np.meshgrid(t, x, indexing="ij")
+    values = (T**2 + X**2 + T * X)[None, ..., None]
+    return (
+        from_numpy(
+            values,
+            dims=("batch", "time", "x", "var"),
+            coords={"time": t, "x": x},
+            var_name="u",
+            metadata=_nonperiodic_metadata(x_boundary=x_boundary),
+        ),
+        t,
+        x,
+    )
+
+
+def test_polynomial_derivatives_are_exact_in_interior() -> None:
+    """For u = t^2 + x^2 + t*x, edge-order-2 FD recovers u_t, u_x, u_xx exactly.
+
+    np.gradient with edge_order=2 is exact for polynomials of degree <=2.
+    """
+    field, t, x = _polynomial_field()
+    d = compute_finite_difference_derivatives(field, max_spatial_order=2)
+
+    # u_t = 2t + x, u_x = 2x + t, u_xx = 2
+    T, X = np.meshgrid(t, x, indexing="ij")
+    expected_u_t = (2.0 * T + X)[None, ..., None]
+    expected_u_x = (2.0 * X + T)[None, ..., None]
+    expected_u_xx = np.full_like(expected_u_t, 2.0)
+
+    np.testing.assert_allclose(d.derivatives["u_t"], expected_u_t, atol=1e-10)
+    np.testing.assert_allclose(d.derivatives["u_x"], expected_u_x, atol=1e-10)
+    np.testing.assert_allclose(d.derivatives["u_xx"], expected_u_xx, atol=1e-9)
+
+
+def test_max_spatial_order_1_emits_only_first_derivatives() -> None:
+    field, _, _ = _polynomial_field()
+    d = compute_finite_difference_derivatives(field, max_spatial_order=1)
+    assert set(d.derivatives.keys()) == {"u_t", "u_x"}
+    assert d.config["spatial_max_order"] == 1
+
+
+def test_derivative_batch_validates_against_field() -> None:
+    field, _, _ = _polynomial_field()
+    d = compute_finite_difference_derivatives(field, max_spatial_order=2)
+    # Already called inside compute_finite_difference_derivatives, but re-asserting:
+    d.validate_against(field)
+    assert d.backend == "finite_difference"
+    assert d.backend in ALLOWED_DERIVATIVE_BACKENDS
+
+
+def test_backend_config_carries_required_fields() -> None:
+    field, _, _ = _polynomial_field(x_boundary="neumann")
+    d = compute_finite_difference_derivatives(field)
+    assert d.config["spatial_method"] == "finite_difference_centered"
+    assert d.config["temporal_method"] == "finite_difference"
+    assert d.config["stencil_edge_order"] == 2
+    assert d.config["boundary_handling"] == "neumann"
+    assert d.config["spatial_max_order"] == 2
+    assert d.config["backend_selected_by_boundary_condition"] is False
+    assert d.config["backend_selection_reason"] is None
+    assert d.config["recommended_residual_domain_policy"] == "interior_only"
+    assert d.config["recommended_boundary_trim_width"] == 4
+    assert "neumann" in d.boundary_assumptions
+    assert d.diagnostics["x_points"] == field.values.shape[2]
+    assert d.diagnostics["time_points"] == field.values.shape[1]
+    for key in ("dx", "dt"):
+        assert math.isfinite(d.diagnostics[key])
+
+
+def test_derivative_batch_is_strict_json_compatible() -> None:
+    field, _, _ = _polynomial_field()
+    d = compute_finite_difference_derivatives(field)
+    payload = d.to_dict()
+    # No NaN; round-trippable.
+    assert json.loads(json.dumps(payload, allow_nan=False)) == payload
+
+
+def test_rejects_periodic_input() -> None:
+    """Periodic data must go through spectral_fd. The FD backend explicitly rejects it."""
+    t = np.linspace(0.0, 1.0, 17, dtype=float)
+    x = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False, dtype=float)
+    values = np.zeros((1, 17, 16, 1), dtype=float)
+    field = from_numpy(
+        values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata={
+            "boundary_conditions": {"x": "periodic"},
+            "coordinate_system": "cartesian",
+            "grid_regularity": "uniform",
+            "grid_type": "rectilinear",
+            "parameter_tags": {},
+        },
+    )
+    with pytest.raises(ScopeValidationError, match="rejects periodic"):
+        compute_finite_difference_derivatives(field)
+
+
+def test_rejects_max_spatial_order_3() -> None:
+    field, _, _ = _polynomial_field()
+    with pytest.raises(ScopeValidationError, match="max_spatial_order must be 1 or 2"):
+        compute_finite_difference_derivatives(field, max_spatial_order=3)
+
+
+def test_rejects_max_spatial_order_4() -> None:
+    field, _, _ = _polynomial_field()
+    with pytest.raises(ScopeValidationError, match="max_spatial_order must be 1 or 2"):
+        compute_finite_difference_derivatives(field, max_spatial_order=4)
+
+
+def test_rejects_bool_max_spatial_order() -> None:
+    field, _, _ = _polynomial_field()
+    # True passes int() to 1 but is explicitly disallowed.
+    with pytest.raises(ScopeValidationError, match="max_spatial_order"):
+        compute_finite_difference_derivatives(field, max_spatial_order=True)
+
+
+def test_rejects_nonuniform_x_grid() -> None:
+    n_t, n_x = 17, 9
+    t = np.linspace(0.0, 1.0, n_t, dtype=float)
+    x = np.array([0.0, 0.2, 0.5, 0.9, 1.3, 1.6, 1.7, 1.8, 2.0], dtype=float)
+    values = np.zeros((1, n_t, n_x, 1), dtype=float)
+    # from_numpy rejects nonuniform x at ingestion. Build FieldBatch directly to
+    # exercise the backend's uniform-x check.
+    # Actually from_numpy checks _is_uniform; we can satisfy the FieldBatch contract
+    # only with a uniform grid. Use a uniform grid via from_numpy, then mutate.
+    field = from_numpy(
+        np.zeros((1, n_t, 9, 1), dtype=float),
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": np.linspace(0.0, 2.0, 9, dtype=float)},
+        var_name="u",
+        metadata=_nonperiodic_metadata(),
+    )
+    # Mutate the x coords to make them nonuniform; bypass validate() because we
+    # explicitly want to exercise the backend's own check.
+    field.coords["x"] = x
+    # FieldBatch.validate() (called first by the backend) catches nonuniform spatial
+    # grids at the canonical contract layer. The error message is the contract's.
+    with pytest.raises(ScopeValidationError, match="uniform rectilinear"):
+        compute_finite_difference_derivatives(field)
+
+
+def test_rejects_nonuniform_time_grid() -> None:
+    field, _, _ = _polynomial_field()
+    field.coords["time"] = np.array([0.0, 0.1, 0.3, 0.45, 0.55, 0.7, 0.8, 0.9, 0.95, 1.0,
+                                      1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7], dtype=float)[: field.values.shape[1]]
+    # Time-axis uniformity is checked by the FD backend itself (the contract layer
+    # only enforces it for SPATIAL_DIMS like x).
+    with pytest.raises(ScopeValidationError, match="uniform time grid"):
+        compute_finite_difference_derivatives(field)
+
+
+def test_rejects_too_few_x_points() -> None:
+    t = np.linspace(0.0, 1.0, 5, dtype=float)
+    x = np.linspace(0.0, 1.0, 4, dtype=float)
+    values = np.zeros((1, 5, 4, 1), dtype=float)
+    field = from_numpy(
+        values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(),
+    )
+    # Drop x to 2 points
+    field.values = field.values[..., :2, :]
+    field.coords["x"] = x[:2]
+    with pytest.raises(ScopeValidationError, match="at least 3 x-points"):
+        compute_finite_difference_derivatives(field)
+
+
+def test_rejects_too_few_time_points() -> None:
+    t = np.linspace(0.0, 1.0, 5, dtype=float)
+    x = np.linspace(0.0, 1.0, 5, dtype=float)
+    values = np.zeros((1, 5, 5, 1), dtype=float)
+    field = from_numpy(
+        values,
+        dims=("batch", "time", "x", "var"),
+        coords={"time": t, "x": x},
+        var_name="u",
+        metadata=_nonperiodic_metadata(),
+    )
+    field.values = field.values[:, :2, :, :]
+    field.coords["time"] = t[:2]
+    with pytest.raises(ScopeValidationError, match="at least 3 time points"):
+        compute_finite_difference_derivatives(field)
+
+
+def test_accepts_structured_dirichlet_spec() -> None:
+    structured = normalize_x_boundary_condition({
+        "type": "dirichlet",
+        "left": {"value": 0.0, "time_dependent": False, "source": "user_supplied"},
+        "right": {"value": 1.0, "time_dependent": False, "source": "user_supplied"},
+    })
+    field, _, _ = _polynomial_field(x_boundary=structured)
+    d = compute_finite_difference_derivatives(field)
+    assert d.config["boundary_handling"] == "dirichlet"
+
+
+def test_accepts_neumann_and_open_unknown_legacy_strings() -> None:
+    for bc in ("neumann", "open_unknown"):
+        field, _, _ = _polynomial_field(x_boundary=bc)
+        d = compute_finite_difference_derivatives(field)
+        assert d.config["boundary_handling"] == bc

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -112,6 +112,7 @@ _FIELD_BATCH_READINESS_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
     "metadata_diagnostics",
     "metadata_suggestions",
     "residual_preflight",
+    "boundary_condition_warnings",  # v0.30c
     "stable_scope",
 }
 _XARRAY_DATASET_READINESS_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
@@ -125,6 +126,7 @@ _XARRAY_DATASET_READINESS_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
     "metadata_diagnostics",
     "metadata_suggestions",
     "conversion_preflight",
+    "boundary_condition_warnings",  # v0.30c
     "stable_scope",
 }
 _WEAK_FORM_SUPPORTABILITY_SUMMARY_KEYS = _SUMMARY_PREFIX_KEYS | {
@@ -322,12 +324,23 @@ def test_summarize_field_batch_readiness_reports_attention_and_not_ready_cases()
     assert multivariable_summary["readiness_label"] == "not_ready"
     assert multivariable_summary["component_statuses"]["field"]["status"] == "failed"
 
+    # v0.30c: nonperiodic is no longer a metadata failure; it's flagged via
+    # boundary_condition_warnings, which downgrades a would-be "ready" label
+    # to "needs_attention". Metadata status itself passes.
     nonperiodic = _copy_field(field)
     nonperiodic.metadata = copy.deepcopy(nonperiodic.metadata)
     nonperiodic.metadata["boundary_conditions"] = {"x": "dirichlet"}
     nonperiodic_summary = summarize_field_batch_readiness(nonperiodic)
-    assert nonperiodic_summary["readiness_label"] == "not_ready"
-    assert nonperiodic_summary["component_statuses"]["metadata"]["status"] == "failed"
+    assert nonperiodic_summary["readiness_label"] == "needs_attention"
+    assert nonperiodic_summary["component_statuses"]["metadata"]["status"] == "passed"
+    assert (
+        "x_boundary_dirichlet_unspecified"
+        in nonperiodic_summary["boundary_condition_warnings"]
+    )
+    assert (
+        "x_boundary_legacy_string_under_schema_0_2"
+        in nonperiodic_summary["boundary_condition_warnings"]
+    )
 
 
 def test_summarize_field_batch_readiness_reports_coordinate_failures() -> None:
@@ -505,8 +518,10 @@ def test_summarize_residual_batch_returns_frozen_json_summary(heat_artifacts: di
         "normalization",
         "max_abs_residual",
         "rms_residual",
+        "residual_domain_policy",  # v0.30c
         "diagnostics",
     }
+    assert summary["residual_domain_policy"] == "not_configured"
     assert summary["summary_schema_version"] == "0.1"
     assert summary["summary_type"] == "residual_batch"
     assert summary["residual_shape"] == list(residual.residual.shape)

--- a/tests/test_v0_30_hygiene_audit.py
+++ b/tests/test_v0_30_hygiene_audit.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_AUDIT_DOC_PATH = "docs/design/V0_30_HYGIENE_AUDIT.md"
+_SCOPE_CONFIG_PATH = "configs/planning/v0_30_nonperiodic_readiness_scope.json"
+
+
+def _repo_path(path: str) -> Path:
+    return _REPO_ROOT / path
+
+
+def _repo_text(path: str) -> str:
+    return _repo_path(path).read_text(encoding="utf-8")
+
+
+def _repo_json(path: str) -> dict[str, object]:
+    return json.loads(_repo_text(path))
+
+
+def _audit_text() -> str:
+    return _repo_text(_AUDIT_DOC_PATH)
+
+
+def test_v0_30_hygiene_audit_doc_exists_with_required_headings() -> None:
+    """The hygiene audit document exists and covers every required section."""
+    audit_path = _repo_path(_AUDIT_DOC_PATH)
+    assert audit_path.exists(), f"missing {audit_path}"
+    audit = _audit_text()
+    required_headings = [
+        "Lint status",
+        "Type-checker status",
+        "Coverage status",
+        "Python version matrix",
+        "NumPy upper bound",
+        "Release-gate proliferation",
+        "Optional-dependency import pattern",
+        "Strict JSON",
+        "Staged enforcement",
+        "Release-gate consolidation",
+    ]
+    for heading in required_headings:
+        assert heading in audit, f"hygiene audit missing required section: {heading!r}"
+
+
+def test_v0_30_hygiene_audit_records_current_baseline() -> None:
+    """The audit must record the current baseline accurately so we can detect drift."""
+    audit = _audit_text()
+
+    # Lint: ruff/black/flake8 absent
+    assert "ruff" in audit.lower()
+    assert "No `[tool.ruff]`" in audit or "no `[tool.ruff]`" in audit.lower()
+
+    # Type-checker: mypy/pyright absent
+    assert "mypy" in audit.lower()
+    assert "No `[tool.mypy]`" in audit or "no `[tool.mypy]`" in audit.lower()
+
+    # Coverage: absent
+    assert "coverage" in audit.lower()
+    assert "No `[tool.coverage]`" in audit or "no `[tool.coverage]`" in audit.lower()
+
+    # Python matrix: 3.11 only
+    assert "3.11" in audit
+    assert "Python 3.11" in audit or "python-version" in audit.lower()
+
+    # NumPy upper bound documented
+    assert "numpy" in audit.lower()
+    assert "<2" in audit or "1.24" in audit
+
+    # Release-gate file count
+    assert "26" in audit
+
+
+def test_v0_30_hygiene_audit_documents_lazy_optional_import_policy() -> None:
+    """The audit must reaffirm the lazy-import policy referenced by name."""
+    audit = _audit_text()
+    assert "_require_discovery_dependencies" in audit
+    assert "importlib.import_module" in audit
+    # The policy phrasing must be present
+    assert "imported on first use" in audit or "imported on first invocation" in audit.lower()
+    # The reference path is cited
+    assert "src/pdelie/discovery/pysindy_adapter.py" in audit
+
+
+def test_v0_30_hygiene_audit_documents_strict_json_policy() -> None:
+    """The audit must record the JSON-strict / no-NaN policy with concrete references."""
+    audit = _audit_text()
+    assert "allow_nan=False" in audit
+    assert "_validate_strict_json_compatible" in audit
+    assert "_json_safe" in audit
+    # No-NaN guidance for new outputs
+    assert "float(\"nan\")" in audit or 'float("nan")' in audit
+
+
+def test_v0_30_hygiene_audit_documents_release_gate_consolidation_proposal() -> None:
+    """The audit must explain the manifest-driven parameterized release-gate plan."""
+    audit = _audit_text()
+    assert "parameterized" in audit.lower()
+    assert "release_gate_manifest.json" in audit
+    # The proposal must be scoped to v0.30 proper, not v0.30a
+    assert "v0.30 proper" in audit
+    assert "not v0.30a" in audit or "not in v0.30a" in audit.lower()
+
+
+def test_v0_30_hygiene_audit_documents_staged_enforcement_phases() -> None:
+    """The staged-enforcement plan must enumerate phases tied to specific releases."""
+    audit = _audit_text()
+    # Phase 0 is audit-only (v0.30a)
+    assert "Phase 0" in audit
+    assert "v0.30a" in audit
+    # Phase 1 lands in v0.30 proper
+    assert "Phase 1" in audit
+    # Future phases referenced
+    assert "Phase 2" in audit
+    assert "Phase 3" in audit
+    # NumPy 2.x lift deferred
+    assert "numpy 2.x" in audit.lower() or "numpy 2" in audit.lower()
+
+
+def test_v0_30_no_premature_pyproject_changes() -> None:
+    """pyproject.toml must not yet contain lint/type/coverage sections in v0.30a."""
+    pyproject_text = _repo_text("pyproject.toml")
+    pyproject = tomllib.loads(pyproject_text)
+
+    config = _repo_json(_SCOPE_CONFIG_PATH)
+    forbidden_sections = config["guard_no_premature_pyproject_sections"]
+
+    # Top-level [tool.*] sections must not include any forbidden one.
+    tool_sections = pyproject.get("tool", {})
+    for forbidden in forbidden_sections:
+        # forbidden is e.g. "tool.ruff"; the leaf is "ruff"
+        leaf = forbidden.split(".", 1)[1]
+        assert leaf not in tool_sections, (
+            f"v0.30a must not configure [{forbidden}] in pyproject.toml"
+        )
+
+    # numpy upper bound is still < 2
+    deps = pyproject["project"]["dependencies"]
+    numpy_dep = next((dep for dep in deps if dep.lower().startswith("numpy")), None)
+    assert numpy_dep is not None
+    assert "<2" in numpy_dep, f"numpy dep changed unexpectedly: {numpy_dep}"
+
+    # requires-python is still >=3.11
+    requires_python = pyproject["project"]["requires-python"]
+    assert ">=3.11" in requires_python
+
+
+def test_v0_30_no_premature_ci_changes() -> None:
+    """CI workflow must retain exactly the four existing jobs and no premature additions."""
+    workflow = _repo_text(".github/workflows/ci.yml")
+    config = _repo_json(_SCOPE_CONFIG_PATH)
+
+    expected_jobs = config["expected_ci_jobs"]
+    for job in expected_jobs:
+        assert f"{job}:" in workflow, f"expected CI job missing: {job}"
+
+    # No premature additions
+    for forbidden in config["guard_no_premature_ci_jobs"]:
+        # Match as a job-name header to avoid false positives on shell commands
+        # (job declarations sit at column 2 in this workflow file).
+        pattern = rf"^  {re.escape(forbidden)}:\s*$"
+        assert not re.search(pattern, workflow, flags=re.MULTILINE), (
+            f"v0.30a must not add CI job: {forbidden}"
+        )
+
+    # The existing single release-gate job is unchanged
+    release_gate_jobs = re.findall(r"^  (v0_\d+-release-gate):", workflow, flags=re.MULTILINE)
+    assert release_gate_jobs == ["v0_29-release-gate"], (
+        f"v0.30a must not add a v0_30-release-gate job (got: {release_gate_jobs})"
+    )
+
+
+def test_v0_30_release_gate_file_count_matches_audit() -> None:
+    """The audit cites 26 release-gate files; assert that count is current."""
+    files = sorted((_REPO_ROOT / "tests").glob("test_v0_*_release_gate.py"))
+    assert len(files) == 26, (
+        f"hygiene audit cites 26 release-gate files but found {len(files)}; "
+        "update docs/design/V0_30_HYGIENE_AUDIT.md and this assertion together"
+    )
+
+
+def test_v0_30_no_new_optional_dependency_added() -> None:
+    """v0.30a must not declare any new optional dependency."""
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    optional = pyproject["project"].get("optional-dependencies", {})
+    expected_extras = {"downstream", "xarray", "viz", "test"}
+    assert set(optional.keys()) == expected_extras, (
+        f"unexpected optional-dependency extras: {sorted(optional.keys())}"
+    )

--- a/tests/test_v0_30_scope_freeze.py
+++ b/tests/test_v0_30_scope_freeze.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib
+import json
+import tomllib
+from pathlib import Path
+
+import pdelie
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCOPE_CONFIG_PATH = "configs/planning/v0_30_nonperiodic_readiness_scope.json"
+
+
+def _repo_path(path: str) -> Path:
+    return _REPO_ROOT / path
+
+
+def _repo_text(path: str) -> str:
+    return _repo_path(path).read_text(encoding="utf-8")
+
+
+def _repo_json(path: str) -> dict[str, object]:
+    return json.loads(_repo_text(path))
+
+
+def _load_scope_config() -> dict[str, object]:
+    return _repo_json(_SCOPE_CONFIG_PATH)
+
+
+def test_scope_config_is_present_and_strict_json_compatible() -> None:
+    """The v0.30a scope manifest must exist and be JSON-strict (no NaN, round-trippable)."""
+    config = _load_scope_config()
+    assert json.loads(json.dumps(config, allow_nan=False)) == config
+    assert config["summary_schema_version"] == "0.1"
+    assert config["summary_type"] == "pdelie_release_scope"
+    assert config["release"] == "0.30a"
+    assert config["status"] == "in_progress"
+    assert config["parent_release"] == "0.30"
+    assert config["decision_label"] == (
+        "nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only"
+    )
+
+
+def test_v0_30_scope_doc_exists_and_has_required_phrases() -> None:
+    """V0_30_SCOPE.md must exist and contain every phrase the scope manifest requires."""
+    config = _load_scope_config()
+    scope_path = _repo_path("docs/planning/V0_30_SCOPE.md")
+    assert scope_path.exists(), f"missing {scope_path}"
+    scope = scope_path.read_text(encoding="utf-8")
+    assert scope.strip(), "V0_30_SCOPE.md must not be empty"
+
+    for phrase in config["required_phrases_in_scope_doc"]:
+        assert phrase in scope, f"missing required phrase in V0_30_SCOPE.md: {phrase!r}"
+
+
+def test_v0_30_design_documents_exist_and_are_nonempty() -> None:
+    """The three v0.30a design documents and the scope doc must all exist with content."""
+    config = _load_scope_config()
+    for path in config["required_design_documents"]:
+        target = _repo_path(path)
+        assert target.exists(), f"missing required design document: {path}"
+        assert target.read_text(encoding="utf-8").strip(), f"design document is empty: {path}"
+
+
+def test_v0_30_roadmap_records_v0_30a_and_refined_v0_30() -> None:
+    """ROADMAP.md must record v0.30a and reflect the refined v0.30 theme."""
+    config = _load_scope_config()
+    roadmap = _repo_text("docs/planning/ROADMAP.md")
+    for phrase in config["required_phrases_in_roadmap"]:
+        assert phrase in roadmap, f"missing required phrase in ROADMAP.md: {phrase!r}"
+    # The v0.30 theme refinement must mention the new theme
+    assert "Nonperiodic readiness" in roadmap
+    assert "finite-difference" in roadmap.lower() or "finite difference" in roadmap.lower()
+    # Newly deferred surfaces
+    assert "high-order finite-difference derivatives on nonperiodic data" in roadmap
+    assert "overlap-crop" in roadmap
+    assert "root-level one-call symmetry-discovery API" in roadmap
+    # v0.29 row must remain (do not break v0.29 release gate)
+    assert "`v0.29` | Completed | Workflow recipes and support matrix" in roadmap
+
+
+def test_v0_30_plan_records_v0_30a_and_preserves_v0_29() -> None:
+    """PLAN.md must record v0.30a IN_PROGRESS and retain the v0.29 COMPLETE record."""
+    config = _load_scope_config()
+    plan = _repo_text("docs/planning/PLAN.md")
+    for phrase in config["required_phrases_in_plan"]:
+        assert phrase in plan, f"missing required phrase in PLAN.md: {phrase!r}"
+    # v0.30a section
+    assert "**Status:** IN_PROGRESS" in plan
+    # v0.29 record must remain intact (existing v0.29 release gate reads these)
+    assert "V0.29 is complete" in plan
+    assert "Milestone 6: COMPLETE" in plan
+    assert "workflow_recipes_and_support_matrix_complete_no_new_numerical_scope" in plan
+
+
+def test_v0_30_api_stability_records_design_only_note() -> None:
+    """API_STABILITY.md must carry a Decision-only note for v0.30a, after the v0.29 note."""
+    config = _load_scope_config()
+    api_stability = _repo_text("docs/specs/API_STABILITY.md")
+    for phrase in config["required_phrases_in_api_stability"]:
+        assert phrase in api_stability, (
+            f"missing required phrase in API_STABILITY.md: {phrase!r}"
+        )
+    # v0.29 note must remain
+    assert "Decision-only note for the frozen `v0.29`" in api_stability
+    # v0.30a note must explicitly disclaim a new runtime API
+    assert "`v0.30a` adds no new runtime public API" in api_stability
+    # The announced future schema migration must be documented (for external-tooling readiness)
+    assert "`FieldBatch.SCHEMA_VERSION`" in api_stability
+    assert '`"0.1"`' in api_stability and '`"0.2"`' in api_stability
+    assert "backwards-compatible loader" in api_stability
+
+
+def test_v0_30_no_root_export_for_planned_v0_30_apis() -> None:
+    """No planned v0.30/v0.30.1 API may have leaked into the root `pdelie` namespace."""
+    config = _load_scope_config()
+    for name in config["forbidden_root_attributes"]:
+        assert not hasattr(pdelie, name), (
+            f"v0.30a must not export `pdelie.{name}` (planned for a later release)"
+        )
+
+
+def test_v0_30_no_submodule_export_for_planned_v0_30_apis() -> None:
+    """No planned v0.30/v0.30.1 API may have leaked into its target submodule yet."""
+    config = _load_scope_config()
+    forbidden = config["forbidden_submodule_attributes"]
+    for submodule_name, names in forbidden.items():
+        module = importlib.import_module(submodule_name)
+        for name in names:
+            assert not hasattr(module, name), (
+                f"v0.30a must not export `{submodule_name}.{name}` "
+                f"(planned for a later release)"
+            )
+
+
+def test_v0_30_no_version_bump() -> None:
+    """v0.30a must not bump the package version."""
+    config = _load_scope_config()
+    pyproject = tomllib.loads(_repo_text("pyproject.toml"))
+    assert pyproject["project"]["version"] == config["guard_no_version_bump"]
+    assert pyproject["project"]["version"] == "0.29.0"
+
+
+def test_v0_30_schema_migration_design_is_documented() -> None:
+    """The 0.1 -> 0.2 FieldBatch schema migration design is fully documented."""
+    spec_doc = _repo_text("docs/design/BOUNDARY_CONDITION_SPEC.md")
+    assert "0.1" in spec_doc
+    assert "0.2" in spec_doc
+    assert "backwards-compatible" in spec_doc
+    assert "schema_0_1_to_0_2_boundary_normalization" in spec_doc
+
+    config = _load_scope_config()
+    migration = config["planned_schema_migration"]
+    assert migration["field"] == "FieldBatch.SCHEMA_VERSION"
+    assert migration["from_version"] == "0.1"
+    assert migration["to_version"] == "0.2"
+    assert migration["implements_in_release"] == "0.30"
+    assert migration["backwards_compatible_loader"] is True
+
+
+def test_v0_30b_schema_migration_is_applied_at_runtime() -> None:
+    """v0.30b lands the structured BoundaryConditionSpec runtime; SCHEMA_VERSION is 0.2."""
+    assert getattr(pdelie.FieldBatch, "SCHEMA_VERSION", None) == "0.2"
+    # Legacy 0.1 schema_version is still accepted by from_dict for backwards compat.
+    assert "0.1" in getattr(pdelie.FieldBatch, "LEGACY_SCHEMA_VERSIONS", frozenset())
+
+
+def test_v0_30_scope_doc_uses_correct_decision_label() -> None:
+    """The decision label must match between manifest, scope doc, plan, and API stability."""
+    config = _load_scope_config()
+    label = config["decision_label"]
+    assert label in _repo_text("docs/planning/V0_30_SCOPE.md")
+    assert label in _repo_text("docs/planning/PLAN.md")
+    assert label in _repo_text("docs/specs/API_STABILITY.md")
+
+
+# Note: the v0.30a `test_v0_30_no_src_changes_against_main` guard was removed in
+# v0.30b. v0.30b implements the BoundaryConditionSpec runtime, which modifies
+# src/pdelie/ by design. The remaining guards (forbidden_root_attributes,
+# forbidden_submodule_attributes, no_version_bump, schema-migration design and
+# runtime checks) continue to enforce the v0.30 scope freeze.


### PR DESCRIPTION
Three sequential commits opening the v0.30 nonperiodic runtime work. Each is reviewable independently; all three preserve v0.29 behavior for periodic data.

## Summary

- **v0.30a** (`0cbad39`) — scope freeze + design contracts + hygiene audit. No runtime change, no version bump. Adds `docs/planning/V0_30_SCOPE.md`, three design docs (`BOUNDARY_CONDITION_SPEC.md`, `DERIVATIVE_BACKEND_POLICY.md`, `V0_30_HYGIENE_AUDIT.md`), `configs/planning/v0_30_nonperiodic_readiness_scope.json`, and the audit-only tests `test_v0_30_scope_freeze.py` + `test_v0_30_hygiene_audit.py`. Shared docs (`PLAN.md`, `ROADMAP.md`, `API_STABILITY.md`) carry entries for v0.30a/b/c layered above the preserved v0.29 record.
- **v0.30b** (`8ea2e48`) — `BoundaryConditionSpec` runtime + `FieldBatch` schema 0.1 → 0.2 migration. Adds `src/pdelie/_boundary.py` (internal helpers: `BoundaryFace`, `BoundaryConditionSpec`, `normalize_x_boundary_condition`, `get_x_boundary_type`, `is_x_periodic`). `FieldBatch.from_dict` accepts both `"0.1"` and `"0.2"` payloads under a backwards-compatible loader; legacy string BCs are normalized on load and recorded in `preprocess_log` as `schema_0_1_to_0_2_boundary_normalization`. 14 downstream consumer sites refactored to use `is_x_periodic(field)`. Adapters (`from_numpy`, `from_xarray`) accept structured nonperiodic specs; downstream consumers still reject nonperiodic.
- **v0.30c** (`ce6cce0`) — low-order `finite_difference` backend + `compute_derivatives(backend='auto')` dispatcher + boundary-aware readiness. `compute_finite_difference_derivatives` supports `u_t`, `u_x`, `u_xx` only on scalar 1D nonperiodic (dirichlet, neumann, open_unknown) uniform grids. Dispatcher records `backend_selected_by_boundary_condition` + `backend_selection_reason` in `DerivativeBatch.config`. `summarize_field_batch_readiness` gains `boundary_condition_warnings: list[str]` and downgrades `"ready"` → `"needs_attention"` when warnings exist. `summarize_residual_batch` records additive `residual_domain_policy`.

Decision labels:
- `nonperiodic_readiness_and_low_order_finite_difference_diagnostics_design_only` (v0.30a)
- `boundary_condition_spec_runtime_and_field_batch_0_2_migration` (v0.30b)
- `low_order_finite_difference_backend_and_boundary_aware_readiness` (v0.30c)

Non-goals honored:
- No `pyproject.toml` version bump (stays `0.29.0`; version bump is reserved for v0.30 release close).
- No new optional dependency; no CI workflow change.
- No new root `pdelie` export. No new PDE. No PDEBench/The Well support claim.
- No KdV/KS nonperiodic. No weak nonperiodic. No finite-transform verification for nonperiodic translations. No residual evaluator auto-dispatch (that lands in v0.30d, stacked on this branch).
- No symmetry-method registry; no root `pdelie.discover_symmetries`.
- ruff / mypy / coverage config deferred to v0.30e.

## Test plan

- [ ] `python -m pytest` passes (baseline before this PR: 924; at v0.30c tip: 1020, +96 from new tests).
- [ ] `git diff --check` clean.
- [ ] `python -m pytest tests/test_boundary_condition_spec.py tests/test_field_batch_schema_0_2_migration.py tests/test_boundary_condition_internal_usage.py tests/test_v0_30_scope_freeze.py tests/test_v0_30_hygiene_audit.py -v` — the v0.30-arc tests pass.
- [ ] `python -m pytest tests/test_v0_29_release_gate.py tests/test_current_release_gate.py tests/test_api_stability_audit.py` — v0.29 release-gate assertions still hold (v0.29 phrases preserved in `PLAN.md`, `ROADMAP.md`, `API_STABILITY.md`).
- [ ] `python -m pytest tests/test_contracts.py` — existing `FieldBatch` round-trip tests pass unchanged.
- [ ] Confirm `pyproject.toml` `version` is still `"0.29.0"`.
- [ ] Confirm no new job appears in `.github/workflows/ci.yml`.
- [ ] Confirm no new entry in `pdelie/__init__.py` root exports (only the six canonical types remain).
- [ ] Spot-check `compute_derivatives(field, backend="auto")` on both a periodic Heat field and a Dirichlet field — the resulting `DerivativeBatch.config` records `backend_selected_by_boundary_condition: true` and the appropriate `backend_selection_reason`.

## Stacked context

`feat/v0.30d-residual-dispatch` is a stacked branch on this one. Review order: this PR first, then the v0.30d PR. GitHub will auto-retarget the v0.30d PR to `main` once this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)