### PR TITLE
ci(v0.30.1a): promote lint from advisory to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,13 @@ jobs:
           tests/test_v0_27_release_gate.py
           tests/test_v0_28_release_gate.py
           tests/test_v0_29_release_gate.py
-  # v0.30e hygiene phase 1: advisory / non-blocking lint, typecheck, coverage.
-  # These jobs report findings but do not gate merges. `continue-on-error: true`
-  # means a red run shows in the workflow summary without failing the workflow.
+  # v0.30e hygiene phase 1 landed lint/typecheck/coverage as advisory.
+  # v0.30.1a hygiene phase 2 (this PR) promotes `lint` from advisory to
+  # blocking: a red run now fails the workflow. `typecheck` and `coverage`
+  # remain advisory (`continue-on-error: true`) and are promoted in
+  # v0.30.1b (coverage) and v0.30.1c-k (mypy strict-scope broadening).
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -91,8 +92,7 @@ jobs:
           }
           retry 3 python -m pip install --upgrade pip
           retry 3 python -m pip install -e .[test]
-      - name: Ruff lint (non-blocking)
-        continue-on-error: true
+      - name: Ruff lint (blocking as of v0.30.1a)
         run: python -m ruff check .
   typecheck:
     runs-on: ubuntu-latest

--- a/docs/design/V0_30_HYGIENE_AUDIT.md
+++ b/docs/design/V0_30_HYGIENE_AUDIT.md
@@ -127,10 +127,19 @@ Audit-only. This document records the baseline. No `pyproject.toml` change, no C
 
 Phase 1 is opt-in by CI: the existing `editable-tests`, `package-smoke`, `docs-build`, and `v0_29-release-gate` (which becomes `v0_30-release-gate`) jobs continue unchanged and remain the merge gates.
 
-### Phase 2 — v0.30.1 or v0.31
+### Phase 2 — v0.30.1a through v0.30.1k (split per-axis)
 
-- Tighten `[tool.mypy].strict` across all of `src/pdelie/`. Address strictness violations site by site.
-- Promote `lint` and `typecheck` CI jobs to **blocking**.
+Phase 2 is split into small dedicated maintenance PRs, each promoting exactly one advisory job or broadening exactly one mypy strict scope. This is deliberately the opposite of "one big Phase 2 PR": each promotion is boring, mergeable in a day, and cannot fight rebase-hell against v0.31.
+
+- **v0.30.1a — lint promotion (this PR).** Removes `continue-on-error: true` from the `lint` CI job and its `Ruff lint` step. `python -m ruff check .` now gates merges. `typecheck` and `coverage` remain advisory.
+- **v0.30.1b — coverage promotion.** Removes `continue-on-error: true` from the `coverage` CI job and its `pytest --cov` step. Raises `[tool.coverage.report].fail_under` from `80` to `85`. Current baseline is `86%` on `src/pdelie/`; the raise-with-headroom prevents silent regression on new code that lands in v0.31+.
+- **v0.30.1c** through **v0.30.1k — mypy strict-scope broadening, one subpackage per PR.** Order: `pdelie.data.*` → `pdelie.residuals.*` → `pdelie.reporting.*` → `pdelie.discovery.*` → `pdelie.symmetry.*` → `pdelie.invariants.*` → `pdelie.portability.*` → `pdelie.verification.*` → `pdelie.viz.*`. After the last, promote the `typecheck` CI job to blocking.
+
+Rationale for the per-axis split (recorded in the workflow review that authored the v0.31 arc plan):
+
+- Phase 2 sits between two feature releases (v0.30 close and v0.31). Bundling it with either creates review noise and rebase risk.
+- A soak period without new code produces zero new signal — v0.30.0 introduced no code change since v0.30e already ran the advisory jobs. Ordering Phase 2 promotions **before** v0.31 exposes any regression at PR review time on v0.31 itself, rather than after merge.
+- Coverage regression masking is a live risk: `continue-on-error: true` on the coverage job plus `fail_under = 80` against an 86% baseline gives ~6 points of slack. New `pdelie.tasks.discovery` code with thin tests could silently drag coverage toward 80% while CI stays advisory-green. v0.30.1b closes that gap before v0.31a lands.
 
 ### Phase 3 — v0.32
 

--- a/tests/test_v0_30_hygiene_audit.py
+++ b/tests/test_v0_30_hygiene_audit.py
@@ -180,12 +180,23 @@ def test_v0_30e_ci_workflow_now_has_lint_typecheck_coverage_jobs_nonblocking() -
         assert re.search(pattern, workflow, flags=re.MULTILINE), (
             f"v0.30e must add CI job: {job}"
         )
-    # Non-blocking assertion: the workflow's YAML carries continue-on-error: true
-    # on the added jobs. Parse once to be robust to formatting.
+    # Blocking / non-blocking state after v0.30.1a lint promotion:
+    #   lint      -> BLOCKING (promoted in v0.30.1a)
+    #   typecheck -> non-blocking (promoted in v0.30.1c-k, per subpackage)
+    #   coverage  -> non-blocking (promoted in v0.30.1b)
     import yaml  # local import: yaml is already a v0.30e test dep
 
     parsed_jobs = yaml.safe_load(workflow)["jobs"]
-    for job in ("lint", "typecheck", "coverage"):
+    lint_body = parsed_jobs["lint"]
+    assert lint_body.get("continue-on-error") is not True, (
+        "v0.30.1a promoted the lint job to blocking; it must not carry job-level continue-on-error: true"
+    )
+    for step in lint_body.get("steps", []):
+        if "run" in step and "ruff" in step.get("run", ""):
+            assert step.get("continue-on-error") is not True, (
+                "v0.30.1a promoted the lint ruff step to blocking"
+            )
+    for job in ("typecheck", "coverage"):
         job_body = parsed_jobs[job]
         job_level = job_body.get("continue-on-error") is True
         step_level = any(
@@ -194,7 +205,7 @@ def test_v0_30e_ci_workflow_now_has_lint_typecheck_coverage_jobs_nonblocking() -
             if "run" in step
         )
         assert job_level or step_level, (
-            f"v0.30e CI job {job!r} must be non-blocking"
+            f"v0.30.1a advisory CI job {job!r} must remain non-blocking pending its own promotion"
         )
 
     # Release-gate job name across the v0.30 arc:

--- a/tests/test_v0_30e_hygiene_config.py
+++ b/tests/test_v0_30e_hygiene_config.py
@@ -116,21 +116,39 @@ def test_ci_workflow_has_lint_typecheck_coverage_jobs() -> None:
         assert job_name in jobs, f"CI job {job_name!r} missing"
 
 
-def test_lint_typecheck_coverage_jobs_are_non_blocking() -> None:
+def test_lint_is_blocking_after_v0_30_1a_promotion() -> None:
+    """v0.30.1a promoted ``lint`` from advisory to blocking. The job must not
+    carry ``continue-on-error: true`` at either the job or step level.
+    """
+    job = _ci_workflow()["jobs"]["lint"]
+    assert job.get("continue-on-error") is not True, (
+        "lint job must be blocking after v0.30.1a promotion"
+    )
+    for step in job.get("steps", []):
+        if "run" in step and "ruff" in step.get("run", ""):
+            assert step.get("continue-on-error") is not True, (
+                "lint ruff step must be blocking after v0.30.1a promotion"
+            )
+
+
+def test_typecheck_and_coverage_jobs_remain_non_blocking() -> None:
+    """v0.30.1a promoted ``lint`` only. ``typecheck`` stays advisory pending
+    v0.30.1c-k mypy strict-scope broadening; ``coverage`` stays advisory
+    pending v0.30.1b coverage promotion.
+    """
     jobs = _ci_workflow()["jobs"]
-    for job_name in ("lint", "typecheck", "coverage"):
+    for job_name in ("typecheck", "coverage"):
         job = jobs[job_name]
-        # Either the job-level continue-on-error is true, or every action step
-        # that runs the tool has continue-on-error: true.
         job_level = job.get("continue-on-error") is True
         step_level = all(
             step.get("continue-on-error") is True
             for step in job.get("steps", [])
             if "run" in step
-            and ("ruff" in step.get("run", "") or "mypy" in step.get("run", "") or "pytest" in step.get("run", ""))
+            and ("mypy" in step.get("run", "") or "pytest" in step.get("run", ""))
         )
         assert job_level or step_level, (
-            f"job {job_name!r} must be non-blocking (job-level or step-level continue-on-error: true)"
+            f"job {job_name!r} must remain non-blocking through v0.30.1a "
+            f"(job-level or step-level continue-on-error: true)"
         )
 
 


### PR DESCRIPTION
## Summary

First of the split-per-axis Phase 2 hygiene sub-releases identified by the v0.31 arc workflow review. Removes \`continue-on-error: true\` from the \`lint\` CI job (both job-level and its \`Ruff lint\` step). \`typecheck\` and \`coverage\` remain advisory pending v0.30.1b (coverage) and v0.30.1c-k (mypy strict-scope broadening one subpackage per PR).

Zero \`src/pdelie/\` change. Zero \`pyproject.toml\` change. Zero runtime feature. Zero version bump.

## Why land this before v0.31

1. **v0.30.0 introduced no code change since v0.30e already ran advisory jobs** — a "soak period" without new code would produce zero new signal and only delay v0.31.
2. **Coverage regression masking is a live risk**: \`continue-on-error: true\` on the coverage job plus \`fail_under = 80\` against an 86% baseline gives ~6 points of slack. New \`pdelie.tasks.discovery\` code with thin tests could silently drag coverage toward 80% while CI stays green. v0.30.1b will close that gap **before** v0.31a lands.
3. **Splitting Phase 2 per axis** makes each promotion boring, mergeable in a day, and immune to rebase-hell against v0.31.

## What lands

**\`.github/workflows/ci.yml\`**

- Removes \`continue-on-error: true\` from the \`lint\` job (line 70) and its \`Ruff lint\` step (line 95).
- Renames the step from \"Ruff lint (non-blocking)\" to \"Ruff lint (blocking as of v0.30.1a)\".
- Preserves \`continue-on-error: true\` on \`typecheck\` and \`coverage\` jobs — they get their own sub-PRs.
- Header comment rewritten to name the split-per-axis pattern and reference \`v0.30.1b\` (coverage promotion) + \`v0.30.1c-k\` (mypy strict scope broadening).

**Test guards**

- \`tests/test_v0_30e_hygiene_config.py\`: splits the single \`test_lint_typecheck_coverage_jobs_are_non_blocking\` guard into two:
  - \`test_lint_is_blocking_after_v0_30_1a_promotion\` — lint MUST be blocking (no \`continue-on-error: true\` at job level or on the ruff step).
  - \`test_typecheck_and_coverage_jobs_remain_non_blocking\` — typecheck + coverage MUST stay advisory pending their own promotion PRs.
- \`tests/test_v0_30_hygiene_audit.py\`: the \`test_v0_30e_ci_workflow_now_has_lint_typecheck_coverage_jobs_nonblocking\` test's blocking-check block is rewritten to assert lint is blocking and typecheck + coverage remain advisory. All existing hygiene-audit guards on the config and doc content are preserved.

**Docs**

- \`docs/design/V0_30_HYGIENE_AUDIT.md\` Phase 2 section rewritten from \"v0.30.1 or v0.31\" to enumerate the 11 planned sub-releases:
  - \`v0.30.1a\` — lint promotion (this PR)
  - \`v0.30.1b\` — coverage promotion, raise \`fail_under\` 80 → 85
  - \`v0.30.1c\`–\`v0.30.1k\` — mypy strict-scope broadening one subpackage per PR (order: \`pdelie.data.*\` → \`pdelie.residuals.*\` → \`pdelie.reporting.*\` → \`pdelie.discovery.*\` → \`pdelie.symmetry.*\` → \`pdelie.invariants.*\` → \`pdelie.portability.*\` → \`pdelie.verification.*\` → \`pdelie.viz.*\`). After the last, promote the \`typecheck\` CI job to blocking.

Rationale block preserves the workflow review's reasoning about soak periods, coverage regression masking, and per-axis PR isolation.

## Not in scope

- No \`src/pdelie/\` change.
- No \`pyproject.toml\` change (the coverage \`fail_under\` raise is v0.30.1b).
- No mypy strict-scope broadening (v0.30.1c+).
- No new PDE. No runtime API. No root export.
- No version bump. \`v0.30.0\` remains the current release.
- No PyPI/TestPyPI work.

## Test plan

- [x] \`python -m ruff check .\` — All checks passed (this is now the merge gate).
- [x] \`python -m pytest\` — **1120 passed, 2 skipped** (+1 vs v0.30.0 baseline of 1119: the split of one test into two).
- [x] \`python -m pytest tests/test_v0_30e_hygiene_config.py tests/test_v0_30_hygiene_audit.py tests/test_release_gates.py tests/test_current_release_gate.py\` — 103 passed.
- [x] \`python -m sphinx -b html -W --keep-going docs docs/_build/html\` — build succeeded, zero warnings.
- [x] \`git diff --check\` — clean.

## Merge order

Independent of PR #81 (ROADMAP amendment). Ships after both #81 and PR #82 (SCIENTIFIC_POSITIONING expansion, coming next) if you want the docs commits chronologically first, or in any order — no coordination between the three PRs is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)