### PR TITLE
ci(deps): stop Dependabot from opening major-version bumps automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
-# Keeps the SHA pins in .github/workflows/*.yml on their latest patch releases.
-# Actions are pinned by full commit SHA (with a trailing "# vX.Y.Z" comment)
-# per GitHub's security-hardening guidance:
+# Keeps the SHA pins in .github/workflows/*.yml on their latest patch and
+# minor releases. Actions are pinned by full commit SHA (with a trailing
+# "# vX.Y.Z" comment) per GitHub's security-hardening guidance:
 # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
 #
 # Dependabot opens a PR whenever a pinned action publishes a new patch or
-# minor release. Rebase strategy is auto so the PR stays fresh against main.
+# minor release. Major-version bumps (semver X.0.0 breaks) are explicitly
+# ignored via the `ignore` block below — Dependabot's default is to bump to
+# the latest available, which for GitHub Actions has historically been a
+# breaking change (upload-artifact v3→v4 broke the artifact API in Dec 2024;
+# checkout v3→v4 required a Node 20 runner). Major bumps therefore stay
+# manual: a maintainer reads the changelog, updates the SHA and version
+# comment in .github/workflows/ci.yml directly, and reviews the PR themselves.
+#
+# Rebase strategy is auto so the PR stays fresh against main.
 # The PR reviewer confirms the new SHA matches the intended tag before merge.
 #
 # See docs/releases/CI_TROUBLESHOOTING.md for the rationale behind SHA pinning.
@@ -24,3 +32,10 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    ignore:
+      # Block automatic major-version bumps for every action. Major bumps of
+      # GitHub Actions cross API boundaries and require manual review of the
+      # action's changelog. Patch and minor bumps continue to auto-open PRs.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/docs/releases/CI_TROUBLESHOOTING.md
+++ b/docs/releases/CI_TROUBLESHOOTING.md
@@ -37,7 +37,7 @@ Reasons:
 - **Reproducibility.** Two runs of the same commit resolve to the same action bytes forever, regardless of upstream retagging.
 - **Modest resilience against tag-resolution outages.** When GitHub's tag-resolution endpoint 503s, a SHA-pinned reference can (sometimes) skip that lookup step. It does not help if the tarball-download endpoint itself is down.
 
-The pins are kept fresh by Dependabot per `.github/dependabot.yml` — a weekly Monday PR opens whenever a pinned action publishes a new patch or minor release.
+The pins are kept fresh by Dependabot per `.github/dependabot.yml` — a weekly Monday PR opens whenever a pinned action publishes a new **patch or minor** release. Major-version bumps (`X.0.0` breaks) are explicitly ignored by the Dependabot config and stay a manual maintenance task, because GitHub Actions major bumps have a history of cross-API breaks (`upload-artifact` v3 → v4 broke the artifact API in Dec 2024; `checkout` v3 → v4 required a Node 20 runner). To take a major bump, a maintainer reads the action's changelog, updates the SHA and version comment in `.github/workflows/ci.yml` directly, and reviews the PR themselves.
 
 ## Other common CI failure modes
 


### PR DESCRIPTION
## Summary

Follow-up to #88. Dependabot's default is to bump each pinned action to its **latest available version, including major breaks**. On its first scan after #88 merged, it opened three PRs immediately:

- #89 — \`actions/setup-python\` v5 → **v6**
- #90 — \`actions/checkout\` v4 → **v7** (skipping v5 and v6)
- #91 — \`actions/upload-artifact\` v4 → **v7**

All three were closed as too risky to merge on autopilot. GitHub Actions major bumps have a history of cross-API breaks:

- \`upload-artifact\` v3 → v4 broke the artifact API in Dec 2024.
- \`checkout\` v3 → v4 required a Node 20 runner.

This PR tightens the config so the same three-PR flood does not recur every Monday, without disabling patch/minor auto-updates — which are the whole point of running Dependabot in the first place.

Zero \`src/pdelie/\` change. Zero test change. Zero version bump. Zero workflow YAML change (the SHA pins from #88 stay as-is).

## What lands

**\`.github/dependabot.yml\`** — adds a top-level \`ignore\` block on the \`github-actions\` ecosystem that blocks \`version-update:semver-major\` for every action (\`dependency-name: \"*\"\`):

\`\`\`yaml
ignore:
  - dependency-name: \"*\"
    update-types:
      - \"version-update:semver-major\"
\`\`\`

Patch and minor bumps continue to auto-open PRs on the weekly Monday schedule. Major bumps become a **deliberate manual action**: a maintainer reads the action's changelog, updates the SHA and version comment in \`.github/workflows/ci.yml\` by hand, and opens the PR themselves.

Header comment expanded with the rationale so future contributors reading the config understand why major bumps are excluded.

**\`docs/releases/CI_TROUBLESHOOTING.md\`** — updates the \"Why the workflow pins actions by SHA\" section to reflect the new policy — auto patch/minor bumps via Dependabot, manual major bumps by maintainer after changelog review. Preserves the two concrete examples of past breaking major bumps (\`upload-artifact\` v3→v4 API break, \`checkout\` v3→v4 Node 20 requirement).

## Not in scope

- No workflow YAML change (the SHA pins from #88 stay as-is).
- No re-open of the three closed Dependabot PRs (#89, #90, #91). Future major bumps will be considered individually on their own merits, not merged as a batch.
- No \`src/pdelie/\` change.
- No test change.
- No new PDE, no runtime API, no root export.
- No version bump.
- No PyPI/TestPyPI work.

## Test plan

- [x] \`python -c \"yaml.safe_load(open('.github/dependabot.yml').read())\"\` — ok.
- [x] \`python -m pytest tests/test_release_gates.py tests/test_current_release_gate.py\` — 78 passed.
- [x] \`python -m sphinx -b html -W --keep-going docs docs/_build/html\` — build succeeded, zero warnings.

## Merge order

Independent of PR #84 (v0.31a scope freeze). Can go before or after — the workflow YAML that #84's CI uses is unchanged either way; the tightening only affects future Dependabot behavior.

Cheap review; small YAML change plus a documentation update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)