### PR TITLE
ci: pin first-party actions by SHA + add Dependabot + CI troubleshooting note

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Keeps the SHA pins in .github/workflows/*.yml on their latest patch releases.
+# Actions are pinned by full commit SHA (with a trailing "# vX.Y.Z" comment)
+# per GitHub's security-hardening guidance:
+# https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+#
+# Dependabot opens a PR whenever a pinned action publishes a new patch or
+# minor release. Rebase strategy is auto so the PR stays fresh against main.
+# The PR reviewer confirms the new SHA matches the intended tag before merge.
+#
+# See docs/releases/CI_TROUBLESHOOTING.md for the rationale behind SHA pinning.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    labels:
+      - "ci"
+      - "dependencies"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   v0_30-release-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install package and test dependencies
@@ -70,8 +70,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install package and test dependencies
@@ -98,8 +98,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install package and test dependencies
@@ -127,8 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install package and test dependencies
@@ -154,7 +154,7 @@ jobs:
         run: python -m pytest --cov=src/pdelie --cov-report=xml --cov-report=term-missing
       - name: Upload coverage.xml
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-xml
           path: coverage.xml
@@ -162,8 +162,8 @@ jobs:
   docs-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install documentation dependencies
@@ -189,8 +189,8 @@ jobs:
   editable-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install package and test dependencies
@@ -237,8 +237,8 @@ jobs:
   package-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Install packaging frontend

--- a/docs/releases/CI_TROUBLESHOOTING.md
+++ b/docs/releases/CI_TROUBLESHOOTING.md
@@ -1,0 +1,54 @@
+# CI Troubleshooting
+
+Operational reference for common CI failure modes. This document is advisory; it does not change package semantics, release scope, or stable contracts.
+
+## `Failed to resolve action download info. Error: Service Unavailable`
+
+**What it looks like:** an early job log that reaches `Prepare all required actions` → `Getting action download info` and then reports `503 Service Unavailable` after two retries.
+
+**What it means:** transient outage on GitHub's Actions infrastructure. The runner has already provisioned the OS image and the `GITHUB_TOKEN` — the failure is at the step where it fetches the tarball metadata for an action referenced in the workflow (`actions/checkout@...`, `actions/setup-python@...`, `actions/upload-artifact@...`). None of those actions live in this repo; the 503 comes from GitHub's marketplace/registry endpoint.
+
+**What it is not:** a bug in `.github/workflows/ci.yml`. The workflow file is fine. Editing it will not resolve the outage.
+
+**How to respond, in order:**
+
+1. **Check GitHub status.** Visit https://www.githubstatus.com/ and look at the "Actions" component. If it's degraded or an incident is open, that is the confirmed cause; wait for the incident to close.
+2. **Re-run the failed jobs.** Once the incident clears, from the PR page click "Re-run failed jobs", or from the CLI:
+   ```bash
+   gh run list --workflow=ci.yml --branch=<branch> --limit=3
+   gh run rerun <run-id> --failed
+   ```
+3. **Do not force-push to re-trigger.** A force-push closes the current run and starts a fresh one, which is more expensive and identical in outcome to a re-run. Force-push only if a real code change is needed.
+4. **Do not disable job dependencies to work around it.** If `docs-build` blocks a merge and it 503s at action resolution, the answer is a re-run, not to skip the check.
+
+## Why the workflow pins actions by SHA
+
+Every first-party action referenced in `.github/workflows/ci.yml` is pinned by full commit SHA with a trailing `# vX.Y.Z` version comment:
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+- uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+- uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+```
+
+Reasons:
+
+- **Security hardening.** A moving tag like `@v4` can be re-pointed to a different commit by the action's maintainer. SHA pinning removes that trust surface. GitHub's official guidance recommends this for third-party actions and treats it as best practice for first-party ones as well.
+- **Reproducibility.** Two runs of the same commit resolve to the same action bytes forever, regardless of upstream retagging.
+- **Modest resilience against tag-resolution outages.** When GitHub's tag-resolution endpoint 503s, a SHA-pinned reference can (sometimes) skip that lookup step. It does not help if the tarball-download endpoint itself is down.
+
+The pins are kept fresh by Dependabot per `.github/dependabot.yml` — a weekly Monday PR opens whenever a pinned action publishes a new patch or minor release.
+
+## Other common CI failure modes
+
+- **`pip install` hangs or 5xxs.** The workflow already wraps installs in a `retry 3` shell function. If that runs out of retries, the fix is the same: check status, re-run the failed job.
+- **`docs-build` fails with `WARNING: document isn't included in any toctree`.** Sphinx is built with `-W --keep-going`, so any new markdown doc must be added to the appropriate `docs/*/index.rst` toctree in the same PR.
+- **`lint` (blocking as of v0.30.1a) reports ruff violations.** Reproduce locally with `python -m ruff check .` and either fix the code or add a documented per-file ignore to `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml`.
+- **Advisory `typecheck` or `coverage` red.** Both are `continue-on-error: true` through v0.30.1a and do not block merges. Promotion to blocking is scheduled per `docs/design/V0_30_HYGIENE_AUDIT.md` (`v0.30.1b` for coverage; `v0.30.1c-k` for mypy scope broadening).
+
+## Related documents
+
+- `.github/workflows/ci.yml` — the workflow itself.
+- `.github/dependabot.yml` — the automated action-pin refresh.
+- `docs/design/V0_30_HYGIENE_AUDIT.md` — advisory-to-blocking promotion schedule for `lint` / `typecheck` / `coverage`.
+- `docs/releases/PUBLISHING.md` — release cadence and Git-tag-only policy.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -7,6 +7,7 @@ Release readiness and publishing records.
    :maxdepth: 1
 
    PUBLISHING
+   CI_TROUBLESHOOTING
    V0_27_RELEASE_READINESS
    V0_28_RELEASE_READINESS
    V0_29_RELEASE_READINESS


### PR DESCRIPTION
## Summary

Defensive hardening after a transient \"Failed to resolve action download info. Error: Service Unavailable\" 503 hit PR #84's CI run. The 503 was a GitHub-side outage on the tag-resolution endpoint, not a workflow bug.

This PR does not (and cannot) prevent the outage — it makes future runs marginally more resilient and documents the failure mode so future contributors know it's an infra issue rather than something to force-push around.

Zero \`src/pdelie/\` change. Zero test change. Zero version bump. Zero behavior change on the CI job side — all steps still run the same commands; only the action reference syntax changed.

## What lands

**\`.github/workflows/ci.yml\`** — every first-party action reference rewritten to a full-commit SHA pin with a trailing \`# vX.Y.Z\` version comment. Preserves current major-version behavior; picks the highest v4.x / v5.x patch:

| Reference before | Reference after |
|---|---|
| \`actions/checkout@v4\` (7 sites) | \`actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1\` |
| \`actions/setup-python@v5\` (7 sites) | \`actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0\` |
| \`actions/upload-artifact@v4\` (1 site) | \`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2\` |

**Reasons:**

1. **Security hardening.** A moving tag like \`@v4\` can be re-pointed to a different commit by the action's maintainer. SHA pinning removes that trust surface. GitHub's official guidance recommends this for third-party actions and treats it as best practice for first-party ones as well.
2. **Reproducibility.** Two runs of the same commit resolve to the same action bytes forever, regardless of upstream retagging.
3. **Modest resilience against tag-resolution outages.** When GitHub's tag-resolution endpoint 503s, a SHA-pinned reference can (sometimes) skip that lookup step. It does not help if the tarball-download endpoint itself is down.

**\`.github/dependabot.yml\`** (new) — configures github-actions ecosystem for **weekly Monday PRs** whenever a pinned action publishes a new patch or minor release. Rebase strategy auto so the PRs stay fresh against main. \`open-pull-requests-limit: 3\` to cap noise. Commit prefix \`ci\` with scope.

**\`docs/releases/CI_TROUBLESHOOTING.md\`** (new) — one-page operational reference. Documents:

- \"Failed to resolve action download info\" failure mode: what it looks like, what it means, what it is not, response order (check https://www.githubstatus.com/ → re-run failed jobs → do not force-push → do not disable job dependencies).
- Why the workflow now SHA-pins actions (three reasons above).
- Other common CI failure modes: \`pip\` 5xx retries, docs-build toctree WARNING, \`lint\` blocking as of v0.30.1a, advisory \`typecheck\` / \`coverage\` red.
- Cross-references \`V0_30_HYGIENE_AUDIT.md\` promotion schedule and \`PUBLISHING.md\` cadence.

**\`docs/releases/index.rst\`** (modified) — \`CI_TROUBLESHOOTING\` added to the toctree.

## Immediate recovery for the failing job

Independent of merging this PR:

```bash
gh run list --workflow=ci.yml --branch=feat/v0.31a-discovery-task-bridge-scope-freeze --limit=3
gh run rerun <run-id> --failed
```

Or click \"Re-run failed jobs\" on the PR page once https://www.githubstatus.com/ shows Actions healthy.

## Not in scope

- No \`src/pdelie/\` change.
- No test change.
- No new PDE, no runtime API, no root export.
- No version bump.
- No PyPI/TestPyPI work.
- No modification of the existing v0.30-release-gate or hygiene job behavior.
- No self-hosted runner setup. That would be a much larger infrastructure change and disproportionate to a transient outage.

## Test plan

- [x] \`python -c \"yaml.safe_load(open('.github/workflows/ci.yml').read()); yaml.safe_load(open('.github/dependabot.yml').read())\"\` — YAML valid.
- [x] \`python -m pytest tests/test_release_gates.py tests/test_current_release_gate.py tests/test_v0_30_scope_freeze.py tests/test_v0_30_hygiene_audit.py tests/test_v0_30e_hygiene_config.py\` — 115 passed.
- [x] \`python -m ruff check .\` — all checks passed.
- [x] \`python -m sphinx -b html -W --keep-going docs docs/_build/html\` — build succeeded, zero warnings.

The SHAs were resolved via \`gh api repos/{action}/tags\` and verified to correspond to the highest v4.x / v5.x tag respectively.

## Merge order

Independent of PR #84 (v0.31a scope freeze) — this PR doesn't touch any of the files #84 touches. Can merge before or after.

If you merge this **before** #84, PR #84's next CI run picks up the SHA-pinned workflow. If #84 merges first, this PR opens against the post-#84 main and the workflow change lands one release later — same net effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)